### PR TITLE
Change mode of config and templates to 644

### DIFF
--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -204,9 +204,9 @@ def CreateDeb(output,
   if postrm:
     extrafiles['postrm'] = (postrm, 0o755)
   if config:
-    extrafiles['config'] = (config, 0o755)
+    extrafiles['config'] = (config, 0o644)
   if templates:
-    extrafiles['templates'] = (templates, 0o755)
+    extrafiles['templates'] = (templates, 0o644)
   if conffiles:
     extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
   control = CreateDebControl(extrafiles=extrafiles, **kwargs)

--- a/pkg/tests/build_test.sh
+++ b/pkg/tests/build_test.sh
@@ -221,9 +221,9 @@ templates"
   # at root causes later. I am not sure if this is WAI or not.
   check_eq "$ctrl_listing" "$(get_deb_ctl_listing ${package})"
   check_eq "-rw-r--r--" "$(get_deb_ctl_permission ${package} conffiles)"
-  check_eq "-rwxr-xr-x" "$(get_deb_ctl_permission ${package} config)"
+  check_eq "-rw-r--r--" "$(get_deb_ctl_permission ${package} config)"
   check_eq "-rw-r--r--" "$(get_deb_ctl_permission ${package} control)"
-  check_eq "-rwxr-xr-x" "$(get_deb_ctl_permission ${package} templates)"
+  check_eq "-rw-r--r--" "$(get_deb_ctl_permission ${package} templates)"
   local conffiles="/etc/nsswitch.conf
 /etc/other"
   check_eq "$conffiles" "$(get_deb_ctl_file ${package} conffiles)"


### PR DESCRIPTION
Fixes #40
RELNOTES: pkg_dep(). config and templates files are now created with mode 644 instead of 755. 