### PR TITLE
Update make_deb.py to work for Python2 or 3

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -41,10 +41,13 @@ py_binary(
     ],
 )
 
+
+# NOTE: This works for PY2 and PY3.
+# TODO: Figure out how to use "whatever version" we have on the machine.
 py_binary(
     name = "make_deb",
     srcs = ["make_deb.py"],
-    python_version = "PY3",
+    python_version = "PY2",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -44,7 +44,7 @@ py_binary(
 py_binary(
     name = "make_deb",
     srcs = ["make_deb.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -42,11 +42,22 @@ py_binary(
 )
 
 
-# NOTE: This works for PY2 and PY3.
-# TODO: Figure out how to use "whatever version" we have on the machine.
 py_binary(
     name = "make_deb",
     srcs = ["make_deb.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":archive",
+        "@abseil_py//absl/flags",
+    ],
+)
+
+py_binary(
+    name = "make_deb_py2",
+    srcs = ["make_deb.py"],
+    main = "make_deb.py",
     python_version = "PY2",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -46,7 +46,6 @@ py_binary(
     name = "make_deb",
     srcs = ["make_deb.py"],
     python_version = "PY3",
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":archive",

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -380,4 +380,10 @@ def main(unused_argv):
 if __name__ == '__main__':
   MakeGflags()
   FLAGS = flags.FLAGS
+  # sys.argv is not actually proper str types on Unix with Python3
+  # The bytes of the arg are each directly transcribed to the characters of
+  # the str. It is actually more complex than that, as described in the docs.
+  # https://docs.python.org/3/library/sys.html#sys.argv
+  # https://docs.python.org/3/library/os.html#os.fsencode
+  # https://www.python.org/dev/peps/pep-0383/
   main(FLAGS([os.fsencode(arg).decode('utf-8') for arg in sys.argv]))

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -327,8 +327,7 @@ def GetFlagValue(flagvalue, strip=True):
       flagvalue = str(flagvalue)
     if flagvalue[0] == '@':
       with open(flagvalue[1:], 'rb') as f:
-        flagvalue = f.read()
-        flagvalue = flagvalue.decode('utf-8')
+        flagvalue = f.read().decode('utf-8')
     if strip:
       return flagvalue.strip()
   return flagvalue

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -394,11 +394,4 @@ def main(unused_argv):
 if __name__ == '__main__':
   MakeGflags()
   FLAGS = flags.FLAGS
-  # sys.argv is not actually proper str types on Unix with Python3
-  # The bytes of the arg are each directly transcribed to the characters of
-  # the str. It is actually more complex than that, as described in the docs.
-  # https://docs.python.org/3/library/sys.html#sys.argv
-  # https://docs.python.org/3/library/os.html#os.fsencode
-  # https://www.python.org/dev/peps/pep-0383/
-  # main(FLAGS([os.fsencode(arg).decode('utf-8') for arg in sys.argv]))
   main(FLAGS(sys.argv))

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -120,6 +120,12 @@ def _pkg_tar_impl(ctx):
         arguments = ["--flagfile", arg_file.path],
         outputs = [ctx.outputs.out],
         mnemonic = "PackageTar",
+        env = {
+            "LANG": "en_US.UTF-8",
+            "LC_CTYPE": "UTF-8",
+            "PYTHONIOENCODING": "UTF8",
+            "PYTHONUTF8": "1",
+        },
         use_default_shell_env = True,
     )
 

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -15,7 +15,7 @@
 
 load(":path.bzl", "compute_data_path", "dest_path")
 
-version = '0.2.0'
+version = "0.2.0"
 
 # Filetype to restrict inputs
 tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.xz", ".tar.bz2"]
@@ -115,15 +115,15 @@ def _pkg_tar_impl(ctx):
     ctx.actions.write(arg_file, "\n".join(args))
 
     ctx.actions.run(
+        mnemonic = "PackageTar",
         inputs = file_inputs + ctx.files.deps + [arg_file],
         executable = ctx.executable.build_tar,
         arguments = ["--flagfile", arg_file.path],
         outputs = [ctx.outputs.out],
-        mnemonic = "PackageTar",
         env = {
             "LANG": "en_US.UTF-8",
             "LC_CTYPE": "UTF-8",
-            "PYTHONIOENCODING": "UTF8",
+            "PYTHONIOENCODING": "UTF-8",
             "PYTHONUTF8": "1",
         },
         use_default_shell_env = True,
@@ -222,11 +222,17 @@ def _pkg_deb_impl(ctx):
     args += ["--recommends=" + d for d in ctx.attr.recommends]
 
     ctx.actions.run(
+        mnemonic = "MakeDeb",
         executable = ctx.executable.make_deb,
         arguments = args,
         inputs = files,
         outputs = [ctx.outputs.deb, ctx.outputs.changes],
-        mnemonic = "MakeDeb",
+        env = {
+            "LANG": "en_US.UTF-8",
+            "LC_CTYPE": "UTF-8",
+            "PYTHONIOENCODING": "UTF-8",
+            "PYTHONUTF8": "1",
+        },
     )
     ctx.actions.run_shell(
         command = "ln -s %s %s" % (ctx.outputs.deb.basename, ctx.outputs.out.path),

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -82,12 +82,18 @@ def _pkg_rpm_impl(ctx):
     # Call the generator script.
     # TODO(katre): Generate a source RPM.
     ctx.actions.run(
+        mnemonic = "MakeRpm",
         executable = ctx.executable._make_rpm,
         use_default_shell_env = True,
         arguments = args,
         inputs = files,
         outputs = [ctx.outputs.rpm],
-        mnemonic = "MakeRpm",
+        env = {
+            "LANG": "en_US.UTF-8",
+            "LC_CTYPE": "UTF-8",
+            "PYTHONIOENCODING": "UTF-8",
+            "PYTHONUTF8": "1",
+        },
     )
 
     # Link the RPM to the expected output name.

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -82,6 +82,29 @@ pkg_deb(
     version = "test",
 )
 
+pkg_deb(
+    name = "test-deb-py2",
+    built_using = "some_test_data (0.1.2)",
+    conffiles = [
+        "/etc/nsswitch.conf",
+        "/etc/other",
+    ],
+    config = ":testdata/config",
+    data = ":test-tar-gz.tar.gz",
+    depends = [
+        "dep1",
+        "dep2",
+    ],
+    description = "toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é",
+    distribution = "trusty",
+    maintainer = "soméone@somewhere.com",
+    make_deb = "@rules_pkg//:make_deb_py2",
+    package = "titi",
+    templates = ":testdata/templates",
+    urgency = "low",
+    version = "test_py2",
+)
+
 [pkg_tar(
     name = "test-tar-%s" % ext[1:],
     srcs = [
@@ -191,6 +214,7 @@ sh_test(
     data = [
         "testenv.sh",
         ":test-deb.deb",
+        ":test-deb-py2.deb",
         ":test-tar-.tar",
         ":test-tar-bz2.tar.bz2",
         ":test-tar-empty_dirs.tar",


### PR DESCRIPTION
Generally being more careful about unicode handling.
Some very weird magic with pre-processing argv to undo undesired interpreter behavior.

This leaves the code in a state where someone could use either interpreter.
Next step it to figure out how to select the python version to match whatever toolchain we have.