### PR TITLE
Add support to generate stardoc.

### DIFF
--- a/pkg/WORKSPACE
+++ b/pkg/WORKSPACE
@@ -14,6 +14,7 @@
 
 workspace(name = "rules_pkg")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
@@ -21,6 +22,17 @@ rules_pkg_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+http_archive(
+    name = "bazel_stardoc",
+    url = "https://github.com/bazelbuild/stardoc/archive/0.4.0.zip",
+    sha256 = "36b8d6c2260068b9ff82faea2f7add164bf3436eac9ba3ec14809f335346d66a",
+    strip_prefix = "stardoc-0.4.0",
+)
+
+load("@bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
 
 local_repository(
     name = "experimental_test_external_repo",

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -2,9 +2,11 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//:version.bzl", "version")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
+load("@rules_pkg//:version.bzl", "version")
 load("@rules_python//python:defs.bzl", "py_test")
 
 # Build the artifact to put on the github release page.
@@ -26,9 +28,9 @@ pkg_tar(
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
+    deps_method = "rules_pkg_dependencies",
     repo = "rules_pkg",
     version = version,
-    deps_method = "rules_pkg_dependencies",
 )
 
 py_test(
@@ -58,4 +60,55 @@ genrule(
     name = "version_as_py",
     outs = ["release_version.py"],
     cmd = "echo RELEASE_VERSION = \\'%s\\' >$@" % version,
+)
+
+bzl_library(
+    name = "rules_pkg_lib",
+    srcs = [
+        "@//:path.bzl",
+        "@//:pkg.bzl",
+        "@//:rpm.bzl",
+        "@//:version.bzl",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+stardoc(
+    name = "docs_deb",
+    out = "pkg_deb.md",
+    input = "@//:pkg.bzl",
+    symbol_names = [
+        "pkg_deb",
+        "pkg_deb_impl",
+    ],
+    deps = [":rules_pkg_lib"],
+)
+
+stardoc(
+    name = "docs_tar",
+    out = "pkg_tar.md",
+    input = "@//:pkg.bzl",
+    symbol_names = [
+        "pkg_tar",
+        "pkg_tar_impl",
+    ],
+    deps = [":rules_pkg_lib"],
+)
+
+stardoc(
+    name = "docs_zip",
+    out = "pkg_zip.md",
+    input = "@//:pkg.bzl",
+    symbol_names = [
+        "pkg_zip",
+        "pkg_zip_impl",
+    ],
+    deps = [":rules_pkg_lib"],
+)
+
+stardoc(
+    name = "docs_rpm",
+    out = "pkg_rpm.md",
+    input = "@//:rpm.bzl",
+    deps = [":rules_pkg_lib"],
 )

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -300,6 +300,8 @@ pkg_tar_impl = rule(
 )
 
 def pkg_tar(**kwargs):
+    """Creates a .tar file. See pkg_tar_impl."""
+
     # Compatibility with older versions of pkg_tar that define files as
     # a flat list of labels.
     if "srcs" not in kwargs:
@@ -436,6 +438,7 @@ pkg_zip_impl = rule(
 )
 
 def pkg_zip(name, **kwargs):
+    """Creates a .zip file. See pkg_zip_impl."""
     extension = kwargs.get("extension") or "zip"
 
     pkg_zip_impl(


### PR DESCRIPTION
This is done in a manner so there is no new runtime dependency on bazel-skylib. The bzl_library needed as input to stardoc is only created within the distro directory, which is not part of the released package.

Only a trivial cleanup of the docs within the rules was done in this change.