### PR TITLE
Convert make_rpm to argparse and add an initial test for it.

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -82,7 +82,4 @@ py_library(
     srcs = ["make_rpm.py"],
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
-    deps = [
-        "@abseil_py//absl/flags",
-    ],
 )

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import argparse
 import contextlib
 import fileinput
 import os
@@ -26,24 +27,7 @@ import subprocess
 import sys
 import tempfile
 
-from absl import flags
-
 from helpers import GetFlagValue
-
-flags.DEFINE_string('rpmbuild', '', 'Path to rpmbuild executable')
-flags.DEFINE_string('name', '', 'The name of the software being packaged.')
-flags.DEFINE_string('version', '',
-                    'The version of the software being packaged.')
-flags.DEFINE_string('release', '',
-                    'The release of the software being packaged.')
-flags.DEFINE_string('arch', '',
-                    'The CPU architecture of the software being packaged.')
-
-flags.DEFINE_string('spec_file', '',
-                    'The file containing the RPM specification.')
-flags.DEFINE_string('out_file', '',
-                    'The destination to save the resulting RPM file to.')
-flags.DEFINE_boolean('debug', False, 'Print debug messages.')
 
 
 # Setup to safely create a temporary directory and clean it up when done.
@@ -171,15 +155,15 @@ class RpmBuilder(object):
   TEMP_DIR = 'TMP'
   DIRS = [SOURCE_DIR, BUILD_DIR, TEMP_DIR]
 
-  def __init__(self, name, version, release, arch, debug, rpmbuild_path):
+  def __init__(self, name, version, release, arch, rpmbuild_path, debug=False):
     self.name = name
     self.version = GetFlagValue(version)
     self.release = GetFlagValue(release)
     self.arch = arch
-    self.debug = debug
     self.files = []
     self.rpmbuild_path = FindRpmbuild(rpmbuild_path)
     self.rpm_path = None
