### PR TITLE
Quick and dirty rules to help make a release.

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -6,6 +6,12 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "standard_package",
+    srcs = glob(["BUILD", "*.bzl", "*.py", "*.md"]),
+    visibility = ["@//distro:__pkg__"],
+)
+
 py_library(
     name = "archive",
     srcs = [

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -14,6 +14,18 @@
 These build rules are used for building various packaging such as tarball
 and debian package.
 
+<a name="workspace-setup"></a>
+## WORKSPACE setup
+
+http_archive(
+    name = "rules_pkg",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/1.0.0/rules_pkg-1.0.0.tar.gz",
+    sha256 = "..."
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
+
 <a name="basic-example"></a>
 ## Basic Example
 

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -1,0 +1,68 @@
+package(
+    default_visibility = ["//visibility:private"],
+)
+
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+VERSION = "0.1.0"
+
+pkg_tar(
+    name = "rules_pkg-%s" % VERSION,
+    srcs = [
+        "@rules_pkg//:standard_package",
+    ],
+    extension = "tar.gz",
+    mode = "0644",
+    owner = "0.0",
+    package_dir = ".",
+)
+
+py_library(
+    name = "util",
+    srcs = [
+        "__init__.py",
+        "release_tools.py",
+        "release_version.py",
+    ],
+    srcs_version = "PY3",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+    ],
+)
+
+py_binary(
+    name = "print_rel_notes",
+    srcs = [
+        "print_rel_notes.py",
+    ],
+    data = [
+        ":rules_pkg-%s.tar.gz" % VERSION,
+    ],
+    python_version = "PY3",
+    deps = [
+        ":util",
+        "@bazel_tools//tools/python/runfiles",
+    ],
+)
+
+py_test(
+    name = "packaging_test",
+    size = "large",
+    srcs = [
+        "packaging_test.py",
+    ],
+    data = [
+        ":rules_pkg-%s.tar.gz" % VERSION,
+        "testdata/BUILD.tmpl",
+    ],
+    local = True,
+    python_version = "PY3",
+    tags = [
+        "no_windows",
+        "noci",
+    ],
+    deps = [
+        ":util",
+        "@bazel_tools//tools/python/runfiles",
+    ],
+)

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -6,13 +6,16 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 VERSION = "0.1.0"
 
+# Build the artifact to put on the github release page.
 pkg_tar(
     name = "rules_pkg-%s" % VERSION,
     srcs = [
         "@rules_pkg//:standard_package",
     ],
     extension = "tar.gz",
-    mode = "0644",
+    # It is all source code, so make it read-only.
+    mode = "0444",
+    # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
     package_dir = ".",
 )

--- a/pkg/distro/packaging_test.py
+++ b/pkg/distro/packaging_test.py
@@ -1,0 +1,77 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that the rules_pkg distribution is usable."""
+
+import os
+import subprocess
+import unittest
+
+from bazel_tools.tools.python.runfiles import runfiles
+from distro import release_tools
+from distro import release_version
+
+_VERBOSE = True
+
+
+class PackagingTest(unittest.TestCase):
+  """Test the distribution packaging."""
+
+  def setUp(self):
+    self.data_files = runfiles.Create()
+
+  def testBuild(self):
+    # Set up a fresh Bazel workspace
+    tempdir = os.path.join(os.environ['TEST_TMPDIR'], 'build')
+    if not os.path.exists(tempdir):
+      os.makedirs(tempdir)
+    with open(os.path.join(tempdir, 'WORKSPACE'), 'w') as workspace:
+      version = release_version.RELEASE_VERSION
+      file_name = release_tools.package_basename(version)
+      local_path, sha256 = release_tools.get_package_info(version)
+      workspace_content = '\n'.join((
+        'workspace(name = "test_rules_pkg_packaging")',
+        release_tools.workspace_content(
+            'file://%s' % local_path, sha256)
+      ))
+      workspace.write(workspace_content)
+      if _VERBOSE:
+        print('=== WORKSPACE ===')
+        print(workspace_content)
+
+    # We do a little dance of renaming *.tmpl to *, mostly so that we do not
+    # have a BUILD file in testdata, which would create a package boundary.
+    def CopyTestFile(source_name, dest_name):
+      source_path = self.data_files.Rlocation(
+          os.path.join('rules_pkg', 'distro', 'testdata', source_name))
+      with open(source_path) as inp:
+        with open(os.path.join(tempdir, dest_name), 'w') as out:
+          content = inp.read()
+          out.write(content)
+
+    CopyTestFile('BUILD.tmpl', 'BUILD')
+
+    os.chdir(tempdir)
+    build_result = subprocess.check_output(['bazel', 'build', ':dummy_tar'])
+    if _VERBOSE:
+      print('=== Build Result ===')
+      print(build_result)
+
+    content = subprocess.check_output(
+        ['/bin/tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
+    self.assertEqual('./\n./BUILD\n', content)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/pkg/distro/print_rel_notes.py
+++ b/pkg/distro/print_rel_notes.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Print release notes for the package.
+
+"""
+
+import sys
+import textwrap
+
+from bazel_tools.tools.python.runfiles import runfiles
+from distro import release_tools
+from distro import release_version
+
+
+def print_notes(version):
+  file_name = release_tools.package_basename(version)
+  _, sha256 = release_tools.get_package_info(version)
+
+  url = 'https://github.com/bazelbuild/rules_pkg/releases/download/%s/%s' % (
+      version, file_name)
+  print(textwrap.dedent(
+      """
+
+      **WORKSPACE setup**
+
+      ```
+      """).strip())
+  print(release_tools.workspace_content(url, sha256))
+  print(textwrap.dedent(
+      """
+      ```
+
+      **Using the rules**
+
+      See [the source](https://github.com/bazelbuild/rules_pkg/tree/master/pkg).
+      """).strip())
+
+
+def main(_):
+  print_notes(release_version.RELEASE_VERSION)
+
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/pkg/distro/release_tools.py
+++ b/pkg/distro/release_tools.py
@@ -1,0 +1,73 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities to help create a rule set release."""
+
+import hashlib
+import os
+import textwrap
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+
+def package_basename(version):
+  return 'rules_pkg-%s.tar.gz' % version
+
+
+def get_package_info(version):
+  tar_path = runfiles.Create().Rlocation(
+      os.path.join('rules_pkg', 'distro', package_basename(version)))
+  with open(tar_path, 'r') as pkg_content:
+    tar_sha256 = hashlib.sha256(pkg_content.read()).hexdigest()
+  return tar_path, tar_sha256
+
+
+def workspace_content(url, sha256):
+  # Set up a fresh Bazel workspace
+  return textwrap.dedent(
+      """
+      load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+      http_archive(
+          name = "rules_pkg",
+          url = "%s",
+          sha256 = "%s",
+      )
+
+      load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+      rules_pkg_dependencies()
+      """ % (url, sha256)).strip()
+
+
+"""
+    # We do a little dance of renaming *.tmpl to *, mostly so that we do not
+    # have a BUILD file in testdata, which would create a package boundary.
+    def CopyTestFile(source_name, dest_name):
+      source_path = self.data_files.Rlocation(
+          os.path.join('rules_pkg', 'distro', 'testdata', source_name))
+      with open(source_path) as inp:
+        with open(os.path.join(tempdir, dest_name), 'w') as out:
+          content = inp.read()
+          out.write(content)
+
+    CopyTestFile('BUILD.tmpl', 'BUILD')
+
+    os.chdir(tempdir)
+    build_result = subprocess.check_output(['bazel', 'build', ':dummy_tar'])
+    if _VERBOSE:
+      print('=== Build Result ===')
+      print(build_result)
+
+    content = subprocess.check_output(
+        ['/bin/tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
+    self.assertEqual('./\n./BUILD\n', content)
+"""

--- a/pkg/distro/release_version.py
+++ b/pkg/distro/release_version.py
@@ -1,0 +1,16 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Generate this file from the version in BUILD.
+RELEASE_VERSION = '0.1.0'

--- a/pkg/distro/testdata/BUILD.tmpl
+++ b/pkg/distro/testdata/BUILD.tmpl
@@ -1,0 +1,14 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "dummy_tar",
+    srcs = [
+      ":BUILD",
+    ],
+    extension = "tar.gz",
+    owner = "0.0",
+    package_dir = ".",
+    tags = [
+        "manual",
+    ],
+)


### PR DESCRIPTION
- Create the tarball - which is the subset of the repo needed to *use* the rules.
- Smoke test the tarball
- Provide a tool to print the WORKSPACE entry with the correct url and
  sha256, so you can do the release notes.

The code is ugly and has a bunch of TODOs for later. This was good enough to create the packaging for release 0.1.0