### PR TITLE
Improve handling of sources from external repositories

### DIFF
--- a/pkg/path.bzl
+++ b/pkg/path.bzl
@@ -13,9 +13,26 @@
 # limitations under the License.
 """Helper functions that don't depend on Skylark, so can be unit tested."""
 
+def safe_short_path(file_):
+    """Like `File.short_path` but safe for use with files from external repositories.
+    """
+    # Note: "F" is "File", "FO": is "File.owner".  (Lifted from genpkg.bzl.)
+    # | File type | Repo     | `F.path`                                                 | `F.root.path`                | `F.short_path`          | `FO.workspace_name` | `FO.workspace_root` |
+    # |-----------|----------|----------------------------------------------------------|------------------------------|-------------------------|---------------------|---------------------|
+    # | Source    | Local    | `dirA/fooA`                                              |                              | `dirA/fooA`             |                     |                     |
+    # | Generated | Local    | `bazel-out/k8-fastbuild/bin/dirA/gen.out`                | `bazel-out/k8-fastbuild/bin` | `dirA/gen.out`          |                     |                     |
+    # | Source    | External | `external/repo2/dirA/fooA`                               |                              | `../repo2/dirA/fooA`    | `repo2`             | `external/repo2`    |
+    # | Generated | External | `bazel-out/k8-fastbuild/bin/external/repo2/dirA/gen.out` | `bazel-out/k8-fastbuild/bin` | `../repo2/dirA/gen.out` | `repo2`             | `external/repo2`    |
+
+    # Beginning with `file_.path`, remove optional `F.root.path`.
+    working_path = file_.path
+    if not file_.is_source:
+        working_path = working_path[len(file_.root.path)+1:]
+    return working_path
+
 def _short_path_dirname(path):
     """Returns the directory's name of the short path of an artifact."""
-    sp = path.short_path
+    sp = safe_short_path(path)
     last_pkg = sp.rfind("/")
     if last_pkg == -1:
         # Top-level BUILD file.
@@ -24,15 +41,17 @@ def _short_path_dirname(path):
 
 def dest_path(f, strip_prefix):
     """Returns the short path of f, stripped of strip_prefix."""
+    f_short_path = safe_short_path(f)
+
     if strip_prefix == None:
         # If no strip_prefix was specified, use the package of the
         # given input as the strip_prefix.
         strip_prefix = _short_path_dirname(f)
     if not strip_prefix:
-        return f.short_path
-    if f.short_path.startswith(strip_prefix):
-        return f.short_path[len(strip_prefix):]
-    return f.short_path
+        return f_short_path
+    if f_short_path.startswith(strip_prefix):
+        return f_short_path[len(strip_prefix):]
+    return f_short_path
 
 def compute_data_path(out, data_path):
     """Compute the relative data path prefix from the data_path attribute."""

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -287,6 +287,7 @@ pkg_tar(
     name = "test-tar-strip_prefix-dot",
     srcs = [
         ":etc/nsswitch.conf",
+        "@bazel_tools//tools/python/runfiles",
     ],
     strip_prefix = ".",
 )

--- a/pkg/tests/build_test.sh
+++ b/pkg/tests/build_test.sh
@@ -159,7 +159,13 @@ function test_tar() {
 ./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-etc.tar)"
   check_eq "./
 ./etc/
-./etc/nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-dot.tar)"
+./etc/nsswitch.conf
+./external/
+./external/bazel_tools/
+./external/bazel_tools/tools/
+./external/bazel_tools/tools/python/
+./external/bazel_tools/tools/python/runfiles/
+./external/bazel_tools/tools/python/runfiles/runfiles.py" "$(get_tar_listing test-tar-strip_prefix-dot.tar)"
   check_eq "./
 ./not-etc/
 ./not-etc/mapped-filename.conf" "$(get_tar_listing test-tar-files_dict.tar)"

--- a/pkg/tests/path_test.py
+++ b/pkg/tests/path_test.py
@@ -14,17 +14,48 @@
 """Testing for helper functions."""
 
 import imp
+import os.path
 import unittest
+
+from collections import namedtuple
 
 pkg_bzl = imp.load_source('pkg_bzl', 'path.bzl')
 
+Owner = namedtuple("Owner", ["workspace_name", "workspace_root"])
+Root = namedtuple("Root", ["path"])
 
 class File(object):
   """Mock Skylark File class for testing."""
 
