### PR TITLE
fix broken test after https://github.com/bazelbuild/rules_pkg/pull/144

### DIFF
--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -229,6 +229,7 @@ pkg_deb(
     breaks = ["oldbrokenpkg"],
     replaces = ["oldpkg"],
     templates = ":testdata/templates",
+    preinst = ":test-deb-preinst",
     urgency = "low",
     version = "test_py2",
 )


### PR DESCRIPTION
#144 was missing preinst for the the python2 test.