### PR TITLE
Fix labels pointing to helper tools.

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -13,7 +13,7 @@ py_library(
         "archive.py",
     ],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+    visibility = ["@//tests:__pkg__"],
 )
 
 py_binary(

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -251,7 +251,7 @@ _real_pkg_tar = rule(
         "remap_paths": attr.string_dict(),
         # Implicit dependencies.
         "build_tar": attr.label(
-            default = Label("//tools/build_defs/pkg:build_tar"),
+            default = Label("@rules_pkg//:build_tar"),
             cfg = "host",
             executable = True,
             allow_files = True,
@@ -311,7 +311,7 @@ pkg_deb = rule(
         "recommends": attr.string_list(default = []),
         # Implicit dependencies.
         "make_deb": attr.label(
-            default = Label("//tools/build_defs/pkg:make_deb"),
+            default = Label("@rules_pkg//:make_deb"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -155,7 +155,7 @@ pkg_rpm = rule(
         # Implicit dependencies.
         "rpmbuild_path": attr.string(),
         "_make_rpm": attr.label(
-            default = Label("//tools/build_defs/pkg:make_rpm"),
+            default = Label("@rules_pkg//:make_rpm"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -122,7 +122,6 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    build_tar = "@rules_pkg//:build_tar",
     strip_prefix = "",
 )
 
@@ -131,7 +130,6 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    build_tar = "@rules_pkg//:build_tar",
 )
 
 pkg_tar(
@@ -139,7 +137,6 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    build_tar = "@rules_pkg//:build_tar",
     strip_prefix = "etc",
 )
 
@@ -148,13 +145,11 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    build_tar = "@rules_pkg//:build_tar",
     strip_prefix = ".",
 )
 
 pkg_tar(
     name = "test-tar-files_dict",
-    build_tar = "@rules_pkg//:build_tar",
     files = {
         ":etc/nsswitch.conf": "not-etc/mapped-filename.conf",
     },
@@ -162,7 +157,6 @@ pkg_tar(
 
 pkg_tar(
     name = "test-tar-empty_files",
-    build_tar = "@rules_pkg//:build_tar",
     empty_files = [
         "/a",
         "/b",
@@ -172,7 +166,6 @@ pkg_tar(
 
 pkg_tar(
     name = "test-tar-empty_dirs",
-    build_tar = "@rules_pkg//:build_tar",
     empty_dirs = [
         "/tmp",
         "/pmt",
@@ -185,7 +178,6 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    build_tar = "@rules_pkg//:build_tar",
     mtime = 946684740,  # 1999-12-31, 23:59
     portable_mtime = False,
 )


### PR DESCRIPTION
Do not override the path to helper tools in every test. Doing that
hid the fact that the paths were defined wrong in the rule.