### PR TITLE
update WORKSPACE example

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -19,13 +19,12 @@ and debian package.
 ## WORKSPACE setup
 
 ```
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/0.1.0/rules_pkg-0.1.0.tar.gz",
-    sha256 = "752146e2813f4c135ec9f71b592bf98f96f026049e6d65248534dbeccb2448e1"
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+    sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
 )
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-rules_pkg_dependencies()
 ```
 
 <a name="basic-example"></a>


### PR DESCRIPTION
The current url is 404.  
Update stanza via [0.2.4](https://github.com/bazelbuild/rules_pkg/releases/tag/0.2.4) changes.