### PR TITLE
Remove attribute python_version from build_tar target

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -81,7 +81,7 @@ py_binary(
 py_binary(
     name = "make_rpm",
     srcs = ["make_rpm.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -24,7 +24,7 @@ exports_files(
 py_binary(
     name = "make_rpm",
     srcs = ["make_rpm.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -121,7 +121,7 @@ py_test(
         "archive_test.py",
     ],
     data = [":archive_testdata"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     tags = [
         # archive.py requires xzcat, which is not available by default on Mac
@@ -145,7 +145,7 @@ py_test(
 py_test(
     name = "make_rpm_test",
     srcs = ["make_rpm_test.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     # rpmbuild is not available in windows
     tags = [
@@ -160,7 +160,7 @@ py_test(
 py_test(
     name = "helpers_test",
     srcs = ["helpers_test.py"],
-    python_version = "PY2",
+    python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [
         "@rules_pkg//:archive",

--- a/pkg/tests/helpers_test.py
+++ b/pkg/tests/helpers_test.py
@@ -26,7 +26,7 @@ class GetFlagValueTestCase(unittest.TestCase):
 
     def testNonStripped_fromFile(self):
         with tempfile.NamedTemporaryFile() as f:
-            f.write('value ')
+            f.write(b'value ')
             f.flush()
             self.assertEqual(helpers.GetFlagValue(
                 '@{}'.format(f.name),
@@ -34,7 +34,7 @@ class GetFlagValueTestCase(unittest.TestCase):
 
     def testStripped_fromFile(self):
         with tempfile.NamedTemporaryFile() as f:
-            f.write('value ')
+            f.write(b'value ')
             f.flush()
             self.assertEqual(helpers.GetFlagValue(
                 '@{}'.format(f.name),


### PR DESCRIPTION
So build_tar.py isn't forced to run under Python 2.

See related issue: https://github.com/bazelbuild/rules_pkg/issues/157