### PR TITLE
Add pkgfilegroup for package-independent destination mappings

### DIFF
--- a/pkg/.bazelignore
+++ b/pkg/.bazelignore
@@ -1,0 +1,1 @@
+tests/external_project

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -89,3 +89,12 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
 )
+
+# Used within experimental/tests/ for external repo genpkg tests
+filegroup(
+    name = "loremipsum_txt",
+    srcs = [
+        "testdata/loremipsum.txt",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/deps.bzl
+++ b/pkg/deps.bzl
@@ -1,11 +1,34 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Workspace dependencies for rules_pkg/pkg
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 # @federation: BEGIN @rules_pkg
 
-
 def rules_pkg_dependencies():
-    pass
-
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        ],
+        sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    )
 
 def rules_pkg_register_toolchains():
     pass

--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "rules_pkg")
-
-load("//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
+exports_files(
+    glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/pkg/experimental/genpkg.bzl
+++ b/pkg/experimental/genpkg.bzl
@@ -1,0 +1,581 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Package creation helper mapping rules.
+
+This module declares Provider interfaces and rules for specifying the contents
+of packages in a package-type-agnostic way.  The main rules supported here are
+the following:
+
+- `pkgfilegroup` describes destinations for rule outputs
+- `pkg_mkdirs` describes directory structures
+
+Rules that actually make use of the outputs of the above rules are not specified
+here.  See `genrpm.bzl` for an example that builds out RPM packages.
+"""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_PKGFILEGROUP_STRIP_ALL = "."
+
+####
+# Provider interfaces
+####
+
+PackageFileInfo = provider(
+    doc = """Groups a collection of files to be included in a package.
+
+    This provider also includes certain metadata and dependency information.
+    """,
+    fields = {
+        "srcs": "Source file list",
+        "dests": "Destination file list",
+        "attrs": "File attributes to be set on all 'dests' in this provider",
+        "section": "'Section' property, see pkgfilegroup docs for details",
+    },
+)
+
+PackageDirInfo = provider(
+    doc = """Groups a collection of directories to be created within a package.
+
+    Also owns directory attributes and other properties.
+    """,
+    fields = {
+        "dirs": "Directories to be created within the package",
+        "attrs": "File attributes to be set on all 'dirs' in this provider",
+        "section": "'Section' property, see pkgfilegroup docs for details",
+    },
+)
+
+####
+# External-facing helpers
+####
+
+def make_strip_prefix(files_only = None, from_pkg = None, from_root = None):
+    """Compute a strip_prefix value for a desired path stripping behavior.
+
+    This function computes a value that can be used for the `pkgfilegroup`
+    rule's `strip_prefix` attribute to select a desired path prefix stripping
+    behavior.  Exactly one of `files_only`, `from_pkg`, and `from_root` must be
+    set.
+
+    This routine is used to instruct `pkgfilegroup` to remove (strip) path
+    components from the file as it exists in the current repository.  After this
+    is done, what's left of the path will be concatenated with the prefix as
+    provided to `pkgfilegroup`.
+
+    For arguments that accept paths (`from_pkg`, `from_root`), provided path
+    components will only be stripped from files to be included in a
+    `pkgfilegroup` if the `pkgfilegroup` paths contain all of the path
+    components provided.  For example, if you have a root-relative file at:
+
+    ```
+    foo/srcs/prog
+    ```
+
+    And if you provide `from_root="foo/src"`, the path in the
+    package will be:
+
+    ```
+    $PREFIX/foo/srcs/prog
+    ```
+
+    where $PREFIX is the `prefix` defined in the `pkgfilegroup`.  If
+    `from_root="foo/srcs"`, then:
+
+    ```
+    $PREFIX/prog
+    ```
+
+    Args:
+      files_only: Set to `True` or `False`.  If `True`, the paths will be stripped
+        of all directories, leaving only the basename.
+
+      from_pkg: Set to a path (string).  If provided, the entirety of the path
+        leading up to the package name in which the files are found will be
+        removed, followed by whatever is provided to this argument.  May be an
+        empty string to strip all components through the package only.
+
+      from_root: Set to a path (string).  If provided, path components to be
+        removed will be considered relative to the workspace root where files in
+        question are actually located.  May be an empty string to do no local
+        path stripping.
+
+    Returns:
+      A path specification used by the `pkgfilegroup` implementation that
+      instructs it to do path stripping as documented here.
+    """
+
+    # Exactly one must be "true"
+    not_none_cnt = 0
+    for b in [files_only, from_pkg, from_root]:
+        if b != None:
+            not_none_cnt += 1
+    if not_none_cnt != 1:
+        fail("Provide exactly one of files_only, from_pkg, or from_root")
+
+    if files_only:  # Boolean, must be true
+        return _PKGFILEGROUP_STRIP_ALL
+    elif from_pkg != None:  # String, can be empty
+        if from_pkg.startswith("/"):
+            return from_pkg[1:]
+        else:
+            return from_pkg
+    elif from_root != None:  # String, can be empty
+        # Assume that the user has given us everything we need (accurately, too)
+        if from_root.startswith("/"):
+            return from_root
+        else:
+            return "/" + from_root
+    else:
+        # FIXME: We should probably migrate the files_only checks to the top of
+        # the function, or make this into a struct-module so that this and the
+        # other Noneness tests are obviated.
+        #
+        # The big thing this will catch is if files_only is "false"
+        fail("Invalid make_strip_prefix arguments: files_only={}, from_pkg={}, from_root={}".format(
+            files_only,
+            from_pkg,
+            from_root,
+        ))
+
+####
+# Internal helpers
+####
+
+def _validate_attr(attr):
+    # If/when the "attr" list expands, this should probably be modified to use
+    # sets (like the one in skylib) instead
+    valid_keys = ["unix"]
+    for k in attr.keys():
+        if k not in valid_keys:
+            fail("Invalid attr {}, allowed are {}".format(k, valid_keys), "attrs")
+
+    # We could do more here, perhaps
+    if "unix" in attr.keys():
+        if len(attr["unix"]) != 3:
+            fail("'unix' attrs key must have three child values")
+
+def _do_strip_prefix(path, to_strip):
+    path_norm = paths.normalize(path)
+    to_strip_norm = paths.normalize(to_strip) + "/"
+
+    if path_norm.startswith(to_strip_norm):
+        return path_norm[len(to_strip_norm):]
+    else:
+        return path_norm
+
+# The below routines make use of some path checking magic that may difficult to
+# understand out of the box.  This following table may be helpful to demonstrate
+# how some of these members may look like in real-world usage:
+#
+# Note: "F" is "File", "FO": is "File.owner".
+
+# | File type | Repo     | `F.path`                                                 | `F.root.path`                | `F.short_path`          | `FO.workspace_name` | `FO.workspace_root` |
+# |-----------|----------|----------------------------------------------------------|------------------------------|-------------------------|---------------------|---------------------|
+# | Source    | Local    | `dirA/fooA`                                              |                              | `dirA/fooA`             |                     |                     |
+# | Generated | Local    | `bazel-out/k8-fastbuild/bin/dirA/gen.out`                | `bazel-out/k8-fastbuild/bin` | `dirA/gen.out`          |                     |                     |
+# | Source    | External | `external/repo2/dirA/fooA`                               |                              | `../repo2/dirA/fooA`    | `repo2`             | `external/repo2`    |
+# | Generated | External | `bazel-out/k8-fastbuild/bin/external/repo2/dirA/gen.out` | `bazel-out/k8-fastbuild/bin` | `../repo2/dirA/gen.out` | `repo2`             | `external/repo2`    |
+
+def _owner(file):
+    # File.owner allows us to find a label associated with a file.  While highly
+    # convenient, it may return None in certain circumstances, which seem to be
+    # primarily when bazel doesn't know about the files in question.
+    #
+    # Given that a sizeable amount of the code we have here relies on it, we
+    # should fail() when we encounter this if only to make the rare error more
+    # clear.
+    #
+    # File.owner returns a Label structure
+    if file.owner == None:
+        fail("File {} ({}) has no owner attribute; cannot continue".format(file, file.path))
+    else:
+        return file.owner
+
+def _relative_workspace_root(label):
+    # Helper function that returns the workspace root relative to the bazel File
+    # "short_path", so we can exclude external workspace names in the common
+    # path stripping logic.
+    #
+    # This currently is "../$LABEL_WORKSPACE_ROOT" if the label has a specific
+    # workspace name specified, else it's just an empty string.
+    #
+    # XXX: Make this not a hack
+    return paths.join("..", label.workspace_name) if label.workspace_name else ""
+
+def _path_relative_to_package(file):
+    # Helper function that returns a path to a file relative to its package.
+    owner = _owner(file)
+    return paths.relativize(
+        file.short_path,
+        paths.join(_relative_workspace_root(owner), owner.package),
+    )
+
+def _path_relative_to_repo_root(file):
+    # Helper function that returns a path to a file relative to its workspace root.
+    return paths.relativize(
+        file.short_path,
+        _relative_workspace_root(_owner(file)),
+    )
+
+####
+# Rule/Macro implementations
+####
+
+def _pkgfilegroup_impl(ctx):
+    # The input sources are already known.  Let's calculate the destinations...
+
+    # Exclude excludes
+    srcs = [f for f in ctx.files.srcs if f not in ctx.files.excludes]
+
+    if ctx.attr.strip_prefix == _PKGFILEGROUP_STRIP_ALL:
+        dests = [paths.join(ctx.attr.prefix, src.basename) for src in srcs]
+    elif ctx.attr.strip_prefix.startswith("/"):
+        # Relative to workspace/repository root
+        dests = [
+            paths.join(
+                ctx.attr.prefix,
+                _do_strip_prefix(
+                    _path_relative_to_repo_root(f),
+                    ctx.attr.strip_prefix[1:],
+                ),
+            )
+            for f in srcs
+        ]
+    else:
+        # Relative to package
+        dests = [
+            paths.join(
+                ctx.attr.prefix,
+                _do_strip_prefix(
+                    _path_relative_to_package(f),
+                    ctx.attr.strip_prefix,
+                ),
+            )
+            for f in srcs
+        ]
+
+    # If the lengths of these are not the same, then it impossible to correlate
+    # them in the actual package helpers, and in the map below.
+    if len(srcs) != len(dests):
+        fail("INTERNAL ERROR: pkgfilegroup length mismatch")
+
+    # Dictionary for convenience purposes.
+    #
+    # TODO(nacl): It would be nice to be able to
+    # build it in one fell swoop.
+    src_dest_files_map = dict(zip(srcs, dests))
+
+    _validate_attr(ctx.attr.attrs)
+
+    # TODO(nacl): consider writing out a tiny parser for this
+    valid_sections = [
+        "",
+        "doc",
+        "config",
+        "config(missingok)",
+        "config(noreplace)",
+        "config(missingok, noreplace)",
+    ]
+
+    if ctx.attr.section not in valid_sections:
+        fail("Invalid 'section' value", "section")
+
+    # Do file renaming
+    for rename_src, rename_dest in ctx.attr.renames.items():
+        # rename_src.files is a depset
+        rename_src_files = rename_src.files.to_list()
+
+        # Need to do a length check before proceeding.  We cannot rename
+        # multiple files simultaneously.
+        if len(rename_src_files) != 1:
+            fail(
+                "Target {} expands to multiple files, should only refer to one".format(rename_src),
+                "renames",
+            )
+
+        src_file = rename_src_files[0]
+        if src_file not in src_dest_files_map:
+            fail(
+                "File remapping from {0} to {1} is invalid: {0} is not provided to this rule or was excluded".format(rename_src, rename_dest),
+                "renames",
+            )
+        src_dest_files_map[src_file] = paths.join(ctx.attr.prefix, rename_dest)
+
+    return [
+        PackageFileInfo(
+            srcs = src_dest_files_map.keys(),
+            dests = src_dest_files_map.values(),
+            attrs = ctx.attr.attrs,
+            section = ctx.attr.section,
+        ),
+        DefaultInfo(
+            # Simple passthrough
+            files = depset(src_dest_files_map.keys()),
+        ),
+    ]
+
+pkgfilegroup = rule(
+    doc = """General-purpose package target-to-destination mapping rule.
+
+    This rule provides a specification for the locations and attributes of
+    targets when they are packaged. No outputs are created other than Providers
+    that are intended to be consumed by other packaging rules, such as
+    `gen_rpm`.
+
+    Instead of providing the actual rules that generate your desired outputs to
+    packaging rules, you instead pass in the associated `pkgfilegroup`.
+
+    Consumers of `pkgfilegroup`s will, where possible, create the necessary
+    directory structure for your files so you do not have to unless you have
+    special requirements.  Consult `pkg_mkdirs` for more details.
+    """,
+    implementation = _pkgfilegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = """Files/Labels to include in this target filegroup""",
+            mandatory = True,
+            allow_files = True,
+        ),
+        "attrs": attr.string_list_dict(
+            doc = """Attributes to set for the output targets
+
+            Must be a dict of:
+
+            ```
+            "unix" : [
+                "Four-digit octal permissions string (e.g. "0644") or "-" (don't change from what's provided),
+                "User Id, or "-" (use current user)",
+                "Group Id, or "-" (use current group)",
+            ]
+            ```
+
+            All values default to "-".
+            """,
+            default = {"unix": ["-", "-", "-"]},
+        ),
+        "prefix": attr.string(
+            doc = """Installation prefix.
+
+            This may be an arbitrary string, but it should be understandable by
+            the packaging system you are using to have the desired outcome.  For
+            example, RPM macros like `%{_libdir}` may work correctly in paths
+            for RPM packages, not, say, Debian packages.
+
+            """,
+            default = "",
+        ),
+        "section": attr.string(
+            doc = """Type of file this pkgfilegroup gathers for installation.
+            Legal values for section are:
+            - "" (i.e. an empty string)
+            - "doc"
+            - "config"
+            - "config(missingok)"
+            - "config(noreplace)"
+            - "config(missingok, noreplace)"
+
+            "doc" specifies the file is documentation, and "config" specifies
+            the file is a configuration file. The section attribute should be
+            omitted or an empty string should be explicitly passed for any other
+            kind of file. Note some package managers (for example, RPM) may
+            treat documentation and configuration files differently than other
+            installable files.
+
+            Some package managers (such as RPM) may also recognize the
+            "missingok" and/or "noreplace" sub-types of configuration files
+            (which are not mutually exclusive). "missingok" directs the package
+            manager not to report an error if the file is missing when
+            validating an installation of the package. "noreplace" tells the
+            package manager not to overwrite or move an existing configuration
+            file when upgrading an installation (the package manager should
+            instead move where it places the new version of the configuration
+            file).
+
+            If a legal value (enumerated above) is given for the section
+            attribute but a a package is built for a type of package manager
+            that does not support that given value, that section value will
+            simply be ignored. If "config" was given with a sub-type (i.e.
+            "missingok" or "no-replace"), the value of section may be treated as
+            if it were just "config" if a package is built for a package manager
+            that distinguishes configuration files but does not recognize these
+            sub-types.
+            """,
+            default = "",
+        ),
+        "strip_prefix": attr.string(
+            doc = """What prefix of a file's path to discard prior to installation.
+
+            This specifies what prefix of an incoming file's path should not be
+            included in the path the file is installed at after being appended
+            to the install prefix (the prefix attribute).  Note that this is
+            only applied to full directory names, see `make_strip_prefix` for
+            more details.
+
+            Use the `make_strip_prefix()` function to define this attribute.  If this
+            attribute is not specified, all directories will be stripped from
+            all files prior to being included in packages
+            (`make_strip_prefix(files_only = True`).
+            """,
+            default = make_strip_prefix(files_only = True),
+        ),
+        "excludes": attr.label_list(
+            doc = """List of files or labels to exclude from the inputs to this pkgfilegroup.
+
+            Mostly useful for removing files from generated outputs or
+            preexisting `filegroup`s.
+            """,
+            allow_files = True,
+            default = [],
+        ),
+        "renames": attr.label_keyed_string_dict(
+            doc = """Destination override map
+
+            This attribute allows the user to override destinations of files in
+            `pkgfilegroup`s relative to the `prefix` attribute.  Keys to the
+            dict are source files/labels, values are destinations relative to
+            the `prefix`, ignoring whatever value was provided for
+            `strip_prefix`.
+
+            This is the most effective way to rename files using
+            `pkgfilegroup`s.  For single files, consider using
+            `pkg_rename_single`.
+
+            The following keys are rejected:
+
+            - Any label that expands to more than one file (mappings must be
+              one-to-one).
+
+            - Any label or file that was either not provided or explicitly
+              `exclude`d.
+            """,
+            default = {},
+            allow_files = True,
+        ),
+    },
+)
+
+def pkg_rename_single(name = None, src = None, dest = None, **kwargs):
+    """Macro that eases the renaming of files in `pkgfilegroup`s
+
+    Effectively calls:
+
+    ```
+    pkgfilegroup(
+        name = name,
+        deps = [src],
+        renames = {src : dest},
+        **kwargs,
+    )
+    ```
+
+    All of `name`, `src`, and `dest` must be provided.
+
+    Args:
+      name: (String) Name of the underlying `pkgfilegroup`.
+
+      src: (String/Label) Source file/label to copy from.  Must refer to exactly one
+        file/output (see `renames` in `pkgfilegroup`).
+
+      dest: (String) Destination within packages.
+
+      **kwargs: Additional args to be passed `pkgfilegroup`.  Useful ones
+        include `attrs` and `section`; see the relevant documentation in
+        `pkgfilegroup`.
+    """
+    if None in [name, src, dest]:
+        fail("All of 'name', 'src', and 'dest' must be provided")
+
+    rule_args = kwargs
+
+    rule_args["name"] = name
+    rule_args["srcs"] = [src]
+    rule_args["renames"] = {src: dest}
+
+    pkgfilegroup(**rule_args)
+
+def _pkg_mkdirs_impl(ctx):
+    _validate_attr(ctx.attr.attrs)
+
+    if ctx.attr.section not in ["dir", "docdir"]:
+        fail("Invalid 'section' value", "section")
+    return [
+        PackageDirInfo(
+            dirs = ctx.attr.dirs,
+            attrs = ctx.attr.attrs,
+            section = ctx.attr.section,
+        ),
+    ]
+
+pkg_mkdirs = rule(
+    doc = """pkgfilegroup-like rule for the creation and ownership of directories.
+
+    Use this if:
+
+    1) You need to create an empty directory in your package.
+
+    2) Your package needs to explicitly own a directory, even if it already owns
+       files in those directories.
+
+    3) You need nonstandard permissions (typically, not "0755") on a directory
+       in your package.
+
+    For some package management systems (e.g. RPM), directory ownership (2) may
+    imply additional semantics.  Consult your package manager's and target
+    distribution's documentation for more details.
+    """,
+    implementation = _pkg_mkdirs_impl,
+    attrs = {
+        "dirs": attr.string_list(
+            doc = """Directory names to make within the package""",
+            mandatory = True,
+        ),
+        "attrs": attr.string_list_dict(
+            doc = """Attributes to set for the output targets.
+
+            Must be a dict of:
+
+            ```
+            "unix" : [
+                "Four-digit octal permissions string (e.g. "0755") or "-" (don't change from what's provided),
+                "User Id, or "-" (use current user)",
+                "Group Id, or "-" (use current group)",
+            ]
+            ```
+
+            All values default to "-".
+            """,
+            default = {"unix": ["-", "-", "-"]},
+        ),
+        "section": attr.string(
+            doc = """Directory type used by package generators.
+
+            Legal values are:
+
+            - `dir`
+            - `docdir`
+
+            `dir` specifies that the provided paths will just be plain old
+            directories without any special characteristics.
+
+            `docdir` is like `dir` but also specifies that this directory will
+            exclusively contain documentation.
+
+            The default is `dir`.
+            """,
+            default = "dir",
+        ),
+    },
+)

--- a/pkg/experimental/tests/BUILD
+++ b/pkg/experimental/tests/BUILD
@@ -1,0 +1,5 @@
+load(":genpkg_test.bzl", "genpkg_analysis_tests", "genpkg_unit_tests")
+
+genpkg_analysis_tests()
+
+genpkg_unit_tests()

--- a/pkg/experimental/tests/external_repo/BUILD
+++ b/pkg/experimental/tests/external_repo/BUILD
@@ -12,17 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "rules_pkg")
-
-load("//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-local_repository(
-    name = "experimental_test_external_repo",
-    path = "experimental/tests/external_repo",
-)
+# Intenionally empty; defines package boundaries

--- a/pkg/experimental/tests/external_repo/WORKSPACE
+++ b/pkg/experimental/tests/external_repo/WORKSPACE
@@ -12,17 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "rules_pkg")
-
-load("//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-local_repository(
-    name = "experimental_test_external_repo",
-    path = "experimental/tests/external_repo",
-)
+workspace(name = "test_external_project")

--- a/pkg/experimental/tests/external_repo/pkg/BUILD
+++ b/pkg/experimental/tests/external_repo/pkg/BUILD
@@ -12,17 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "rules_pkg")
+load("@rules_pkg//experimental:genpkg.bzl", "make_strip_prefix", "pkgfilegroup")
+load("test.bzl", "test_referencing_remote_file")
 
-load("//:deps.bzl", "rules_pkg_dependencies")
+package(default_visibility = ["//visibility:public"])
 
-rules_pkg_dependencies()
+exports_files(
+    glob(["**"]),
+    visibility = ["//visibility:public"],
+)
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+sh_binary(
+    name = "script",
+    srcs = ["dir/extproj.sh"],
+    visibility = ["//visibility:public"],
+)
 
-bazel_skylib_workspace()
+pkgfilegroup(
+    name = "extproj_script_pfg",
+    srcs = ["dir/extproj.sh"],
+    prefix = "usr/bin",
+    strip_prefix = make_strip_prefix(from_pkg = ""),
+)
 
-local_repository(
-    name = "experimental_test_external_repo",
-    path = "experimental/tests/external_repo",
+test_referencing_remote_file(
+    name = "pfg_local_file_in_extrepo",
 )

--- a/pkg/experimental/tests/external_repo/pkg/dir/extproj.sh
+++ b/pkg/experimental/tests/external_repo/pkg/dir/extproj.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "External project script!"

--- a/pkg/experimental/tests/external_repo/pkg/test.bzl
+++ b/pkg/experimental/tests/external_repo/pkg/test.bzl
@@ -1,0 +1,67 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for file mapping routines in pkg/experimental/genpkg.bzl.
+
+Test implementation copied from pkg/experimental/tests/genpkg_test.bzl
+
+"""
+
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_pkg//experimental:genpkg.bzl", "PackageFileInfo", "make_strip_prefix", "pkgfilegroup")
+
+#### BEGIN copied code
+
+def _genpkg_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dests = sets.make(ctx.attr.expected_dests)
+    actual_dests = sets.make(target_under_test[PackageFileInfo].dests)
+
+    asserts.new_set_equals(env, expected_dests, actual_dests, "pkgfilegroup dests do not match expectations")
+
+    return analysistest.end(env)
+
+genpkg_contents_test = analysistest.make(
+    _genpkg_contents_test_impl,
+    attrs = {
+        #"expected_srcs" : attr.label_list(),
+        "expected_dests": attr.string_list(
+            mandatory = True,
+        ),
+        # attrs/section are always passed
+        # through unchanged (and maybe
+        # rejected)
+    },
+)
+#### END copied code
+
+# Called from the rules_pkg tests
+def test_referencing_remote_file(name):
+    pkgfilegroup(
+        name = "{}_g".format(name),
+        prefix = "usr/share",
+        srcs = ["@rules_pkg//tests:loremipsum_txt"],
+        # The prefix in rules_pkg.  Why yes, this is knotty
+        strip_prefix = make_strip_prefix(from_root = "tests"),
+    )
+
+    genpkg_contents_test(
+        name = name,
+        target_under_test = ":{}_g".format(name),
+        expected_dests = ["usr/share/testdata/loremipsum.txt"],
+    )

