### PR TITLE
Change owners so we spamming everyone while we are in rapid developem…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
-* @aiuto @lberki @philwo @fwe
+* @aiuto
+# Alternate reviewers: @philwo @fwe
 
 /deb_packages/  @MarkusTeufelberger @adragomir


### PR DESCRIPTION
…ent.

The bazel team members are churning this right now. We can select our
own reviewers.