### PR TITLE
Preserve mtimes from input tar files in TarFileWriter output tars

### DIFF
--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -378,7 +378,6 @@ class TarFileWriter(object):
       intar = tarfile.open(name=tar, mode=inmode)
     for tarinfo in intar:
       if name_filter is None or name_filter(tarinfo.name):
-        tarinfo.mtime = self.default_mtime
         if rootuid is not None and tarinfo.uid == rootuid:
           tarinfo.uid = 0
           tarinfo.uname = 'root'

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -241,7 +241,8 @@ class TarFileWriterTest(unittest.TestCase):
 
   def testPreserveTarMtimesTrueByDefault(self):
     with archive.TarFileWriter(self.tempfile) as f:
-      input_tar_path = os.path.join(testenv.TESTDATA_PATH, "tar_test.tar")
+      input_tar_path = self.data_files.Rlocation(
+          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
       f.add_tar(input_tar_path)
       input_tar = tarfile.open(input_tar_path, "r")
       for file_name in f.members:
@@ -251,7 +252,9 @@ class TarFileWriterTest(unittest.TestCase):
 
   def testPreserveTarMtimesFalse(self):
     with archive.TarFileWriter(self.tempfile, preserve_tar_mtimes=False) as f:
-      f.add_tar(os.path.join(testenv.TESTDATA_PATH, "tar_test.tar"))
+      input_tar_path = self.data_files.Rlocation(
+          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+      f.add_tar(input_tar_path)
       for output_file in f.tar:
         self.assertEqual(output_file.mtime, 0)
 

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -227,6 +227,20 @@ class TarFileWriterTest(unittest.TestCase):
       f.add_tar(datafile, name_filter=lambda n: n != "./b", root="/foo")
     self.assertTarFileContent(self.tempfile, content)
 
+  def testPreserveInputTarMtimes(self):
+    input_tar_path = os.path.join(testenv.TESTDATA_PATH, "tar_test.tar")
+    with archive.TarFileWriter(self.tempfile) as f:
+      f.add_tar(input_tar_path)
+
+    with tarfile.open(input_tar_path, "r:") as input_tar:
+      input_mtimes = {}
+      for input_file in input_tar:
+        input_mtimes[input_file.name] = input_file.mtime
+
+    with tarfile.open(self.tempfile, "r:") as output_tar:
+      for output_file in output_tar:
+        self.assertEqual(input_mtimes[output_file.name], output_file.mtime)
+
   def testAddingDirectoriesForFile(self):
     with archive.TarFileWriter(self.tempfile) as f:
       f.add_file("d/f")


### PR DESCRIPTION
This tool should not need to override mtimes for files contained in tar files that are added to the output of TarFileWriter, since these files are either constructed by other parts of the build process (in which case we can rely on the caching and reproducibility of those steps) or they are constructed outside of the bazel system, in which case we shouldn't need to alter them.

See discussion on [this issue](https://github.com/bazelbuild/rules_pkg/issues/149) for more information.

Fixes #149 