--- a/pkg/experimental/tests/genpkg_test.bzl
+++ b/pkg/experimental/tests/genpkg_test.bzl
@@ -1,0 +1,666 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for file mapping routines in pkg/experimental/genpkg.bzl"""
+
+# NOTE: When making this module unexperimental, you can clean it up via calling something like this:
+#
+#   sed 's|experimental[_/]\?||' experimental/tests/genpkg_test.bzl
+
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load(
+    "@rules_pkg//experimental:genpkg.bzl",
+    "PackageDirInfo",
+    "PackageFileInfo",
+    "make_strip_prefix",
+    "pkg_mkdirs",
+    "pkg_rename_single",
+    "pkgfilegroup",
+)
+
+def _genpkg_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dests = sets.make(ctx.attr.expected_dests)
+    actual_dests = sets.make(target_under_test[PackageFileInfo].dests)
+
+    asserts.new_set_equals(env, expected_dests, actual_dests, "pkgfilegroup dests do not match expectations")
+
+    return analysistest.end(env)
+
+genpkg_contents_test = analysistest.make(
+    _genpkg_contents_test_impl,
+    attrs = {
+        # Other attributes can be tested here, but the most important one is the
+        # destinations.
+        "expected_dests": attr.string_list(
+            mandatory = True,
+        ),
+        # attrs/section are always passed
+        # through unchanged (and maybe
+        # rejected)
+    },
+)
+
+# Generic negative test boilerplate
+def _generic_neg_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    asserts.expect_failure(env, ctx.attr.reason)
+
+    return analysistest.end(env)
+
+generic_neg_test = analysistest.make(
+    _generic_neg_test_impl,
+    attrs = {
+        "reason": attr.string(
+            default = "",
+        ),
+    },
+    expect_failure = True,
+)
+
+def generic_bad_section_test(**kwargs):
+    generic_neg_test(
+        reason = "Invalid 'section' value",
+        **kwargs
+    )
+
+def _test_genpkg_contents():
+    # Test stripping when no arguments are provided (same as files_only=True)
+    pkgfilegroup(
+        name = "pfg_no_strip_prefix_g",
+        srcs = ["testdata/hello.txt"],
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_no_strip_prefix",
+        target_under_test = ":pfg_no_strip_prefix_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # And now, files_only = True
+    pkgfilegroup(
+        name = "pfg_files_only_g",
+        srcs = ["testdata/hello.txt"],
+        strip_prefix = make_strip_prefix(files_only = True),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_files_only",
+        target_under_test = ":pfg_files_only_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Used in the following tests
+    #
+    # Note that since the pkgfilegroup rule is never actually used in anything
+    # other than this test, nonexistent_script can be included with no ill effects. :P
+    native.sh_binary(
+        name = "test_script",
+        srcs = ["testdata/nonexistent_script.sh"],
+        tags = ["manual"],
+    )
+
+    # Test stripping from the package root
+    pkgfilegroup(
+        name = "pfg_from_pkg_g",
+        srcs = [
+            "testdata/hello.txt",
+            ":test_script",
+        ],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata/"),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_strip_testdata_from_pkg",
+        target_under_test = ":pfg_from_pkg_g",
+        expected_dests = [
+            # Static file
+            "hello.txt",
+            # The script itself
+            "nonexistent_script.sh",
+            # The generated target output, in this case, a symlink
+            "test_script",
+        ],
+    )
+
+    # Test the stripping from root.
+    #
+    # In this case, the components to be stripped are taken relative to the root
+    # of the package.  Local and generated files should have the same prefix in
+    # all cases.
+
+    pkgfilegroup(
+        name = "pfg_from_root_g",
+        srcs = [":test_script"],
+        strip_prefix = make_strip_prefix(from_root = "experimental/tests/"),
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_strip_prefix_from_root",
+        target_under_test = ":pfg_from_root_g",
+        expected_dests = [
+            # The script itself
+            "testdata/nonexistent_script.sh",
+            # The generated target output, in this case, a symlink
+            "test_script",
+        ],
+    )
+
+def _test_genpkg_exclusions():
+    # Normal filegroup, used in all of the below tests
+    native.filegroup(
+        name = "test_base_fg",
+        srcs = [
+            "testdata/config",
+            "testdata/hello.txt",
+        ],
+    )
+
+    # Tests to exclude from the case where stripping is done up to filenames
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_all_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//experimental/tests:testdata/config"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_all",
+        target_under_test = ":pfg_exclude_by_label_strip_all_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_all_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_all",
+        target_under_test = ":pfg_exclude_by_filename_strip_all_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Tests to exclude from the case where stripping is done from the package root
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_from_pkg_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//experimental/tests:testdata/config"],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_from_pkg",
+        target_under_test = ":pfg_exclude_by_label_strip_from_pkg_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_from_pkg_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        strip_prefix = make_strip_prefix(from_pkg = "testdata"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_from_pkg",
+        target_under_test = ":pfg_exclude_by_filename_strip_from_pkg_g",
+        expected_dests = ["hello.txt"],
+    )
+
+    # Tests to exclude from the case where stripping is done from the root
+    pkgfilegroup(
+        name = "pfg_exclude_by_label_strip_from_root_g",
+        srcs = ["test_base_fg"],
+        excludes = ["//experimental/tests:testdata/config"],
+        strip_prefix = make_strip_prefix(from_root = "experimental/tests"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_label_strip_from_root",
+        target_under_test = ":pfg_exclude_by_label_strip_from_root_g",
+        expected_dests = ["testdata/hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_exclude_by_filename_strip_from_root_g",
+        srcs = ["test_base_fg"],
+        excludes = ["testdata/config"],
+        strip_prefix = make_strip_prefix(from_root = "experimental/tests"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_exclude_by_filename_strip_from_root",
+        target_under_test = ":pfg_exclude_by_filename_strip_from_root_g",
+        expected_dests = ["testdata/hello.txt"],
+    )
+
+# Tests involving external repositories
+def _test_genpkg_extrepo():
+    # From external repo root, basenames only
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_all_g",
+        srcs = ["@experimental_test_external_repo//pkg:script"],
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_all",
+        target_under_test = ":pfg_extrepo_strip_all_g",
+        expected_dests = ["extproj.sh", "script"],
+    )
+
+    # From external repo root, relative to the "pkg" package
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_from_pkg_g",
+        srcs = ["@experimental_test_external_repo//pkg:script"],
+        strip_prefix = make_strip_prefix(from_pkg = "dir"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_from_pkg",
+        target_under_test = ":pfg_extrepo_strip_from_pkg_g",
+        expected_dests = [
+            "extproj.sh",  # "dir" is stripped
+            "script",  # Nothing to strip
+        ],
+    )
+
+    # From external repo root, relative to the "pkg" directory
+    pkgfilegroup(
+        name = "pfg_extrepo_strip_from_root_g",
+        srcs = ["@experimental_test_external_repo//pkg:script"],
+        strip_prefix = make_strip_prefix(from_root = "pkg"),
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_strip_from_root",
+        target_under_test = ":pfg_extrepo_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh", "script"],
+    )
+
+    native.filegroup(
+        name = "extrepo_test_fg",
+        srcs = ["@experimental_test_external_repo//pkg:dir/extproj.sh"],
+    )
+
+    # Test the case when a have a pkgfilegroup that targets a local filegroup
+    # that has files in an external repo.
+    pkgfilegroup(
+        name = "pfg_extrepo_filegroup_strip_from_pkg_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = make_strip_prefix(from_pkg = ""),
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_filegroup_strip_from_pkg",
+        target_under_test = ":pfg_extrepo_filegroup_strip_from_pkg_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Ditto, except strip from the workspace root instead
+    pkgfilegroup(
+        name = "pfg_extrepo_filegroup_strip_from_root_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = make_strip_prefix(from_root = "pkg"),
+    )
+    genpkg_contents_test(
+        name = "pfg_extrepo_filegroup_strip_from_root",
+        target_under_test = ":pfg_extrepo_filegroup_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Reference a pkgfilegroup in @experimental_test_external_repo
+    genpkg_contents_test(
+        name = "pfg_pkgfilegroup_in_extrepo",
+        target_under_test = "@experimental_test_external_repo//pkg:extproj_script_pfg",
+        expected_dests = ["usr/bin/dir/extproj.sh"],
+    )
+
+def _test_genpkg_rename():
+    # NOTE: unless rules contain "macro", they are not using the macro
+    # "pfg_rename_single".  This is perhaps old (perhaps bad) naming convention.
+
+    pkgfilegroup(
+        name = "pfg_rename_single_g",
+        srcs = [
+            # Should come out relative to prefix and renames
+            "testdata/hello.txt",
+            # Should come out relative to prefix only
+            "testdata/loremipsum.txt",
+        ],
+        prefix = "usr",
+        renames = {
+            "testdata/hello.txt": "share/goodbye.txt",
+        },
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_rename_single",
+        target_under_test = ":pfg_rename_single_g",
+        expected_dests = [
+            "usr/share/goodbye.txt",
+            "usr/loremipsum.txt",
+        ],
+    )
+
+    pkgfilegroup(
+        name = "pfg_rename_multiple_g",
+        srcs = [
+            "testdata/hello.txt",
+            "testdata/loremipsum.txt",
+        ],
+        prefix = "usr",
+        renames = {
+            "testdata/hello.txt": "share/goodbye.txt",
+            "testdata/loremipsum.txt": "doc/dolorsitamet.txt",
+        },
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_rename_multiple",
+        target_under_test = ":pfg_rename_multiple_g",
+        expected_dests = [
+            "usr/share/goodbye.txt",
+            "usr/doc/dolorsitamet.txt",
+        ],
+    )
+
+    # Used in the following tests
+    #
+    # Note that since the pkgfilegroup rule is never actually used in anything
+    # other than this test, nonexistent_script can be included with no ill
+    # effects. :P
+    native.sh_binary(
+        name = "test_script_rename",
+        srcs = ["testdata/nonexistent_script.sh"],
+        tags = ["manual"],
+    )
+
+    # test_script_rename produces multiple outputs.  Thus, this test should
+    # fail, as pkgfilegroup can't figure out what should actually be mapped to
+    # the output destination.
+    pkgfilegroup(
+        name = "pfg_rename_rule_with_multiple_outputs_g",
+        srcs = ["test_script_rename"],
+        renames = {
+            ":test_script_rename": "still_nonexistent_script",
+        },
+        tags = ["manual"],
+    )
+    generic_neg_test(
+        name = "pfg_rename_rule_with_multiple_outputs",
+        target_under_test = ":pfg_rename_rule_with_multiple_outputs_g",
+    )
+
+    # Fail because we tried to install a file that wasn't mentioned in the deps
+    # list
+    pkgfilegroup(
+        name = "pfg_rename_single_missing_value_g",
+        srcs = ["testdata/hello.txt"],
+        prefix = "usr",
+        renames = {
+            "nonexistent_script": "nonexistent_output_location",
+        },
+        tags = ["manual"],
+    )
+    generic_neg_test(
+        name = "pfg_rename_single_missing_value",
+        target_under_test = ":pfg_rename_single_missing_value_g",
+    )
+
+    # Ditto, except for exclusions
+    pkgfilegroup(
+        name = "pfg_rename_single_excluded_value_g",
+        srcs = [
+            "testdata/hello.txt",
+            "testdata/loremipsum.txt",
+        ],
+        prefix = "usr",
+        excludes = [
+            "testdata/hello.txt",
+        ],
+        renames = {
+            "testdata/hello.txt": "share/goodbye.txt",
+        },
+        tags = ["manual"],
+    )
+    generic_neg_test(
+        name = "pfg_rename_single_excluded_value",
+        target_under_test = ":pfg_rename_single_excluded_value_g",
+    )
+
+    # Test the macro
+    pkg_rename_single(
+        name = "pfg_rename_single_macro_g",
+        src = "testdata/hello.txt",
+        dest = "share/goodbye.txt",
+        prefix = "usr",
+        tags = ["manual"],
+    )
+    genpkg_contents_test(
+        name = "pfg_rename_single_macro",
+        target_under_test = ":pfg_rename_single_macro_g",
+        expected_dests = ["usr/share/goodbye.txt"],
+    )
+
+def _test_genpkg_section():
+    pkgfilegroup(
+        name = "pfg_good_section",
+        srcs = ["testdata/hello.txt"],
+        section = "doc",
+        tags = ["manual"],
+    )
+
+    genpkg_contents_test(
+        name = "pfg_doc_section_test",
+        target_under_test = ":pfg_good_section",
+        expected_dests = ["hello.txt"],
+    )
+
+    pkgfilegroup(
+        name = "pfg_bad_section",
+        srcs = ["testdata/hello.txt"],
+        section = "bad_section",
+        tags = ["manual"],
+    )
+
+    generic_bad_section_test(
+        name = "pfg_bad_section_test",
+        target_under_test = ":pfg_bad_section",
+    )
+
+##########
+# Test pkg_mkdirs
+##########
+
+def _pkg_mkdirs_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dirs = sets.make(ctx.attr.expected_dirs)
+    actual_dirs = sets.make(target_under_test[PackageDirInfo].dirs)
+
+    asserts.new_set_equals(env, expected_dirs, actual_dirs, "pkg_mkdirs dirs do not match expectations")
+
+    # Simple equality checks for the others
+    asserts.equals(
+        env,
+        ctx.attr.expected_attrs,
+        target_under_test[PackageDirInfo].attrs,
+        "pkg_mkdir attrs do not match expectations",
+    )
+    asserts.equals(
+        env,
+        ctx.attr.expected_section,
+        target_under_test[PackageDirInfo].section,
+        "pkg_mkdir section do not match expectations",
+    )
+
+    return analysistest.end(env)
+
+pkg_mkdirs_contents_test = analysistest.make(
+    _pkg_mkdirs_contents_test_impl,
+    attrs = {
+        #"expected_srcs" : attr.label_list(),
+        "expected_dirs": attr.string_list(
+            mandatory = True,
+        ),
+        "expected_attrs": attr.string_list_dict(),
+        "expected_section": attr.string(),
+    },
+)
+
+def _test_genpkg_mkdirs():
+    # Reasonable base case
+    pkg_mkdirs(
+        name = "pfg_pkg_mkdirs_base_g",
+        dirs = ["foo/bar", "baz"],
+        attrs = {"unix": ["0711", "root", "sudo"]},
+        tags = ["manual"],
+    )
+    pkg_mkdirs_contents_test(
+        name = "pfg_pkg_mkdirs_base",
+        target_under_test = "pfg_pkg_mkdirs_base_g",
+        expected_dirs = ["foo/bar", "baz"],
+        expected_attrs = {"unix": ["0711", "root", "sudo"]},
+        expected_section = "dir",
+    )
+
+    # "docdir" is a valid attribute name
+    pkg_mkdirs(
+        name = "pfg_pkg_mkdirs_docdir_g",
+        dirs = ["foo/bar", "baz"],
+        attrs = {"unix": ["0555", "root", "sudo"]},
+        section = "docdir",
+        tags = ["manual"],
+    )
+    pkg_mkdirs_contents_test(
+        name = "pfg_pkg_mkdirs_docdir",
+        target_under_test = "pfg_pkg_mkdirs_docdir_g",
+        expected_dirs = ["foo/bar", "baz"],
+        expected_attrs = {"unix": ["0555", "root", "sudo"]},
+        expected_section = "docdir",
+    )
+
+    pkg_mkdirs(
+        name = "pfg_pkg_mkdirs_bad_attrs_g",
+        dirs = ["foo/bar", "baz"],
+        attrs = {"not_unix": ["derp"]},
+        tags = ["manual"],
+    )
+    generic_neg_test(
+        name = "pfg_pkg_mkdirs_bad_attrs",
+        target_under_test = ":pfg_pkg_mkdirs_bad_attrs_g",
+    )
+
+    pkg_mkdirs(
+        name = "pfg_pkg_mkdirs_bad_section_g",
+        dirs = ["foo/bar", "baz"],
+        section = "config",
+        tags = ["manual"],
+    )
+    generic_neg_test(
+        name = "pfg_pkg_mkdirs_bad_section",
+        target_under_test = ":pfg_pkg_mkdirs_bad_section_g",
+    )
+
+##########
+# Test make_strip_prefix()
+##########
+
+def _strip_prefix_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, ".", make_strip_prefix(files_only = True))
+    asserts.equals(env, "path", make_strip_prefix(from_pkg = "path"))
+    asserts.equals(env, "path", make_strip_prefix(from_pkg = "/path"))
+    asserts.equals(env, "/path", make_strip_prefix(from_root = "path"))
+    asserts.equals(env, "/path", make_strip_prefix(from_root = "/path"))
+    return unittest.end(env)
+
+strip_prefix_test = unittest.make(_strip_prefix_test_impl)
+
+def genpkg_analysis_tests():
+    """Declare genpkg.bzl analysis tests"""
+    _test_genpkg_contents()
+    _test_genpkg_exclusions()
+    _test_genpkg_extrepo()
+    _test_genpkg_rename()
+    _test_genpkg_section()
+    _test_genpkg_mkdirs()
+
+    native.test_suite(
+        name = "genpkg_analysis_tests",
+        # We should find a way to get rid of this test list; it would be nice if
+        # it could be derived from something else...
+        tests = [
+            # buildifier: don't sort
+            # Simple tests
+            ":pfg_no_strip_prefix",
+            ":pfg_files_only",
+            ":pfg_strip_testdata_from_pkg",
+            ":pfg_strip_prefix_from_root",
+            # Tests involving excluded files
+            ":pfg_exclude_by_label_strip_all",
+            ":pfg_exclude_by_filename_strip_all",
+            ":pfg_exclude_by_label_strip_from_pkg",
+            ":pfg_exclude_by_filename_strip_from_pkg",
+            ":pfg_exclude_by_label_strip_from_root",
+            ":pfg_exclude_by_filename_strip_from_root",
+            # Tests involving external repositories
+            ":pfg_extrepo_strip_all",
+            ":pfg_extrepo_strip_from_pkg",
+            ":pfg_extrepo_strip_from_root",
+            ":pfg_extrepo_filegroup_strip_from_pkg",
+            ":pfg_extrepo_filegroup_strip_from_root",
+            ":pfg_pkgfilegroup_in_extrepo",
+            # This one fits into the same category, but can't be aliased, apparently.
+            #
+            # The main purpose behind it is to verify cases wherein we build a
+            # file, but then have it consumed by some remote package.
+            "@experimental_test_external_repo//pkg:pfg_local_file_in_extrepo",
+            # Tests involving file renaming
+            ":pfg_rename_single",
+            ":pfg_rename_multiple",
+            ":pfg_rename_rule_with_multiple_outputs",
+            ":pfg_rename_single_missing_value",
+            ":pfg_rename_single_excluded_value",
+            ":pfg_rename_single_macro",
+            # Tests involving the "section" attribute
+            ":pfg_doc_section_test",
+            ":pfg_bad_section_test",
+            # Tests involving pkg_mkdirs
+            ":pfg_pkg_mkdirs_base",
+            ":pfg_pkg_mkdirs_docdir",
+            ":pfg_pkg_mkdirs_bad_attrs",
+            ":pfg_pkg_mkdirs_bad_section",
+        ],
+    )
+
+def genpkg_unit_tests():
+    unittest.suite(
+        "genpkg_unit_tests",
+        strip_prefix_test,
+    )

--- a/pkg/experimental/tests/testdata
+++ b/pkg/experimental/tests/testdata
@@ -1,0 +1,1 @@
+../../tests/testdata

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -377,3 +377,12 @@ test_suite(
     name = "all_windows_tests",
     tests = [":windows_tests"],
 )
+
+# Used within experimental/tests/ for external repo genpkg tests
+filegroup(
+    name = "loremipsum_txt",
+    srcs = [
+        "testdata/loremipsum.txt",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This adds an experimental rule, `pkgfilegroup`, along with associated Providers,
that gives rule developers and users a consistent mechanism for using the output
of bazel targets in packaging rules.

Inspired by #36.

Other capabilities that are provided by this that were not mentioned in #36 are:

- Creation of empty directories (`pkg_mkdirs`)
- Exclusion of files from a `pkgfilegroup` (`excludes`)
- Renames of files in a `pkgfilegroup` (`renames`)