### PR TITLE
Add pkgfilegroup for archive-independent file package structuring mechanisms

### DIFF
--- a/pkg/.bazelignore
+++ b/pkg/.bazelignore
@@ -1,0 +1,1 @@
+tests/external_project

--- a/pkg/WORKSPACE
+++ b/pkg/WORKSPACE
@@ -2,3 +2,11 @@ workspace(name = "rules_pkg")
 
 load("//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+local_repository(
+    name = "test_external_repo",
+    path = "tests/external_repo"
+)

--- a/pkg/deps.bzl
+++ b/pkg/deps.bzl
@@ -1,11 +1,20 @@
 # Workspace dependencies for rules_pkg/pkg
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
 # @federation: BEGIN @rules_pkg
 
-
 def rules_pkg_dependencies():
-    pass
-
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        ],
+        sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    )
 
 def rules_pkg_register_toolchains():
     pass

--- a/pkg/genpkg.bzl
+++ b/pkg/genpkg.bzl
@@ -1,0 +1,364 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Package creation helper mapping rules.
+
+This module declares `pkgfilegroup`, which provides a way to, within bazel only,
+describe how files should be mapped within packages.
+
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_PKGFILEGROUP_STRIP_ALL = "."
+
+# NOTE: this is subject to change
+PackageFileInfo = provider(
+    doc = """Groups a collection of files to be included in a package.
+    This provider also includes certain metadata and dependency information.""",
+    fields = {
+        "srcs": "Source file list",
+        "dests": "Destination file list",
+        "attrs": "File attributes to be set on all 'dests' in this provider",
+        "section": "'Section' property, see other docs for details",
+    },
+)
+
+def make_strip_prefix(files_only = None, from_pkg = None, from_root = None):
+    """Compute a strip_prefix value for a desired path stripping behavior.
+
+    This function computes a value that can be used for the `pkgfilegroup` rule
+    to select a desired path prefix stripping behavior.  Exactly one of
+    `files_only`, `from_pkg`, and `from_root` must be set.
+
+    This routine is used to instruct `pkgfilegroup` to remove (strip) path
+    components from the file as it exists in the current repository.  After this
+    is done, what's left of the path will be concatenated with with the prefix
+    as provided to `pkgfilegroup`.
+
+    For arguments that accept paths (`from_pkg`, `from_root`), provided path
+    components will only be stripped from files to be included in a
+    `pkgfilegroup` if the `pkgfilegroup` paths contain all of the path
+    components provided.  For example, if you have a root-relative file at:
+
+    ```
+    foo/srcs/prog
+    ```
+
+    And if you provide `from_root="foo/src"`, the path in the
+    package will be:
+
+    ```
+    $PREFIX/foo/srcs/prog
+    ```
+
+    where $PREFIX is the `prefix` defined in the `pkgfilegroup`.  If
+    `from_root="foo/srcs"`, then:
+
+    ```
+    $PREFIX/prog
+    ```
+
+    Args:
+      files_only: Set to `True` or `False`.  If `True`, the paths will be stripped
+        of all directories, leaving only the basename.
+
+      from_pkg: Set to a path (string).  If provided, the entirety of the path
+        leading up to the package name in which the files are found will be
+        removed, followed by whatever is provided to this argument.  May be an
+        empty string to strip all components through the package only.
+
+      from_root: Set to a path (string).  If provided, path components to be
+        removed will be considered relative to the workspace root where files in
+        question are actually located.  May be an empty string to do no local
+        path stripping.
+
+    Returns:
+      A path specification used by the `pkgfilegroup` implementation that
+      instructs it to do path stripping as documented here.
+
+    """
+
+    # Exactly one must be "true"
+    not_none_cnt = 0
+    for b in [files_only, from_pkg, from_root]:
+        if b != None:
+            not_none_cnt += 1
+    if not_none_cnt != 1:
+        fail("Provide exactly one of files_only, from_pkg, or from_root")
+
+    if files_only:  # Boolean, must be true
+        return _PKGFILEGROUP_STRIP_ALL
+    elif from_pkg != None:  # String, can be empty
+        if from_pkg.startswith("/"):
+            return from_pkg[1:]
+        else:
+            return from_pkg
+    elif from_root != None:  # String, can be empty
+        # Assume that the user has given us everything we need (accurately, too)
+        if from_root.startswith("/"):
+            return from_root
+        else:
+            return "/" + from_root
+    else:
+        # FIXME: We should probably migrate the files_only checks to the top of
+        # the function, or make this into a struct-module so that this and the
+        # other Noneness tests are obviated.
+        #
+        # The big thing this will catch is if files_only is "false"
+        fail("Invalid make_strip_prefix arguments: files_only={}, from_pkg={}, from_root={}".format(
+            files_only,
+            from_pkg,
+            from_root,
+        ))
+
+def _validate_attr(attr):
+    # If/when the "attr" list expands, this should probably be modified to use
+    # sets (like the one in skylib) instead
+    valid_keys = ["unix"]
+    for k in attr.keys():
+        if k not in valid_keys:
+            fail("Invalid attr {}, allowed are {}".format(k, valid_keys), "attrs")
+
+    # We could do more here, perhaps
+    if "unix" in attr.keys():
+        if len(attr["unix"]) != 3:
+            fail("'unix' attrs key must have three child values")
+
+def _do_strip_prefix(path, to_strip):
+    path_norm = paths.normalize(path)
+    to_strip_norm = paths.normalize(to_strip) + "/"
+
+    if path_norm.startswith(to_strip_norm):
+        return path_norm[len(to_strip_norm):]
+    else:
+        return path_norm
+
+# The below routines make use of some path checking magic that may difficult to
+# understand out of the box.  This following table may be helpful to demonstrate
+# how some of these members may look like in real-world usage:
+#
+# Note: "F" is "File", "FO": is "File.owner".
+
+# | File type | Repo     | `F.path`                                                 | `F.root.path`                | `F.short_path`          | `FO.workspace_name` | `FO.workspace_root` |
+# |-----------|----------|----------------------------------------------------------|------------------------------|-------------------------|---------------------|---------------------|
+# | Source    | Local    | `dirA/fooA`                                              |                              | `dirA/fooA`             |                     |                     |
+# | Generated | Local    | `bazel-out/k8-fastbuild/bin/dirA/gen.out`                | `bazel-out/k8-fastbuild/bin` | `dirA/gen.out`          |                     |                     |
+# | Source    | External | `external/repo2/dirA/fooA`                               |                              | `../repo2/dirA/fooA`    | `repo2`             | `external/repo2`    |
+# | Geneated  | External | `bazel-out/k8-fastbuild/bin/external/repo2/dirA/gen.out` | `bazel-out/k8-fastbuild/bin` | `../repo2/dirA/gen.out` | `repo2`             | `external/repo2`    |
+
+def _owner(file):
+    # File.owner allows us to find a label associated with a file.  While highly
+    # convenient, it may return None in certain circumstances, which seem to be
+    # primarily when bazel doesn't know about the files in question.
+    #
+    # Given that a sizeable amount of the code we have here relies on it, we
+    # should fail() when we encounter this if only to make the rare error more
+    # clear.
+    #
+    # File.owner returns a Label structure
+    if file.owner == None:
+        fail("File {} ({}) has no owner attribute; cannot continue".format(file, file.path))
+    else:
+        return file.owner
+
+
+def _relative_workspace_root(label):
+    # Helper function that returns the workspace root relative to the bazel File
+    # "short_path", so we can exclude external workspace names in the common
+    # path stripping logic.
+    #
+    # This currently is "../$LABEL_WORKSPACE_ROOT" if the label has a specific
+    # workspace name specified, else it's just an empty string.
+    #
+    # XXX: Make this not a hack
+    return paths.join("..", label.workspace_name) if label.workspace_name else ""
+
+def _path_relative_to_package(file):
+    owner = _owner(file)
+    return paths.relativize(
+        file.short_path,
+        paths.join(_relative_workspace_root(owner), owner.package),
+    )
+
+def _path_relative_to_repo_root(file):
+    # Helper function that returns a path to a file relative to its workspace root.
+    return paths.relativize(
+        file.short_path,
+        _relative_workspace_root(_owner(file)),
+    )
+
+def _pkgfilegroup_impl(ctx):
+    # The input sources are already known.  Let's calculate the destinations...
+
+    # Exclude excludes
+    srcs = [f for f in ctx.files.srcs if f not in ctx.files.excludes]
+
+    if ctx.attr.strip_prefix == _PKGFILEGROUP_STRIP_ALL:
+        dests = [paths.join(ctx.attr.prefix, src.basename) for src in srcs]
+    elif ctx.attr.strip_prefix.startswith("/"):
+        # Relative to workspace/repository root
+        dests = [
+            paths.join(
+                ctx.attr.prefix,
+                _do_strip_prefix(
+                    _path_relative_to_repo_root(f),
+                    ctx.attr.strip_prefix[1:],
+                ),
+            )
+            for f in srcs
+        ]
+    else:
+        # Relative to package
+        dests = [
+            paths.join(
+                ctx.attr.prefix,
+                _do_strip_prefix(
+                    _path_relative_to_package(f),
+                    ctx.attr.strip_prefix,
+                ),
+            )
+            for f in srcs
+        ]
+
+    # If the lengths of these are not the same, then it impossible to correlate
+    # them in the actual package helpers, and in the map below.
+    if len(srcs) != len(dests):
+        fail("INTERNAL ERROR: pkgfilegroup length mismatch")
+
+    _validate_attr(ctx.attr.attrs)
+
+    # TODO: consider writing out a tiny parser for this
+    valid_sections = [
+        "",
+        "doc",
+        "config",
+        "config(missingok)",
+        "config(noreplace)",
+        "config(missingok, noreplace)",
+    ]
+
+    if ctx.attr.section not in valid_sections:
+        fail(msg = "Invalid value for section.", attr = "section")
+
+    return [
+        PackageFileInfo(
+            srcs = srcs,
+            dests = dests,
+            attrs = ctx.attr.attrs,
+            section = ctx.attr.section,
+        ),
+        DefaultInfo(
+            # Simple passthrough
+            files = depset(srcs),
+        ),
+    ]
+
+# TODO: Support File renaming
+# TODO: Directory creation
+pkgfilegroup = rule(
+    implementation = _pkgfilegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = """Files/Labels to include in this target filegroup""",
+            mandatory = True,
+            allow_files = True,
+        ),
+        "attrs": attr.string_list_dict(
+            doc = """Attributes to set for the output targets
+
+            Must be a dict of:
+
+            ```
+            "unix" : [
+                "Four-digit octal permissions string (e.g. "0644") or "-" (don't change from what's provided),
+                "User Id, or "-" (use current user)",
+                "Group Id, or "-" (use current group)",
+            ]
+            ```
+
+            All values default to "-".
+            """,
+            default = {"unix": ["-", "-", "-"]},
+        ),
+        "prefix": attr.string(
+            doc = """Installation prefix.""",
+            default = "",
+        ),
+        "section": attr.string(
+            doc = """Type of file this pkgfilegroup gathers for installation.
+            Legal values for section are:
+            - "" (i.e. an empty string)
+            - "doc"
+            - "config"
+            - "config(missingok)"
+            - "config(noreplace)"
+            - "config(missingok, noreplace)"
+
+            "doc" specifies the file is documentation, and "config" specifies
+            the file is a configuration file. The section attribute should be
+            omitted or an empty string should be explicitly passed for any other
+            kind of file. Note some package managers (for example, RPM) may
+            treat documentation and configuration files differently than other
+            installable files.
+
+            Some package managers (such as RPM) may also recognize the
+            "missingok" and/or "noreplace" sub-types of configuration files
+            (which are not mutually exclusive). "missingok" directs the package
+            manager not to report an error if the file is missing when
+            validating an installation of the package. "noreplace" tells the
+            package manager not to overwrite or move an existing configuration
+            file when upgrading an installation (the package manager should
+            instead move where it places the new version of the configuration
+            file).
+
+            If a legal value (enumerated above) is given for the section
+            attribute but a a package is built for a type of package manager
+            that does not support that given value, that section value will
+            simply be ignored. If "config" was given with a sub-type (i.e.
+            "missingok" or "no-replace"), the value of section may be treated as
+            if it were just "config" if a package is built for a package manager
+            that distinguishes configuration files but does not recognize these
+            sub-types.""",
+            default = "",
+        ),
+        "strip_prefix": attr.string(
+            doc = """What prefix of a file's path to discard prior to installation.
+
+            This specifies what prefix of an incoming file's path should not be
+            included in the path the file is installed at after being appended
+            to the install prefix (the prefix attribute).  Note that this is
+            only applied to full directory names, see `make_strip_prefix` for
+            more details.
+
+            Use the `make_strip_prefix()` function to define this attribute.  If this
+            attribute is not specified, all directories will be stripped from
+            all files prior to being included in packages
+            (`make_strip_prefix(files_only = True`).
+
+            """,
+            default = make_strip_prefix(files_only = True),
+        ),
+        "excludes": attr.label_list(
+            doc = """List of files or labels to exclude from the inputs to this pkgfilegroup.
+
+            Mostly useful for removing files from generated outputs or
+            preexisting `filegroup`s.
+
+            """,
+            allow_files = True,
+            default = [],
+        ),
+    },
+)

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2.0
 
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar", "pkg_zip")
 load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+load(":genpkg_test.bzl", "genpkg_analysis_tests", "genpkg_unit_tests")
 
 genrule(
     name = "generate_files",
@@ -377,3 +378,16 @@ test_suite(
     name = "all_windows_tests",
     tests = [":windows_tests"],
 )
+
+# Used within genpkg_analysis_tests
+filegroup(
+    name = "loremipsum_txt",
+    srcs = [
+        "testdata/loremipsum.txt",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+genpkg_analysis_tests()
+
+genpkg_unit_tests()

--- a/pkg/tests/external_repo/BUILD
+++ b/pkg/tests/external_repo/BUILD
@@ -1,0 +1,2 @@
+# Intenionally empty; defines package boundaries
+

--- a/pkg/tests/external_repo/WORKSPACE
+++ b/pkg/tests/external_repo/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "test_external_project")

--- a/pkg/tests/external_repo/pkg/BUILD
+++ b/pkg/tests/external_repo/pkg/BUILD
@@ -1,0 +1,26 @@
+load("@rules_pkg//:genpkg.bzl", "make_strip_prefix", "pkgfilegroup")
+load("test.bzl", "test_referencing_remote_file")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(
+    glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "script",
+    srcs = ["dir/extproj.sh"],
+    visibility = ["//visibility:public"]
+)
+
+pkgfilegroup(
+    name = "extproj_script_pfg",
+    prefix = "usr/bin",
+    srcs = ["dir/extproj.sh"],
+    strip_prefix = make_strip_prefix(from_pkg = "")
+)
+
+test_referencing_remote_file(
+    name = "pfg_local_file_in_extrepo"
+)

--- a/pkg/tests/external_repo/pkg/dir/extproj.sh
+++ b/pkg/tests/external_repo/pkg/dir/extproj.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "External project script!"

--- a/pkg/tests/external_repo/pkg/test.bzl
+++ b/pkg/tests/external_repo/pkg/test.bzl
@@ -1,0 +1,66 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for file mapping routines in pkg/genpkg.bzl.
+
+Test implementation copied from pkg/tests/genpkg_test.bzl
+
+"""
+
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@rules_pkg//:genpkg.bzl", "PackageFileInfo", "make_strip_prefix", "pkgfilegroup")
+
+#### BEGIN copied code
+
+def _genpkg_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dests = sets.make(ctx.attr.expected_dests)
+    actual_dests = sets.make(target_under_test[PackageFileInfo].dests)
+
+    asserts.new_set_equals(env, expected_dests, actual_dests, "pkgfilegroup dests do not match expectations")
+
+    return analysistest.end(env)
+
+genpkg_contents_test = analysistest.make(
+    _genpkg_contents_test_impl,
+    attrs = {
+        #"expected_srcs" : attr.label_list(),
+        "expected_dests": attr.string_list(
+            mandatory = True,
+        ),
+        # attrs/section are always passed
+        # through unchanged (and maybe
+        # rejected)
+    },
+)
+#### END copied code
+
+# Called from the rules_pkg tests
+def test_referencing_remote_file(name):
+    pkgfilegroup(
+        name = "{}_g".format(name),
+        prefix = "usr/share",
+        srcs = ["@rules_pkg//tests:loremipsum_txt"],
+        # The prefix in rules_pkg.  Why yes, this is knotty
+        strip_prefix = make_strip_prefix(from_root = "tests"),
+    )
+
+    genpkg_contents_test(
+        name = name,
+        target_under_test = ":{}_g".format(name),
+        expected_dests = ["usr/share/testdata/loremipsum.txt"],
+    )

--- a/pkg/tests/genpkg_test.bzl
+++ b/pkg/tests/genpkg_test.bzl
@@ -1,0 +1,414 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for file mapping routines in pkg/genpkg.bzl"""
+
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@rules_pkg//:genpkg.bzl", "PackageFileInfo", "make_strip_prefix", "pkgfilegroup")
+
+def _genpkg_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dests = sets.make(ctx.attr.expected_dests)
+    actual_dests = sets.make(target_under_test[PackageFileInfo].dests)
+
+    asserts.new_set_equals(env, expected_dests, actual_dests, "pkgfilegroup dests do not match expectations")
+
+    return analysistest.end(env)
+
+genpkg_contents_test = analysistest.make(
+    _genpkg_contents_test_impl,
+    attrs = {
+        #"expected_srcs" : attr.label_list(),
+        "expected_dests": attr.string_list(
+            mandatory = True,
+        ),
+        # attrs/section are always passed
+        # through unchanged (and maybe
+        # rejected)
+    },
+)
+
+# Generic negative test boilerplate
+def _genpkg_neg_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    #target_under_test = analysistest.target_under_test(env)
+
+    asserts.expect_failure(env, ctx.attr.reason)
+
+    return analysistest.end(env)
+
+genpkg_neg_test = analysistest.make(
+    _genpkg_neg_test_impl,
+    attrs = {
+        "reason": attr.string(
+            default = "",
+        ),
+    },
+    expect_failure = True,
+)
+
+def genpkg_bad_section_test(**kwargs):
+    genpkg_neg_test(
+        reason = "Invalid value for section",
+        **kwargs
+    )
+
+def _test_genpkg_contents():
+    # Test stripping when no arguments are provided (same as files_only=True)
+    pkgfilegroup(
+        name = "pfg_no_strip_prefix_g",
+        srcs = ["testdata/hello.txt"],
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_no_strip_prefix",
+        target_under_test = ":pfg_no_strip_prefix_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # And now, files_only = True
+    pkgfilegroup(
+        name = "pfg_files_only_g",
+        srcs = ["testdata/hello.txt"],
+        strip_prefix = make_strip_prefix(files_only = True),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_files_only",
+        target_under_test = ":pfg_files_only_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Used in the following tests
+    #
+    # Note that since the pkgfilegroup rule is never actually used in anything
+    # other than this test, nonexistent_script can be included with no ill effects. :P
+    native.sh_binary(
+        name = "test_script",
+        srcs = ["testdata/nonexistent_script.sh"],
+        tags = ["manual"],
+    )
+
+    # Test stripping from the package root
+    pkgfilegroup(
+        name = "pfg_from_pkg_g",
+        srcs = [
+            "testdata/hello.txt",
+            ":test_script",
+        ],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata/"),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_strip_testdata_from_pkg",
+        target_under_test = ":pfg_from_pkg_g",
+        expected_dests = [
+            # Static file
+            "hello.txt",
+            # The script itself
+            "nonexistent_script.sh",
+            # The generated target output, in this case, a symlink
+            "test_script",
+        ],
+    )
+
+    # Test the stripping from root.
+    #
+    # In this case, the components to be stripped are taken relative to the root
+    # of the package.  Local and generated files should have the same prefix in
+    # all cases.
+
+    pkgfilegroup(
+        name = "pfg_from_root_g",
+        srcs = [":test_script"],
+        strip_prefix = make_strip_prefix(from_root = "tests/"),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_strip_prefix_from_root",
+        target_under_test = ":pfg_from_root_g",
+        expected_dests = [
+            # The script itself
+            "testdata/nonexistent_script.sh",
+            # The generated target output, in this case, a symlink
+            "test_script",
+        ],
+    )
+
+def _test_genpkg_exclusions():
+    # Normal filegroup, used in all of the below tests
+    native.filegroup(
+        name = "test_base_fg",
+        srcs = [
+            "testdata/config",
+            "testdata/hello.txt",
+        ],
+    )
+
+    # Tests to exclude from the case where stripping is done up to filenames
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_all_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//tests:testdata/config"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_all",
+        target_under_test = ":pfg_exclude_by_label_strip_all_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_all_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_all",
+        target_under_test = ":pfg_exclude_by_filename_strip_all_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Tests to exclude from the case where stripping is done from the package root
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_from_pkg_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//tests:testdata/config"],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_from_pkg",
+        target_under_test = ":pfg_exclude_by_label_strip_from_pkg_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_from_pkg_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_from_pkg",
+        target_under_test = ":pfg_exclude_by_filename_strip_from_pkg_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Tests to exclude from the case where stripping is done from the root
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_from_root_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//tests:testdata/config"],
+        strip_prefix = make_strip_prefix(from_root = "tests"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_from_root",
+        target_under_test = ":pfg_exclude_by_label_strip_from_root_g",
+        expected_dests = ["testdata/hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_from_root_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        strip_prefix = make_strip_prefix(from_root = "tests"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_from_root",
+        target_under_test = ":pfg_exclude_by_filename_strip_from_root_g",
+        expected_dests = ["testdata/hello.txt"],
+    )
+
+# Tests involving external repositories
+def _test_genpkg_extrepo():
+    # From external repo root, basenames only
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_all_g",
+        srcs = ["@test_external_repo//pkg:script"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_all",
+        target_under_test = ":pfg_extrepo_strip_all_g",
+        expected_dests = ["extproj.sh", "script"],
+    )
+
+    # From external repo root, relative to the "pkg" package
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_from_pkg_g",
+        srcs = ["@test_external_repo//pkg:script"],
+        strip_prefix = make_strip_prefix(from_pkg = "dir"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_from_pkg",
+        target_under_test = ":pfg_extrepo_strip_from_pkg_g",
+        expected_dests = [
+            "extproj.sh",  # "dir" is stripped
+            "script",  # Nothing to strip
+        ],
+    )
+
+    # From external repo root, relative to the "pkg" directory
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_from_root_g",
+        srcs = ["@test_external_repo//pkg:script"],
+        strip_prefix = make_strip_prefix(from_root = "pkg"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_from_root",
+        target_under_test = ":pfg_extrepo_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh", "script"],
+    )
+
+    native.filegroup(
+        name = "extrepo_test_fg",
+        srcs = ["@test_external_repo//pkg:dir/extproj.sh"],
+    )
+
+    # Test the case when a have a pkgfilegroup that targets a local filegroup
+    # that has files in an external repo.
+    pkgfilegroup(
+        name = "pfg_extrepo_filegroup_strip_from_pkg_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = make_strip_prefix(from_pkg = ""),
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_filegroup_strip_from_pkg",
+        target_under_test = ":pfg_extrepo_filegroup_strip_from_pkg_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Ditto, except strip from the workspace root instead
+    pkgfilegroup(
+        name = "pfg_extrepo_filegroup_strip_from_root_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = make_strip_prefix(from_root = "pkg"),
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_filegroup_strip_from_root",
+        target_under_test = ":pfg_extrepo_filegroup_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Reference a pkgfilegroup in @test_external_repo
+    genpkg_contents_test(
+        name = "pfg_pkgfilegroup_in_extrepo",
+        target_under_test = "@test_external_repo//pkg:extproj_script_pfg",
+        expected_dests = ["usr/bin/dir/extproj.sh"],
+    )
+
+def _test_genpkg_section():
+    pkgfilegroup(
+        name = "pfg_good_section",
+        srcs = ["testdata/hello.txt"],
+        section = "doc",
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_doc_section_test",
+        target_under_test = ":pfg_good_section",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_bad_section",
+        srcs = ["testdata/hello.txt"],
+        section = "bad_section",
+        tags = ["manual"],
+    )
+
+    genpkg_bad_section_test(
+        name = "pfg_bad_section_test",
+        target_under_test = ":pfg_bad_section",
+    )
+
+def _strip_prefix_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, ".", make_strip_prefix(files_only = True))
+    asserts.equals(env, "path", make_strip_prefix(from_pkg = "path"))
+    asserts.equals(env, "path", make_strip_prefix(from_pkg = "path"))
+    asserts.equals(env, "path", make_strip_prefix(from_pkg = "/path"))
+    asserts.equals(env, "/path", make_strip_prefix(from_root = "path"))
+    asserts.equals(env, "/path", make_strip_prefix(from_root = "/path"))
+    return unittest.end(env)
+
+strip_prefix_test = unittest.make(_strip_prefix_test_impl)
+
+def genpkg_analysis_tests():
+    """Declare genpkg.bzl analysis tests"""
+    _test_genpkg_contents()
+    _test_genpkg_section()
+    _test_genpkg_exclusions()
+    _test_genpkg_extrepo()
+
+    native.test_suite(
+        name = "genpkg_analysis_tests",
+        # We should find a way to get rid of this test list; it would be nice if
+        # it could be derived from something else...
+        tests = [
+            # buildifier: don't sort
+            # Simple tests
+            ":pfg_no_strip_prefix",
+            ":pfg_files_only",
+            ":pfg_strip_testdata_from_pkg",
+            ":pfg_strip_prefix_from_root",
+            # Tests involving excluded files
+            ":pfg_exclude_by_label_strip_all",
+            ":pfg_exclude_by_filename_strip_all",
+            ":pfg_exclude_by_label_strip_from_pkg",
+            ":pfg_exclude_by_filename_strip_from_pkg",
+            ":pfg_exclude_by_label_strip_from_root",
+            ":pfg_exclude_by_filename_strip_from_root",
+            # Tests involving external repositories
+            ":pfg_extrepo_strip_all",
+            ":pfg_extrepo_strip_from_pkg",
+            ":pfg_extrepo_strip_from_root",
+            ":pfg_extrepo_filegroup_strip_from_pkg",
+            ":pfg_extrepo_filegroup_strip_from_root",
+            ":pfg_pkgfilegroup_in_extrepo",
+            # This one fits into the same category, but can't be aliased, apparently.
+            #
+            # The main purpose behind it is to verify cases wherein we build a
+            # file, but then have it consumed by some remote package.
+            "@test_external_repo//pkg:pfg_local_file_in_extrepo",
+            # Tests involving the "section" attribute
+            ":pfg_doc_section_test",
+            ":pfg_bad_section_test",
+        ],
+    )
+
+def genpkg_unit_tests():
+    unittest.suite(
+        "genpkg_unit_tests",
+        strip_prefix_test,
+    )


### PR DESCRIPTION
Currently, package contents need to be assembled in each of their `pkg_*` rules, and each one has a different mechanism for doing so.  This provides a unified interface, the `pkgfilegroup` rule, for accomplishing this task. Packaging rules can be written to take advantage of this in future changes.

Analysis tests are also included.

This is inspired by #36.

This is currently incomplete.  Features in development include:

- File renaming
- Non-file creation (e.g. directories, device nodes)