### PR TITLE
Remove glob pattern that doesn't match anything

### DIFF
--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -21,7 +21,6 @@ filegroup(
         "BUILD",
         "*.bzl",
         "*.py",
-        "*.md",
     ]),
     visibility = ["@//distro:__pkg__"],
 )


### PR DESCRIPTION
Fix for Bazel flag --incompatible_disallow_empty_glob