### PR TITLE
add macos to CI, fix  most tests, skip some others

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -11,7 +11,7 @@ tasks:
     platform: ubuntu1804
     <<: *common
   macos:
+    <<: *common
     test_targets:
-    - "..."
     - "-//tests:build_test_deb"
     - "-//tests:make_rpm_test"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -10,3 +10,8 @@ tasks:
   ubuntu1804:
     platform: ubuntu1804
     <<: *common
+  macos
+    test_targets:
+    - "..."
+    - "-//tests:build_test_deb"
+    - "-//tests:make_rpm_test"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -10,7 +10,7 @@ tasks:
   ubuntu1804:
     platform: ubuntu1804
     <<: *common
-  macos
+  macos:
     test_targets:
     - "..."
     - "-//tests:build_test_deb"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,5 +1,4 @@
 common: &common
-  working_directory: /workdir/pkg
   test_targets:
   - "..."
 
@@ -11,7 +10,8 @@ tasks:
     platform: ubuntu1804
     <<: *common
   macos:
-    <<: *common
+    working_directory: ../pkg
     test_targets:
+    - "..."
     - "-//tests:build_test_deb"
     - "-//tests:make_rpm_test"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,4 +1,5 @@
 common: &common
+  working_directory: /workdir/pkg
   test_targets:
   - "..."
 

--- a/pkg/distro/packaging_test.py
+++ b/pkg/distro/packaging_test.py
@@ -73,8 +73,9 @@ class PackagingTest(unittest.TestCase):
       print('=== Build Result ===')
       print(build_result)
 
