### PR TITLE
Fixes broken rpm tests

### DIFF
--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -75,6 +75,7 @@ py_test(
     ],
     deps = [
         "@rules_pkg//:make_rpm_lib",
+        "@rules_pkg//:archive",
     ],
 )
 
@@ -84,7 +85,7 @@ py_test(
     python_version = "PY2",
     srcs_version = "PY2AND3",
     deps = [
-        "//:archive",
+        "@rules_pkg//:archive",
     ],
 )
 


### PR DESCRIPTION
A dependency was left out of the BUILD file for the tests in a recent PR.