### PR TITLE
Kaoru/issue 54/pass target arch

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -638,8 +638,19 @@ for more details on this.
     <tr>
       <td><code>architecture</code></td>
       <td>
-        <code>String, default to 'all'</code>
-        <p>The architecture that this package target.</p>
+        <code>String, default to 'noarch'</code>
+        <p>The target's CPU architecture. Primarily used in the NVR. See <a href="https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch01s03.html">RPM Terminology</a></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>target_platform</code></td>
+      <td>
+        <code>String, default to ''</code>
+        <p>
+            Allows you to set the target's platform CPU architecture, vendor and OS. RPM will error with <code>package [your_package_name] is intended for a different operating system</code>
+            if your host CPU and OS differs from your target's CPU and OS.
+            See <a href="https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-rpmbuild.html#id757256">building for other platforms.</a>
+        </p>
       </td>
     </tr>
     <tr>

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -281,7 +281,7 @@ def main(argv):
   parser.add_argument('--release', required=True,
                       help='The release of the software being packaged.')
   parser.add_argument('--target_platform',
-                      help="The target's platform which the software is meant to run on.")
+                      help="The target's platform which the software is meant to run on. Format should be cpu-vendor-os")
   parser.add_argument('--spec_file', required=True,
                       help='The file containing the RPM specification.')
   parser.add_argument('--out_file', required=True,

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -46,8 +46,8 @@ def _pkg_rpm_impl(ctx):
     elif ctx.attr.release:
         args += ["--release=" + ctx.attr.release]
 
-    if ctx.attr.architecture:
-        args += ["--arch=" + ctx.attr.architecture]
+    if ctx.attr.target_platform:
+        args += ["--target_platform=" + ctx.attr.target_platform]
 
     if not ctx.attr.spec_file:
         fail("spec_file was not specified")
@@ -142,7 +142,8 @@ pkg_rpm = rule(
             mandatory = True,
             allow_single_file = spec_filetype,
         ),
-        "architecture": attr.string(default = "all"),
+        "architecture": attr.string(default = "noarch"),
+        "target_platform": attr.string(),
         "version_file": attr.label(
             allow_single_file = True,
         ),


### PR DESCRIPTION
## Problems
When building RPMs we cannot set the RPM's metadata on build. Thus when we try to install it in the target host, RPM complains that the RPM package was not built for the host's OS / CPU architecture.

## Solution
Allow `pkg_rpm` to accept an optional `target_platform` attr, which is passed to the `rpmbuild` setting the rpm's target platform.