### PR TITLE
Fix repo names with '-' in them.

### DIFF
--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -17,7 +17,12 @@ package(
 
 filegroup(
     name = "standard_package",
-    srcs = glob(["BUILD", "*.bzl", "*.py", "*.md"]),
+    srcs = glob([
+        "BUILD",
+        "*.bzl",
+        "*.py",
+        "*.md",
+    ]),
     visibility = ["@//distro:__pkg__"],
 )
 
@@ -36,6 +41,14 @@ py_binary(
         "print_rel_notes.py",
     ],
     python_version = "PY3",
+    deps = [
+        ":release_utils",
+    ],
+)
+
+py_test(
+    name = "release_tools_test",
+    srcs = ["release_tools_test.py"],
     deps = [
         ":release_utils",
     ],

--- a/pkg/releasing/release_tools.py
+++ b/pkg/releasing/release_tools.py
@@ -65,6 +65,12 @@ def workspace_content(url, repo, sha256, setup_file=None, deps_method=None,
   if toolchains_method:
     methods.append(toolchains_method)
 
+  # If the github repo has a '-' in the name, that breaks bazel unless we remove
+  # it or change it to an '_'
+  repo = repo.replace('-', '_')
+  # Correct the common mistake of not putting a ':' in your setup file name
+  if setup_file and ':' not in setup_file:
+    setup_file = ':' + setup_file
   ret = WORKSPACE_STANZA_TEMPLATE.substitute({
       'url': url,
       'sha256': sha256,
@@ -76,9 +82,9 @@ def workspace_content(url, repo, sha256, setup_file=None, deps_method=None,
         'setup_file': setup_file or ':deps.bzl',
         'to_load': ', '.join('"%s"' % m for m in methods),
     })
-    ret += "\n%s" % deps
+    ret += "\n%s\n" % deps
 
   for m in methods:
-    ret += '\n%s()' % m
+    ret += '%s()\n' % m
 
   return ret

--- a/pkg/releasing/release_tools_test.py
+++ b/pkg/releasing/release_tools_test.py
@@ -1,0 +1,74 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import filecmp
+import os
+import unittest
+
+import release_tools
+
+
+class ReleaseToolsTest(unittest.TestCase):
+
+  def test_workspace_content_full(self):
+    content = release_tools.workspace_content(
+        url='http://github.com',
+        repo='foo-bar',
+        sha256='@computed@',
+        setup_file='my_setup.bzl',
+        deps_method='my_deps',
+        toolchains_method='my_tools')
+    self.assertTrue(content.find(' name = "foo_bar",') > 0, content)
+    self.assertTrue(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_deps", "my_tools")\n') > 0,
+        content)
+    self.assertTrue(content.find('\nmy_deps()\n') > 0)
+    self.assertTrue(content.find('\nmy_tools()\n') > 0, content)
+
+  def test_workspace_content_notools(self):
+    content = release_tools.workspace_content(
+        url='http://github.com',
+        repo='foo-bar',
+        sha256='@computed@',
+        setup_file='my_setup.bzl',
+        deps_method='my_deps')
+    self.assertTrue(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_deps")\n') > 0,
+        content)
+    self.assertTrue(content.find('\nmy_deps()\n') > 0)
+    self.assertTrue(content.find('\nmy_tools()\n') < 0)
+
+  def test_workspace_content_nodeps(self):
+    content = release_tools.workspace_content(
+        url='http://github.com',
+        repo='foo-bar',
+        sha256='@computed@',
+        setup_file='my_setup.bzl',
+        toolchains_method='my_tools')
+    self.assertTrue(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_tools")\n') > 0,
+        content)
+    self.assertTrue(content.find('\nmy_deps()\n') < 0)
+    self.assertTrue(content.find('\nmy_tools()\n') > 0)
+
+  def test_workspace_content_minimal(self):
+    content = release_tools.workspace_content(
+        url='http://github.com',
+        repo='foo-bar',
+        sha256='@computed@')
+    self.assertTrue(content.find('\nload("@foo_bar') < 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We can not use the form "@repo-name" in Bazel, so the common solution is
to transform that to "@repo_name". We auto-correct the repo names to the
required form when printing the WORKSPACE stanza.

Add tests for workspace content.