### PR TITLE
Relnotes: Support projects without deps.bzl file

### DIFF
--- a/pkg/releasing/defs.bzl
+++ b/pkg/releasing/defs.bzl
@@ -1,6 +1,6 @@
 
 
-def print_rel_notes(name, repo, version, outs=None):
+def print_rel_notes(name, repo, version, outs=None, has_deps_file=True):
     tarball_name = ":%s-%s.tar.gz" % (repo, version)
     native.genrule(
         name = "relnotes",
@@ -13,6 +13,7 @@ def print_rel_notes(name, repo, version, outs=None):
             repo,
             version,
             "$(location %s)" % tarball_name,
+            str(has_deps_file),
             ">$@",
         ]),
         tools = [

--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -22,13 +22,13 @@ import textwrap
 from releasing import release_tools
 
 
-def print_notes(repo, version, tarball_path, org='bazelbuild'):
+def print_notes(repo, version, tarball_path, has_deps_file, org='bazelbuild'):
   file_name = release_tools.package_basename(repo, version)
   sha256 = release_tools.get_package_sha256(tarball_path)
 
   url = 'https://github.com/%s/%s/releases/download/%s/%s' % (
       org, repo, version, file_name)
-  workspace_stanza = release_tools.workspace_content(url, repo, sha256)
+  workspace_stanza = release_tools.workspace_content(url, repo, sha256, has_deps_file)
   relnotes_template = Template(textwrap.dedent(
       """
       ------------------------ snip ----------------------------
@@ -56,7 +56,9 @@ def print_notes(repo, version, tarball_path, org='bazelbuild'):
 
 
 def main(args):
-  print_notes(repo=args[1], version=args[2], tarball_path=args[3])
+  # has_deps_file defaults to True
+  has_deps_file = len(args) > 4 and args[4] != "False"
+  print_notes(repo=args[1], version=args[2], tarball_path=args[3], has_deps_file=has_deps_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The WORKSPACE stanza of the release notes should not always contain instructions to load a deps.bzl file, since projects may not have such a file. This behavior can be controlled by setting the has_deps_file parameter of the print_rel_notes macro.
It defaults to True for backwards compatibility.

I'd like to modify the Python scripts in a future commit to improve the handling of flags, and to support WORKSPACE stanzas that refer to the Bazel federation.