-  def __init__(self, short_path):
-    self.short_path = short_path
+  def __init__(self, short_path, is_generated=False, is_external=False):
+    self.is_source = not is_generated
+    self.root = Root("bazel-out/k8-fastbuild/bin" if is_generated else "")
+    if is_external:
+      self.owner = Owner("repo", "external/repo")
+      self.short_path = "../repo/" + short_path
+    else:
+      self.owner = Owner("", "")
+      self.short_path = short_path
+    self.path = os.path.join(self.root.path, self.owner.workspace_root, short_path)
 
+class SafeShortPathTest(unittest.TestCase):
+  """Testing for safe_short_path."""
+
+  def testSafeShortPath(self):
+    path = pkg_bzl.safe_short_path(File('foo/bar/baz'))
+    self.assertEqual('foo/bar/baz', path)
+
+  def testSafeShortPathGen(self):
+    path = pkg_bzl.safe_short_path(File('foo/bar/baz', is_generated=True))
+    self.assertEqual('foo/bar/baz', path)
+
+  def testSafeShortPathExt(self):
+    path = pkg_bzl.safe_short_path(File('foo/bar/baz', is_external=True))
+    self.assertEqual('external/repo/foo/bar/baz', path)
+
+  def testSafeShortPathGenExt(self):
+    path = pkg_bzl.safe_short_path(File('foo/bar/baz', is_generated=True, is_external=True))
+    self.assertEqual('external/repo/foo/bar/baz', path)
 
 class ShortPathDirnameTest(unittest.TestCase):
   """Testing for _short_path_dirname."""
@@ -33,9 +64,29 @@ class ShortPathDirnameTest(unittest.TestCase):
     path = pkg_bzl._short_path_dirname(File('foo/bar/baz'))
     self.assertEqual('foo/bar', path)
 
+  def testShortPathDirnameGen(self):
+    path = pkg_bzl._short_path_dirname(File('foo/bar/baz', is_generated=True))
+    self.assertEqual('foo/bar', path)
+
+  def testShortPathDirnameExt(self):
+    path = pkg_bzl._short_path_dirname(File('foo/bar/baz', is_external=True))
+    self.assertEqual('external/repo/foo/bar', path)
+
+  def testShortPathDirnameGenExt(self):
+    path = pkg_bzl._short_path_dirname(File('foo/bar/baz', is_generated=True, is_external=True))
+    self.assertEqual('external/repo/foo/bar', path)
+
   def testTopLevel(self):
     path = pkg_bzl._short_path_dirname(File('baz'))
     self.assertEqual('', path)
+
+  def testTopLevelGen(self):
+    path = pkg_bzl._short_path_dirname(File('baz', is_generated=True))
+    self.assertEqual('', path)
+
+  def testTopLevelExt(self):
+    path = pkg_bzl._short_path_dirname(File('baz', is_external=True))
+    self.assertEqual('external/repo', path)
 
 
 class DestPathTest(unittest.TestCase):
@@ -44,6 +95,18 @@ class DestPathTest(unittest.TestCase):
   def testDestPath(self):
     path = pkg_bzl.dest_path(File('foo/bar/baz'), 'foo')
     self.assertEqual('/bar/baz', path)
+
+  def testDestPathGen(self):
+    path = pkg_bzl.dest_path(File('foo/bar/baz', is_generated=True), 'foo')
+    self.assertEqual('/bar/baz', path)
+
+  def testDestPathExt(self):
+    path = pkg_bzl.dest_path(File('foo/bar/baz', is_external=True), 'external/repo/foo')
+    self.assertEqual('/bar/baz', path)
+
+  def testDestPathExtWrong(self):
+    path = pkg_bzl.dest_path(File('foo/bar/baz', is_external=True), 'foo')
+    self.assertEqual('external/repo/foo/bar/baz', path)
 
   def testNoMatch(self):
     path = pkg_bzl.dest_path(File('foo/bar/baz'), 'qux')


### PR DESCRIPTION
Avoid use of [`File.short_path`][1] when mapping filenames, because when
creating archives from files imported from external repositories we'll create
archive members with leading `./../` prefixes.  Instead, we'll stick to stripping
to leading `File.root.path` (if present) from `File.path`, resulting in archive
members like `external/repo/package/file.txt`.

[1]: https://docs.bazel.build/versions/master/skylark/lib/File.html#short_path

Resolves #131.