### PR TITLE
make_deb: fix length computation for extrafiles

### DIFF
--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -149,9 +149,10 @@ def CreateDebControl(extrafiles=None, **kwargs):
       if extrafiles:
         for name, (data, mode) in extrafiles.items():
           tarinfo = tarfile.TarInfo('./' + name)
-          tarinfo.size = len(data)
+          data_encoded = data.encode('utf-8')
+          tarinfo.size = len(data_encoded)
           tarinfo.mode = mode
-          f.addfile(tarinfo, fileobj=BytesIO(data.encode('utf-8')))
+          f.addfile(tarinfo, fileobj=BytesIO(data_encoded))
   control = tar.getvalue()
   tar.close()
   return control

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -167,6 +167,12 @@ py_test(
     ],
 )
 
+genrules(
+    name = "test-deb-preinst",
+    outs = ["test-deb.preinst",
+    cmd = "echo -n \"#!/usr/bin/env bash\n# tete ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\necho fnord\" > \"$@\"",
+)
+
 pkg_deb(
     name = "test-deb",
     built_using = "some_test_data (0.1.2)",
@@ -188,6 +194,7 @@ pkg_deb(
     breaks = ["oldbrokenpkg"],
     replaces = ["oldpkg"],
     templates = ":testdata/templates",
+    preinst = ":test-deb-preinst",
     urgency = "low",
     version = "test",
 )

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -167,9 +167,9 @@ py_test(
     ],
 )
 
-genrules(
+genrule(
     name = "test-deb-preinst",
-    outs = ["test-deb.preinst",
+    outs = ["test-deb.preinst"],
     cmd = "echo -n \"#!/usr/bin/env bash\n# tete ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\necho fnord\" > \"$@\"",
 )
 

--- a/pkg/tests/build_test.sh
+++ b/pkg/tests/build_test.sh
@@ -228,6 +228,7 @@ function check_deb() {
   local ctrl_listing="./conffiles
 ./config
 ./control
+./preinst
 ./templates"
   # TODO: The config and templates come out with a+x permissions. Because I am
   # currently seeing the same behavior in the Bazel sources, I am going to look

--- a/pkg/tests/build_test.sh
+++ b/pkg/tests/build_test.sh
@@ -216,6 +216,11 @@ function check_deb() {
   get_deb_ctl_file ${package} config >$TEST_log
   expect_log "# test config file"
 
+  get_deb_ctl_file ${package} preinst >$TEST_log
+  expect_log "#!/usr/bin/env bash"
+  expect_log "# tete ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é"
+  expect_log "echo fnord"
+
   if ! dpkg_deb_supports_ctrl_tarfile ${package} ; then
     echo "Unable to test deb control files listing, too old dpkg-deb!" >&2
     return 0


### PR DESCRIPTION
When adding the extrafiles (e.g. preinst, postinst etc.) with non-ascii characters in the content to the tar, a potentially faulty length was used. This would result in truncated files.

~~This seems to only occur when using files that are the result of build rules, i.e. the problem does not seem to occur when using a plain file as input for e.g. postinst.~~ Correction: apparently this difference does no longer exist, my completely un-educated guess is that this difference existed only in python2.

This seems to have been be an oversight in https://github.com/bazelbuild/bazel/commit/70e3c339bea02f6e9273b13de11d078ca6c2752f where the same problem was fixed for the main control file.
This change makes the handling of the length of the extrafiles identical to the main control file.