### PR TITLE
Ensure the experimental/ tree lands in the output release archive

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -10,7 +10,14 @@ exports_files(
 
 filegroup(
     name = "standard_package",
-    srcs = glob(["BUILD", "*.bzl", "*.py", "*.md"]),
+    srcs = glob([
+        "*.bzl",
+        "*.py",
+        "*.md",
+    ]) + [
+        "BUILD",
+        "//experimental:standard_package",
+    ],
     visibility = ["@//distro:__pkg__"],
 )
 

--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -32,3 +32,15 @@ py_binary(
         "@rules_pkg//:make_rpm_lib",
     ],
 )
+
+filegroup(
+    name = "standard_package",
+    srcs = glob([
+        "*.bzl",
+        "*.py",
+    ]) + [
+        "BUILD",
+        "template.spec.in",
+    ],
+    visibility = ["@//:__pkg__"],
+)


### PR DESCRIPTION
The `experimental/` tree containing the then `pkgfilegroup` (and now `pkg_filegroup`) rule was missing from the 0.2.5 release archive.
    
This change ensures that the files in the experimental/ tree are included in release packages so users can use the rules within.
    
Testing was done by trying to run the experimental `pkg_rpm` rule on a dummy project importing rules_pkg.
