### PR TITLE
fix CI setup

### DIFF
--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,13 +1,13 @@
+common: &common
+  name: distribution
+  working_directory: pkg
+  build_targets:
+  - "distro:*"
+
 tasks:
   ubuntu1604:
-    name: distribution
-    working_directory: pkg
     platform: ubuntu1604
-    build_targets:
-    - "distro:*"
+    <<: *common
   ubuntu1804:
-    name: distribution
-    working_directory: pkg
     platform: ubuntu1804
-    build_targets:
-    - "distro:*"
+    <<: *common

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,6 +1,6 @@
 common: &common
   name: distribution
-  working_directory: pkg
+  working_directory: /workdir/pkg
   build_targets:
   - "distro:*"
 

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,0 +1,13 @@
+tasks:
+  ubuntu1604:
+    name: distribution
+    working_directory: pkg
+    platform: ubuntu1604
+    build_targets:
+    - "distro:*"
+  ubuntu1804:
+    name: distribution
+    working_directory: pkg
+    platform: ubuntu1804
+    build_targets:
+    - "distro:*"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,3 @@
+imports:
+- tests.yml
+- integration.yml

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,0 +1,13 @@
+tasks:
+  ubuntu1604:
+    name: tests
+    working_directory: pkg
+    platform: ubuntu1604
+    test_targets:
+    - "..."
+  ubuntu1804:
+    name: tests
+    working_directory: pkg
+    platform: ubuntu1804
+    test_targets:
+    - "..."

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,11 +1,12 @@
+common: &common
+  working_directory: pkg
+  test_targets:
+  - "..."
+  
 tasks:
   ubuntu1604:
-    working_directory: pkg
     platform: ubuntu1604
-    test_targets:
-    - "..."
+    <<: *common
   ubuntu1804:
-    working_directory: pkg
     platform: ubuntu1804
-    test_targets:
-    - "..."
+    <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -2,7 +2,7 @@ common: &common
   working_directory: pkg
   test_targets:
   - "..."
-  
+
 tasks:
   ubuntu1604:
     platform: ubuntu1604

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,5 +1,5 @@
 common: &common
-  working_directory: pkg
+  working_directory: /workdir/pkg
   test_targets:
   - "..."
 

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,12 +1,10 @@
 tasks:
   ubuntu1604:
-    name: tests
     working_directory: pkg
     platform: ubuntu1604
     test_targets:
     - "..."
   ubuntu1804:
-    name: tests
     working_directory: pkg
     platform: ubuntu1804
     test_targets:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ channels).
 
 Use rules-pkg-discuss@googlegroups.com for discussion.
 
-Travis CI :---:
-[![Build Status](https://travis-ci.org/bazelbuild/rules_pkg.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_pkg)
+CI:
+[![Build status](https://badge.buildkite.com/e12f23186aa579f1e20fcb612a22cd799239c3134bc38e1aff.svg)](https://buildkite.com/bazel/rules-pkg)
 
 ## Basic rules
 


### PR DESCRIPTION
Set working_directory with an absolute path (/workdir/pkg)
The default working directory is (unintuitively) `/workdir/<name of the yml file>` instead of /workdir. So, just using `pkg` was pointing to a non-existent directory.