### PR TITLE
Get ready for 0.2.3 release

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -391,7 +391,7 @@ Creates a zip file from a list of inputs.
       </td>
     </tr>
     <tr>
-      <td><code>srcs</code></td>
+      <td><code>timestamp</code></td>
       <td>
         <code>Integer, default to 315532800</code>
         <p>
@@ -399,7 +399,7 @@ Creates a zip file from a list of inputs.
           Unix Epoch, RFC 3339.
         </p>
         <p>
-          Due to limitations in the format of zip files, values bevfore
+          Due to limitations in the format of zip files, values before
           Jan 1, 1980 will be rounded up and the precision in the zip file is
           limited to a granularity of 2 seconds.
         </p>

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -2,7 +2,8 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "version")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//:version.bzl", "version")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
 
 # Build the artifact to put on the github release page.

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -15,8 +15,6 @@
 
 load(":path.bzl", "compute_data_path", "dest_path")
 
-version = "0.2.2"
-
 # Filetype to restrict inputs
 tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.xz", ".tar.bz2"]
 deb_filetype = [".deb", ".udeb"]

--- a/pkg/version.bzl
+++ b/pkg/version.bzl
@@ -1,0 +1,16 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The version of rules_pkg."""
+
+version = "0.2.3"


### PR DESCRIPTION
- Bump version
- Split version number out to version.bzl
- Incorporate some suggested typo fixes.