+    # TODO(aiuto): Find tar in a disciplined way
     content = subprocess.check_output(
-        ['/bin/tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
+        ['tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
     self.assertEqual(b'./\n./BUILD\n', content)
 
 

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -345,6 +345,7 @@ sh_test(
         "testenv.sh",
         ":test-deb.deb",
         ":test-deb-py2.deb",
+        ":titi_test_all.changes",
     ],
     tags = [
         # dpkg tools are only available on debian

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -336,15 +336,35 @@ pkg_tar(
 )
 
 sh_test(
-    name = "build_test",
+    name = "build_test_deb",
     size = "medium",
     srcs = [
-        "build_test.sh",
+        "build_test_deb.sh",
     ],
     data = [
         "testenv.sh",
         ":test-deb.deb",
         ":test-deb-py2.deb",
+    ],
+    tags = [
+        # dpkg tools are only available on debian
+        "no_macos",
+        "no_windows",
+    ],
+    deps = [
+        "@rules_pkg//third_party/test/shell:bashunit",
+    ],
+)
+
+sh_test(
+    name = "build_test_tar",
+    size = "medium",
+    srcs = [
+        "build_test_tar.sh",
+    ],
+    data = [
+        "testenv.sh",
+        ":archive_testdata",
         ":test-tar-.tar",
         ":test-tar-bz2.tar.bz2",
         ":test-tar-empty_dirs.tar",
@@ -365,7 +385,7 @@ sh_test(
     ],
     tags = [
         # archive.py requires xzcat, which is not available by default on Mac
-        "noci",
+        "no_macos",
         # TODO(laszlocsomor): fix on Windows or describe why it cannot pass.
         "no_windows",
     ],

--- a/pkg/tests/build_test_deb.sh
+++ b/pkg/tests/build_test_deb.sh
@@ -15,45 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Unit tests for pkg_deb and pkg_tar
+# Unit tests for pkg_deb
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source ${DIR}/testenv.sh || { echo "testenv.sh not found!" >&2; exit 1; }
-
-function get_tar_listing() {
-  local input=$1
-  local test_data="${TEST_DATA_DIR}/${input}"
-  # We strip unused prefixes rather than dropping "v" flag for tar, because we
-  # want to preserve symlink information.
-  tar tvf "${test_data}" | sed -e 's/^.*:00 //'
-}
-
-function get_tar_verbose_listing() {
-  local input=$1
-  local test_data="${TEST_DATA_DIR}/${input}"
-  TZ="UTC" tar tvf "${test_data}"
-}
-
-function get_tar_owner() {
-  local input=$1
-  local file=$2
-  local test_data="${TEST_DATA_DIR}/${input}"
-  tar tvf "${test_data}" | grep "00 $file\$" | cut -d " " -f 2
-}
-
-function get_numeric_tar_owner() {
-  local input=$1
-  local file=$2
-  local test_data="${TEST_DATA_DIR}/${input}"
-  tar --numeric-owner -tvf "${test_data}" | grep "00 $file\$" | cut -d " " -f 2
-}
-
-function get_tar_permission() {
-  local input=$1
-  local file=$2
-  local test_data="${TEST_DATA_DIR}/${input}"
-  tar tvf "${test_data}" | fgrep "00 $file" | cut -d " " -f 1
-}
 
 function get_deb_listing() {
   local input=$1
@@ -133,54 +98,6 @@ function assert_content() {
     check_eq "titi/tata" "$(get_tar_owner $1 ./usr/)"
     check_eq "titi/tata" "$(get_tar_owner $1 ./usr/titi)"
   fi
-}
-
-function test_tar() {
-  local listing="./
-./etc/
-./etc/nsswitch.conf
-./usr/
-./usr/titi
-./usr/bin/
-./usr/bin/java -> /path/to/bin/java"
-  for i in "" ".gz" ".bz2" ".xz"; do
-    assert_content "test-tar-${i:1}.tar$i"
-    # Test merging tar files
-    # We pass a second argument to not test for user and group
-    # names because tar merging ask for numeric owners.
-    assert_content "test-tar-inclusion-${i:1}.tar" "true"
-  done;
-
-  check_eq "./
-./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-empty.tar)"
-  check_eq "./
-./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-none.tar)"
-  check_eq "./
-./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-etc.tar)"
-  check_eq "./
-./etc/
-./etc/nsswitch.conf
-./external/
-./external/bazel_tools/
-./external/bazel_tools/tools/
-./external/bazel_tools/tools/python/
-./external/bazel_tools/tools/python/runfiles/
-./external/bazel_tools/tools/python/runfiles/runfiles.py" "$(get_tar_listing test-tar-strip_prefix-dot.tar)"
-  check_eq "./
-./not-etc/
-./not-etc/mapped-filename.conf" "$(get_tar_listing test-tar-files_dict.tar)"
-  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
--rwxrwxrwx 0/0               0 2000-01-01 00:00 ./a
--rwxrwxrwx 0/0               0 2000-01-01 00:00 ./b" \
-      "$(get_tar_verbose_listing test-tar-empty_files.tar)"
-  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
-drwxrwxrwx 0/0               0 2000-01-01 00:00 ./tmp/
-drwxrwxrwx 0/0               0 2000-01-01 00:00 ./pmt/" \
-      "$(get_tar_verbose_listing test-tar-empty_dirs.tar)"
-  check_eq \
-    "drwxr-xr-x 0/0               0 1999-12-31 23:59 ./
--r-xr-xr-x 0/0               2 1999-12-31 23:59 ./nsswitch.conf" \
-    "$(get_tar_verbose_listing test-tar-mtime.tar)"
 }
 
 function check_deb() {

--- a/pkg/tests/build_test_tar.sh
+++ b/pkg/tests/build_test_tar.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unit tests for pkg_tar
+
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source ${DIR}/testenv.sh || { echo "testenv.sh not found!" >&2; exit 1; }
+
+readonly OS=$(uname)
+
+# Linux and macos report 1999-12-31 19:00 in different ways
+readonly TAR_OUTPUT_FIXERS=$(mktemp)
+trap '/bin/rm $TAR_OUTPUT_FIXERS' 0 1 2 3 15
+(
+  echo 's# Dec 31  1999 # 1999-12-31 19:00 #'
+  echo 's# Jan  1  2000 # 1999-12-31 19:00 #'
+  echo 's#  *0 tata   titi # tata/titi #'
+  echo 's#  *0 titi   tata # titi/tata #'
+  echo 's#  *0 0      0 # 0/0     #'
+  echo 's#  *0 24     42 # 24/42     #'
+  echo 's#  *0 42     24 # 42/24     #'
+) >"$TAR_OUTPUT_FIXERS"
+
+function get_tar_listing() {
+  local input=$1
+  local test_data="${TEST_DATA_DIR}/${input}"
+  # We strip unused prefixes rather than dropping "v" flag for tar, because we
+  # want to preserve symlink information.
+  tar tvf "${test_data}" | sed -f "$TAR_OUTPUT_FIXERS" | sed -e 's/^.*:00 //'
+}
+
+function get_tar_verbose_listing() {
+  local input=$1
+  local test_data="${TEST_DATA_DIR}/${input}"
+  TZ="UTC" tar tvf "${test_data}" | sed -f "$TAR_OUTPUT_FIXERS"
+}
+
+function get_tar_owner() {
+  local input=$1
+  local file=$2
+  local test_data="${TEST_DATA_DIR}/${input}"
+  tar tvf "${test_data}" | sed -f "$TAR_OUTPUT_FIXERS" | grep "00 $file\$" | cut -d " " -f 2
+}
+
+function get_numeric_tar_owner() {
+  local input=$1
+  local file=$2
+  local test_data="${TEST_DATA_DIR}/${input}"
+  tar --numeric-owner -tvf "${test_data}" | sed -f "$TAR_OUTPUT_FIXERS" | grep "00 $file\$" | cut -d " " -f 2
+}
+
+function get_tar_permission() {
+  local input=$1
+  local file=$2
+  local test_data="${TEST_DATA_DIR}/${input}"
+  tar tvf "${test_data}" | sed -f "$TAR_OUTPUT_FIXERS" | fgrep "00 $file" | cut -d " " -f 1
+}
+
+function assert_content() {
+  local listing="./
+./etc/
+./etc/nsswitch.conf
+./usr/
+./usr/titi
+./usr/bin/
+./usr/bin/java -> /path/to/bin/java"
+  check_eq "$listing" "$(get_tar_listing $1)"
+  check_eq "-rwxr-xr-x" "$(get_tar_permission $1 ./usr/titi)"
+  check_eq "-rw-r--r--" "$(get_tar_permission $1 ./etc/nsswitch.conf)"
+  check_eq "24/42" "$(get_numeric_tar_owner $1 ./etc/)"
+  check_eq "24/42" "$(get_numeric_tar_owner $1 ./etc/nsswitch.conf)"
+  check_eq "42/24" "$(get_numeric_tar_owner $1 ./usr/)"
+  check_eq "42/24" "$(get_numeric_tar_owner $1 ./usr/titi)"
+  if [ -z "${2-}" ]; then
+    check_eq "tata/titi" "$(get_tar_owner $1 ./etc/)"
+    check_eq "tata/titi" "$(get_tar_owner $1 ./etc/nsswitch.conf)"
+    check_eq "titi/tata" "$(get_tar_owner $1 ./usr/)"
+    check_eq "titi/tata" "$(get_tar_owner $1 ./usr/titi)"
+  fi
+}
+
+function test_tar() {
+  local listing="./
+./etc/
+./etc/nsswitch.conf
+./usr/
+./usr/titi
+./usr/bin/
+./usr/bin/java -> /path/to/bin/java"
+  for i in "" ".gz" ".bz2" ".xz"; do
+    assert_content "test-tar-${i:1}.tar$i"
+    # Test merging tar files
+    # We pass a second argument to not test for user and group
+    # names because tar merging ask for numeric owners.
+    assert_content "test-tar-inclusion-${i:1}.tar" "true"
+  done;
+
+  check_eq "./
+./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-empty.tar)"
+  check_eq "./
+./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-none.tar)"
+  check_eq "./
+./nsswitch.conf" "$(get_tar_listing test-tar-strip_prefix-etc.tar)"
+  check_eq "./
+./etc/
+./etc/nsswitch.conf
+./external/
+./external/bazel_tools/
+./external/bazel_tools/tools/
+./external/bazel_tools/tools/python/
+./external/bazel_tools/tools/python/runfiles/
+./external/bazel_tools/tools/python/runfiles/runfiles.py" "$(get_tar_listing test-tar-strip_prefix-dot.tar)"
+  check_eq "./
+./not-etc/
+./not-etc/mapped-filename.conf" "$(get_tar_listing test-tar-files_dict.tar)"
+
+# TODO(aiuto): Make these tests less brittle w.r.t. tar variations, so that
+# we can run them on something besides Linux.
+if [[ "$OS" == 'Linux' ]] ; then
+  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
+-rwxrwxrwx 0/0               0 2000-01-01 00:00 ./a
+-rwxrwxrwx 0/0               0 2000-01-01 00:00 ./b" \
+      "$(get_tar_verbose_listing test-tar-empty_files.tar)"
+  check_eq "drwxr-xr-x 0/0               0 2000-01-01 00:00 ./
+drwxrwxrwx 0/0               0 2000-01-01 00:00 ./tmp/
+drwxrwxrwx 0/0               0 2000-01-01 00:00 ./pmt/" \
+      "$(get_tar_verbose_listing test-tar-empty_dirs.tar)"
+  check_eq \
+    "drwxr-xr-x 0/0               0 1999-12-31 23:59 ./
+-r-xr-xr-x 0/0               2 1999-12-31 23:59 ./nsswitch.conf" \
+    "$(get_tar_verbose_listing test-tar-mtime.tar)"
+fi
+}
+
+
+run_suite "build_test"


### PR DESCRIPTION
Add macos to the CI tests.
Disable deb and rpm tests for macos
Fix the tar tests for differences between linux and macos. But yeeech. They should all be replaced completely rather than fixed.