+    self.debug = debug
 
   def AddFiles(self, paths, root=''):
     """Add a set of files to the current RPM.
@@ -225,6 +209,7 @@ class RpmBuilder(object):
   def CallRpmBuild(self, dirname):
     """Call rpmbuild with the correct arguments."""
 
+    buildroot = os.path.join(dirname, RpmBuilder.BUILD_DIR)
     args = [
         self.rpmbuild_path,
         '--define',
@@ -232,10 +217,10 @@ class RpmBuilder(object):
         '--define',
         '_tmppath %s/TMP' % dirname,
         '--bb',
-        '--buildroot',
-        os.path.join(dirname, 'BUILDROOT'),
+        '--buildroot=%s' % buildroot,
         self.spec_file,
     ]
+    os.environ['RPM_BUILD_ROOT'] = buildroot
     p = subprocess.Popen(
         args,
         stdout=subprocess.PIPE,
@@ -281,16 +266,39 @@ class RpmBuilder(object):
 
 
 def main(argv=()):
+  parser = argparse.ArgumentParser(
+      description='Helper for building rpm packages',
+      fromfile_prefix_chars='@')
+
+  parser.add_argument('--name', required=True,
+                      help='The name of the software being packaged.')
+  parser.add_argument('--version', required=True,
+                      help='The version of the software being packaged.')
+  parser.add_argument('--release', required=True,
+                      help='The release of the software being packaged.')
+  parser.add_argument(
+      '--arch',
+      help='The CPU architecture of the software being packaged.')
+  parser.add_argument('--spec_file', required=True,
+                      help='The file containing the RPM specification.')
+  parser.add_argument('--out_file', required=True,
+                      help='The destination to save the resulting RPM file to.')
+  parser.add_argument('--rpmbuild', help='Path to rpmbuild executable.')
+  parser.add_argument('--debug', action='store_true', default=False,
+                      help='Print debug messages.')
+  parser.add_argument('files', nargs='*')
+
+  options = parser.parse_args()
+
   try:
-    builder = RpmBuilder(FLAGS.name, FLAGS.version, FLAGS.release, FLAGS.arch,
-                         FLAGS.debug, FLAGS.rpmbuild)
-    builder.AddFiles(argv[1:])
-    return builder.Build(FLAGS.spec_file, FLAGS.out_file)
+    builder = RpmBuilder(options.name, options.version, options.release,
+                         options.arch, options.rpmbuild, debug=options.debug)
+    builder.AddFiles(options.files)
+    return builder.Build(options.spec_file, options.out_file)
   except NoRpmbuildFoundError:
     print('ERROR: rpmbuild is required but is not present in PATH')
     return 1
 
 
 if __name__ == '__main__':
-  FLAGS = flags.FLAGS
-  main(FLAGS(sys.argv))
+  main()

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -265,7 +265,7 @@ class RpmBuilder(object):
     return status
 
 
-def main(argv=()):
+def main(argv):
   parser = argparse.ArgumentParser(
       description='Helper for building rpm packages',
       fromfile_prefix_chars='@')
@@ -288,7 +288,7 @@ def main(argv=()):
                       help='Print debug messages.')
   parser.add_argument('files', nargs='*')
 
-  options = parser.parse_args()
+  options = parser.parse_args(argv or ())
 
   try:
     builder = RpmBuilder(options.name, options.version, options.release,
@@ -301,4 +301,4 @@ def main(argv=()):
 
 
 if __name__ == '__main__':
-  main()
+  main(sys.argv[1:])

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -22,6 +22,9 @@ def _pkg_rpm_impl(ctx):
 
     files = []
     args = ["--name=" + ctx.label.name]
+    if ctx.attr.debug:
+        args += ["--debug"]
+
     if ctx.attr.rpmbuild_path:
         args += ["--rpmbuild=" + ctx.attr.rpmbuild_path]
 
@@ -75,9 +78,6 @@ def _pkg_rpm_impl(ctx):
 
     for f in ctx.files.data:
         args += [f.path]
-
-    if ctx.attr.debug:
-        args += ["--debug"]
 
     # Call the generator script.
     # TODO(katre): Generate a source RPM.

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -2,6 +2,7 @@
 licenses(["notice"])  # Apache 2.0
 
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+load("@rules_pkg//:rpm.bzl", "pkg_rpm")
 
 genrule(
     name = "generate_files",
@@ -110,6 +111,15 @@ pkg_deb(
     templates = ":testdata/templates",
     urgency = "low",
     version = "test",
+)
+
+pkg_rpm(
+    name = "test-rpm",
+    version = "1",
+    release = "0",
+    data = [":archive_testdata"],
+    spec_file = "test_rpm.spec",
+    debug = 1,
 )
 
 pkg_deb(

--- a/pkg/tests/make_rpm_test.py
+++ b/pkg/tests/make_rpm_test.py
@@ -122,7 +122,7 @@ class MakeRpmTest(unittest.TestCase):
 
       with PrependPath([outer]):
         # Create the builder and exercise it.
-        builder = make_rpm.RpmBuilder('test', '1.0', '0', 'x86', False, None)
+        builder = make_rpm.RpmBuilder('test', '1.0', '0', 'x86', None)
 
         # Create spec_file, test files.
         WriteFile('test.spec', 'Name: test', 'Version: 0.1',
@@ -162,7 +162,7 @@ class MakeRpmTest(unittest.TestCase):
 
       with PrependPath([outer]):
         # Create the builder and exercise it.
-        builder = make_rpm.RpmBuilder('test', '1.0', '0', 'x86', False, None)
+        builder = make_rpm.RpmBuilder('test', '1.0', '0', 'x86', None)
 
         # Create spec_file, test files.
         WriteFile('test.spec', 'Name: test', 'Version: 0.1',

--- a/pkg/tests/test_rpm.spec
+++ b/pkg/tests/test_rpm.spec
@@ -1,0 +1,29 @@
+Name: rules_pkg
+Version: 0
+Release: 1
+Summary: Test data
+URL: https://github.com/bazelbuild/rules_pkg
+License: Apache License, v2.0
+
+# Do not try to use magic to determine file types
+%define __spec_install_post %{nil}
+# Do not die becuse we give it more input files than are in the files section
+%define _unpackaged_files_terminate_build 0
+
+%description
+This is a package description.
+
+%prep
+
+%build
+
+%install
+
+%files
+/tests/testdata/a.ar
+/tests/testdata/a_ab.ar
+/tests/testdata/a_b.ar
+/tests/testdata/a_b_ab.ar
+/tests/testdata/ab.ar
+/tests/testdata/b.ar
+/tests/testdata/config


### PR DESCRIPTION
Fixes #49 

There are two things going on here.
1. Convert make_rpm.py to use argparse
2. Add a minimal test to show it working
3. Drive by fixe to make_rpm.py because of a BUILDROOT issue.

While testing, I think I discovered a latent bug in the tool, w.r.t. BUILDROOT, so I had to fix that to make any pkg_rpm() instance build.  Regardless of that issue, the change to argparse is what this PR is about. If it turns out there is still flakiness w.r.t. BUILDROOT, we can fix that as a distinct issue.