### PR TITLE
Wrapped dependency repository rules with the _maybe macro

### DIFF
--- a/pkg/deps.bzl
+++ b/pkg/deps.bzl
@@ -8,23 +8,25 @@ def _maybe(repo, name, **kwargs):
 
 def rules_pkg_dependencies():
     # Needed for helper tools
-    http_archive(
+    _maybe(
+        http_archive,
         name = "abseil_py",
         urls = [
             "https://github.com/abseil/abseil-py/archive/pypi-v0.7.1.tar.gz",
-      ],
-      sha256 = "3d0f39e0920379ff1393de04b573bca3484d82a5f8b939e9e83b20b6106c9bbe",
-      strip_prefix = "abseil-py-pypi-v0.7.1",
+        ],
+        sha256 = "3d0f39e0920379ff1393de04b573bca3484d82a5f8b939e9e83b20b6106c9bbe",
+        strip_prefix = "abseil-py-pypi-v0.7.1",
     )
 
     # Needed by abseil-py. They do not use deps yet.
-    http_archive(
-       name = "six_archive",
+    _maybe(
+        http_archive,
+        name = "six_archive",
         urls = [
             "http://mirror.bazel.build/pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
             "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz",
         ],
         sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
         strip_prefix = "six-1.10.0",
-        build_file = "@abseil_py//third_party:six.BUILD"
+        build_file = "@abseil_py//third_party:six.BUILD",
     )


### PR DESCRIPTION
My organization uses Artifactory to proxy/cache all of our build dependencies, and it's hard rule that everything must be sourced this way. To accomplish this with Bazel, we need to be able to override each  repository rule with an equivalent rule that points to Artifactory instead of the upstream source. 

While we could simply omit the `rules_pkg_dependencies()` call and manually override these dependencies, we actually have a tool that will inspect all repo rules and automatically generate the equivalent Artifactory rules. The use of `_maybe` allows that to work.