### PR TITLE
Allow supplying package_dir of pkg_tar from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ijwb
+bazel-*
+

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -17,6 +17,7 @@ py_library(
     srcs = [
         "__init__.py",
         "archive.py",
+        "helpers.py"
     ],
     srcs_version = "PY2AND3",
     # This points to a fundemental bazel workspace deficiency. What we need is a
@@ -74,6 +75,7 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
+        ":archive",
         ":make_rpm_lib",
     ],
 )

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -23,6 +23,8 @@ import tempfile
 from rules_pkg import archive
 from absl import flags
 
+from helpers import GetFlagValue
+
 flags.DEFINE_string('output', None, 'The output file, mandatory')
 flags.mark_flag_as_required('output')
 
@@ -88,16 +90,6 @@ flags.DEFINE_string('root_directory', './',
                     'Default root directory is named "."')
 
 FLAGS = flags.FLAGS
-
-
-def GetFlagValue(flagvalue, strip=True):
-    if flagvalue:
-        if flagvalue[0] == '@':
-            with open(flagvalue[1:], 'r') as f:
-                flagvalue = f.read()
-        if strip:
-            return flagvalue.strip()
-    return flagvalue
 
 
 class TarFile(object):

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -90,6 +90,16 @@ flags.DEFINE_string('root_directory', './',
 FLAGS = flags.FLAGS
 
 
+def GetFlagValue(flagvalue, strip=True):
+    if flagvalue:
+        if flagvalue[0] == '@':
+            with open(flagvalue[1:], 'r') as f:
+                flagvalue = f.read()
+        if strip:
+            return flagvalue.strip()
+    return flagvalue
+
+
 class TarFile(object):
   """A class to generates a TAR file."""
 
@@ -335,7 +345,7 @@ def main(unused_argv):
       ids_map[f] = (int(user), int(group))
 
   # Add objects to the tar file
-  with TarFile(FLAGS.output, FLAGS.directory, FLAGS.compression,
+  with TarFile(FLAGS.output, GetFlagValue(FLAGS.directory), FLAGS.compression,
                FLAGS.root_directory, FLAGS.mtime) as output:
 
     def file_attributes(filename):

--- a/pkg/helpers.py
+++ b/pkg/helpers.py
@@ -48,7 +48,8 @@ def GetFlagValue(flagvalue, strip=True):
         flagvalue = f.read().decode('utf-8')
     else:
       # convert fs specific encoding back to proper unicode.
-      flagvalue = os.fsencode(flagvalue).decode('utf-8')
+      if sys.version_info[0] > 2:
+        flagvalue = os.fsencode(flagvalue).decode('utf-8')
 
     if strip:
       return flagvalue.strip()

--- a/pkg/helpers.py
+++ b/pkg/helpers.py
@@ -1,0 +1,55 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+
+def GetFlagValue(flagvalue, strip=True):
+  """Converts a raw flag string to a useable value.
+
+  1. Expand @filename style flags to the content of filename.
+  2. Cope with Python3 strangness of sys.argv.
+     sys.argv is not actually proper str types on Unix with Python3
+     The bytes of the arg are each directly transcribed to the characters of
+     the str. It is actually more complex than that, as described in the docs.
+       https://docs.python.org/3/library/sys.html#sys.argv
+       https://docs.python.org/3/library/os.html#os.fsencode
+       https://www.python.org/dev/peps/pep-0383/
+
+  Args:
+    flagvalue: (str) raw flag value
+    strip: (bool) Strip white space.
+
+  Returns:
+    Python2: unicode
+    Python3: str
+  """
+  if flagvalue:
+    if sys.version_info[0] < 3:
+      # python2 gives us raw bytes in argv.
+      flagvalue = flagvalue.decode('utf-8')
+    # assertion: py2: flagvalue is unicode
+    # assertion: py3: flagvalue is str, but in weird format
+    if flagvalue[0] == '@':
+      # Subtle: We do not want to re-encode the value here, because it
+      # is encoded in the right format for file open operations.
+      with open(flagvalue[1:], 'rb') as f:
+        flagvalue = f.read().decode('utf-8')
+    else:
+      # convert fs specific encoding back to proper unicode.
+      flagvalue = os.fsencode(flagvalue).decode('utf-8')
+
+    if strip:
+      return flagvalue.strip()
+  return flagvalue

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -28,6 +28,8 @@ from absl import flags
 
 # list of debian fields : (name, mandatory, wrap[, default])
 # see http://www.debian.org/doc/debian-policy/ch-controlfields.html
+from helpers import GetFlagValue
+
 DEBIAN_FIELDS = [
     ('Package', True, False),
     ('Version', True, False),
@@ -305,46 +307,6 @@ def CreateChanges(output,
   ])
   with open(output, 'wb') as changes_fh:
     changes_fh.write(changesdata.encode('utf-8'))
-
-
-def GetFlagValue(flagvalue, strip=True):
-  """Converts a raw flag string to a useable value.
-
-  1. Expand @filename style flags to the content of filename.
-  2. Cope with Python3 strangness of sys.argv.
-     sys.argv is not actually proper str types on Unix with Python3
-     The bytes of the arg are each directly transcribed to the characters of
-     the str. It is actually more complex than that, as described in the docs.
-       https://docs.python.org/3/library/sys.html#sys.argv
-       https://docs.python.org/3/library/os.html#os.fsencode
-       https://www.python.org/dev/peps/pep-0383/
-
-  Args:
-    flagvalue: (str) raw flag value
-    strip: (bool) Strip white space.
-
-  Returns:
-    Python2: unicode
-    Python3: str
-  """
-  if flagvalue:
-    if sys.version_info[0] < 3:
-      # python2 gives us raw bytes in argv.
-      flagvalue = flagvalue.decode('utf-8')
-    # assertion: py2: flagvalue is unicode
-    # assertion: py3: flagvalue is str, but in weird format
-    if flagvalue[0] == '@':
-      # Subtle: We do not want to re-encode the value here, because it
-      # is encoded in the right format for file open operations.
-      with open(flagvalue[1:], 'rb') as f:
-        flagvalue = f.read().decode('utf-8')
-    else:
-      # convert fs specific encoding back to proper unicode.
-      flagvalue = os.fsencode(flagvalue).decode('utf-8')
-
-    if strip:
-      return flagvalue.strip()
-  return flagvalue
 
 
 def GetFlagValues(flagvalues):

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -28,6 +28,7 @@ import tempfile
 
 from absl import flags
 
+from helpers import GetFlagValue
 
 flags.DEFINE_string('rpmbuild', '', 'Path to rpmbuild executable')
 flags.DEFINE_string('name', '', 'The name of the software being packaged.')
@@ -87,16 +88,6 @@ def Tempdir():
 
   with Cd(dirpath, Cleanup):
     yield dirpath
-
-
-def GetFlagValue(flagvalue, strip=True):
-  if flagvalue:
-    if flagvalue[0] == '@':
-      with open(flagvalue[1:], 'r') as f:
-        flagvalue = f.read()
-    if strip:
-      return flagvalue.strip()
-  return flagvalue
 
 
 WROTE_FILE_RE = re.compile(r'Wrote: (?P<rpm_path>.+)', re.MULTILINE)

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -12,9 +12,35 @@ genrule(
     cmd = "for i in $(OUTS); do echo 1 >$$i; done",
 )
 
+pkg_tar(
+    name = "test-tar-package-dir",
+    srcs = [
+        ":etc/nsswitch.conf",
+    ],
+    package_dir = "/package"
+)
+
+genrule(
+    name = "test-tar-package-dir-file-gen",
+    outs = ["test-tar.pkgdir"],
+    srcs = [],
+    cmd = "echo '/package' > $@"
+)
+
+pkg_tar(
+    name = "test-tar-package-dir-file",
+    srcs = [
+        ":etc/nsswitch.conf",
+    ],
+    package_dir_file = ":test-tar-package-dir-file-gen"
+)
+
 filegroup(
     name = "archive_testdata",
-    srcs = glob(["testdata/**"]),
+    srcs = glob(["testdata/**"]) + [
+        ":test-tar-package-dir",
+        ":test-tar-package-dir-file"
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -13,33 +13,26 @@ genrule(
 )
 
 pkg_tar(
-    name = "test-tar-package-dir",
+    name = "test_tar_package_dir",
     srcs = [
         ":etc/nsswitch.conf",
     ],
     package_dir = "/package"
 )
 
-genrule(
-    name = "test-tar-package-dir-file-gen",
-    outs = ["test-tar.pkgdir"],
-    srcs = [],
-    cmd = "echo '/package' > $@"
-)
-
 pkg_tar(
-    name = "test-tar-package-dir-file",
+    name = "test_tar_package_dir_file",
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    package_dir_file = ":test-tar-package-dir-file-gen"
+    package_dir_file = "testdata/test_tar_package_dir_file.txt"
 )
 
 filegroup(
     name = "archive_testdata",
     srcs = glob(["testdata/**"]) + [
-        ":test-tar-package-dir",
-        ":test-tar-package-dir-file"
+        ":test_tar_package_dir",
+        ":test_tar_package_dir_file"
     ],
     visibility = ["//visibility:private"],
 )

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -59,6 +59,16 @@ py_test(
     ],
 )
 
+py_test(
+    name = "helpers_test",
+    srcs = ["helpers_test.py"],
+    python_version = "PY2",
+    srcs_version = "PY2AND3",
+    deps = [
+        "//:archive",
+    ],
+)
+
 pkg_deb(
     name = "test-deb",
     built_using = "some_test_data (0.1.2)",

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -339,5 +339,24 @@ class TarFileWriterTest(unittest.TestCase):
     ]
     self.assertTarFileContent(self.tempfile, content)
 
+  def testPackageDirFileAttribute(self):
+      """
+      Verifies that passing package_dir (string) and package_dir_file(label)
+      to pkg_tar yields identical results
+      """
+      package_dir = self.data_files.Rlocation(
+          os.path.join("rules_pkg", "tests", "test-tar-package-dir.tar"))
+      package_dir_file = self.data_files.Rlocation(
+          os.path.join("rules_pkg", "tests", "test-tar-package-dir-file.tar"))
+
+      expected_content = [
+          {'name': '.'},
+          {'name': './package'},
+          {'name': './package/nsswitch.conf'},
+      ]
+
+      self.assertTarFileContent(package_dir, expected_content)
+      self.assertTarFileContent(package_dir_file, expected_content)
+
 if __name__ == "__main__":
   unittest.main()

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -341,13 +341,15 @@ class TarFileWriterTest(unittest.TestCase):
 
   def testPackageDirFileAttribute(self):
       """
+      Test package_dir and package_dir_file attributes of pkg_tar
+
       Verifies that passing package_dir (string) and package_dir_file(label)
       to pkg_tar yields identical results
       """
       package_dir = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test-tar-package-dir.tar"))
+          os.path.join("rules_pkg", "tests", "test_tar_package_dir.tar"))
       package_dir_file = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test-tar-package-dir-file.tar"))
+          os.path.join("rules_pkg", "tests", "test_tar_package_dir_file.tar"))
 
       expected_content = [
           {'name': '.'},

--- a/pkg/tests/helpers_test.py
+++ b/pkg/tests/helpers_test.py
@@ -1,0 +1,45 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import tempfile
+import helpers
+
+
+class HelpersTestCase(unittest.TestCase):
+    def test_getFlagValue_nonStripped(self):
+        self.assertEqual(helpers.GetFlagValue('value ', strip=False), 'value ')
+
+    def test_getFlagValue_Stripped(self):
+        self.assertEqual(helpers.GetFlagValue('value ', strip=True), 'value')
+
+    def test_getFlagValue_nonStripped_fromFile(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write('value ')
+            f.flush()
+            self.assertEqual(helpers.GetFlagValue(
+                '@{}'.format(f.name),
+                strip=False), 'value ')
+
+    def test_getFlagValue_Stripped_fromFile(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write('value ')
+            f.flush()
+            self.assertEqual(helpers.GetFlagValue(
+                '@{}'.format(f.name),
+                strip=True), 'value')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/tests/testdata/test_tar_package_dir_file.txt
+++ b/pkg/tests/testdata/test_tar_package_dir_file.txt
@@ -1,0 +1,1 @@
+/package


### PR DESCRIPTION
- This PR allows to provide `package_dir_file` to `pkg_tar` — similarly to how `version`/`version_file` [and others] work in `pkg_deb` rule
- `GetFlagValue` implementation was copy-pasted from `make_rpm.py`. IMO, a good refactor here would be to separate it out to `common.py`, wrap it in `py_library` and put it in `deps` of `make_deb`, `make_rpm` and `build_tar`. Let me know if it's needed — I can submit a follow-up PR.