### PR TITLE
Change `gen_rpm` back to `pkg_rpm` in rpm.bzl

### DIFF
--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -20,7 +20,7 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-# Used by gen_rpm in genrpm.bzl.
+# Used by pkg_rpm in rpm.bzl.
 py_binary(
     name = "make_rpm",
     srcs = ["make_rpm.py"],

--- a/pkg/experimental/pkg_filegroup.bzl
+++ b/pkg/experimental/pkg_filegroup.bzl
@@ -22,7 +22,7 @@ the following:
 - `pkg_mkdirs` describes directory structures
 
 Rules that actually make use of the outputs of the above rules are not specified
-here.  See `genrpm.bzl` for an example that builds out RPM packages.
+here.  See `rpm.bzl` for an example that builds out RPM packages.
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
@@ -333,7 +333,7 @@ pkg_filegroup = rule(
     This rule provides a specification for the locations and attributes of
     targets when they are packaged. No outputs are created other than Providers
     that are intended to be consumed by other packaging rules, such as
-    `gen_rpm`.
+    `pkg_rpm`.
 
     Instead of providing the actual rules that generate your desired outputs to
     packaging rules, you instead pass in the associated `pkg_filegroup`.

--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -388,7 +388,7 @@ def _pkg_rpm_outputs(name, rpm_name, version, release):
     return outputs
 
 # Define the rule.
-gen_rpm = rule(
+pkg_rpm = rule(
     doc = """Creates an RPM format package via `pkg_filegroup` and friends.
 
     The uses the outputs of the rules in `pkg_filegroup.bzl` to construct arbitrary RPM


### PR DESCRIPTION
The previous change (2536b7b) reverted some of the naming changes in rpm.bzl and
elsewhere in the codebase.  This was due to a cherry-pick that looks otherwise
correct.

This change adjusts `gen_rpm` back to `pkg_rpm`, and `genrpm` to `rpm` in
various files in experimental/.

The experimental/ tree was checked for the presence of `gen_rpm` and `genrpm`
with `grep(1)`; nothing was found.