### PR TITLE
fix output paths in relfile

### DIFF
--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -9,8 +9,8 @@ load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
 pkg_tar(
     name = "rules_pkg-%s" % version,
     srcs = [
-        "@rules_pkg//:standard_package",
-        "@rules_pkg//releasing:standard_package",
+        "//:standard_package",
+        "//releasing:standard_package",
     ],
     strip_prefix = ".",
     extension = "tar.gz",


### PR DESCRIPTION
pkg_tar has some strange behavior.  If the srcs are
     srcs = ["@rules_pkg//:standard_package"]
vs
     srcs["//:standard_package"]

We get output paths prefixed with "rules_pkg/".
This is unexpected and dubious behavior. It might be because @<me>// != // yet. But that bug should be fixed by Bazel 1.0. It still is strange, because the fileset should not change inherent paths to the files  because of different ways to specify the same repo. They should alwasy be relative to the repo they are defined in, not the users work space.