### PR TITLE
Make archive build rule publicly visible

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -22,6 +22,9 @@ py_library(
         "helpers.py"
     ],
     srcs_version = "PY2AND3",
+    # This build rule is not intended for public use, but needs to
+    # be publicly visible because existing projects rely on it.
+    # Use at your own risk.
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -22,16 +22,7 @@ py_library(
         "helpers.py"
     ],
     srcs_version = "PY2AND3",
-    # This points to a fundemental bazel workspace deficiency. What we need is a
-    # way to specify "the workspace that this BUILD or .bzl file comes from".
-    # I do not want to say '@rules_pkg'. That forces my name on everyone who uses
-    # me. '@' seems to be the outer workspace.
-    visibility = [
-        "@//experimental:__pkg__",
-        "@rules_pkg//experimental:__pkg__",
-        "@//tests:__pkg__",
-        "@rules_pkg//tests:__pkg__"
-    ],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(


### PR DESCRIPTION
The `rules_docker` repository relies on `archive`, which it current builds using the deprecated files in the main Bazel repository (which is already publicly visible). In order to update `rules_docker` to use `rules_pkg` instead, we need to make `archive` visible to it.