### PR TITLE
Add starter CI setup

### DIFF
--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,13 +1,13 @@
+common: &common
+  name: distribution
+  working_directory: pkg
+  build_targets:
+  - "distro:*"
+
 tasks:
   ubuntu1604:
-    name: distribution
-    working_directory: pkg
     platform: ubuntu1604
-    build_targets:
-    - "distro:*"
+    <<: *common
   ubuntu1804:
-    name: distribution
-    working_directory: pkg
     platform: ubuntu1804
-    build_targets:
-    - "distro:*"
+    <<: *common

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,0 +1,13 @@
+tasks:
+  ubuntu1604:
+    name: distribution
+    working_directory: pkg
+    platform: ubuntu1604
+    build_targets:
+    - "distro:*"
+  ubuntu1804:
+    name: distribution
+    working_directory: pkg
+    platform: ubuntu1804
+    build_targets:
+    - "distro:*"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,3 @@
+imports:
+- tests.yml
+- integration.yml

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,0 +1,13 @@
+tasks:
+  ubuntu1604:
+    name: tests
+    working_directory: pkg
+    platform: ubuntu1604
+    test_targets:
+    - "..."
+  ubuntu1804:
+    name: tests
+    working_directory: pkg
+    platform: ubuntu1804
+    test_targets:
+    - "..."

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,11 +1,12 @@
+common: &common
+  working_directory: pkg
+  test_targets:
+  - "..."
+  
 tasks:
   ubuntu1604:
-    working_directory: pkg
     platform: ubuntu1604
-    test_targets:
-    - "..."
+    <<: *common
   ubuntu1804:
-    working_directory: pkg
     platform: ubuntu1804
-    test_targets:
-    - "..."
+    <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -2,7 +2,7 @@ common: &common
   working_directory: pkg
   test_targets:
   - "..."
-  
+
 tasks:
   ubuntu1604:
     platform: ubuntu1604

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,12 +1,10 @@
 tasks:
   ubuntu1604:
-    name: tests
     working_directory: pkg
     platform: ubuntu1604
     test_targets:
     - "..."
   ubuntu1804:
-    name: tests
     working_directory: pkg
     platform: ubuntu1804
     test_targets:


### PR DESCRIPTION
Notes:
WORKSPACE is not at the top level of the source, so all tests set `working_directory` to pkg. I
 wonder if there is a way to factor that up.
I want to start with Linux only now, because I have doubts about windows and macos portability. I will add those later.