### PR TITLE
Depend on rules_python

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
 licenses(["notice"])  # Apache 2.0
 
 exports_files(

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -25,6 +25,8 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
     sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
 )
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
 ```
 
 <a name="basic-example"></a>

--- a/pkg/deps.bzl
+++ b/pkg/deps.bzl
@@ -14,6 +14,7 @@
 
 # Workspace dependencies for rules_pkg/pkg
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
@@ -29,6 +30,13 @@ def rules_pkg_dependencies():
         ],
         sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
     )
+    maybe(
+        git_repository,
+        name = "rules_python",
+        remote = "https://github.com/bazelbuild/rules_python.git",
+        commit = "4b84ad270387a7c439ebdccfd530e2339601ef27",  # (2019-08-02 or later)
+    )
+
 
 def rules_pkg_register_toolchains():
     pass

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -5,6 +5,7 @@ package(
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//:version.bzl", "version")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
+load("@rules_python//python:defs.bzl", "py_test")
 
 # Build the artifact to put on the github release page.
 pkg_tar(

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -27,6 +27,7 @@ print_rel_notes(
     outs = ["relnotes.txt"],
     repo = "rules_pkg",
     version = version,
+    deps_method = "rules_pkg_dependencies",
 )
 
 py_test(

--- a/pkg/distro/packaging_test.py
+++ b/pkg/distro/packaging_test.py
@@ -46,7 +46,9 @@ class PackagingTest(unittest.TestCase):
       workspace_content = '\n'.join((
         'workspace(name = "test_rules_pkg_packaging")',
         release_tools.workspace_content(
-            'file://%s' % local_path, self.repo, sha256)
+            'file://%s' % local_path, self.repo, sha256,
+            deps_method='rules_pkg_dependencies'
+        )
       ))
       workspace.write(workspace_content)
       if _VERBOSE:

--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -172,7 +172,7 @@ pkg_rpm = rule(
         # Implicit dependencies.
         "rpmbuild_path": attr.string(),
         "_make_rpm": attr.label(
-            default = Label("@rules_pkg//:make_rpm"),
+            default = Label("//:make_rpm"),
             cfg = "host",
             executable = True,
             allow_files = True,

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])  # Apache 2.0
 
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar", "pkg_zip")
 load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+load("@rules_python//python:defs.bzl", "py_test")
 
 genrule(
     name = "generate_files",


### PR DESCRIPTION
Depend on rules_python
This is now required as per https://github.com/bazelbuild/bazel/issues/9006