### PR TITLE
convert py_binaries which are python3 ready to python3

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -38,8 +38,8 @@ py_library(
 py_binary(
     name = "build_tar",
     srcs = ["build_tar.py"],
-    python_version = "PY2",
-    srcs_version = "PY2AND3",
+    python_version = "PY3",
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         ":archive",
@@ -49,6 +49,8 @@ py_binary(
 py_binary(
     name = "build_zip",
     srcs = ["build_zip.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [":archive"],
 )

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -185,9 +185,9 @@ class TarFile(object):
       DebError: if the format of the deb archive is incorrect.
     """
     with archive.SimpleArFile(deb) as arfile:
-      current = arfile.next()
+      current = next(arfile)
       while current and not current.filename.startswith('data.'):
-        current = arfile.next()
+        current = next(arfile)
       if not current:
         raise self.DebError(deb + ' does not contains a data file!')
       tmpfile = tempfile.mkstemp(suffix=os.path.splitext(current.filename)[-1])


### PR DESCRIPTION
I left RPM because it is not quite there yet and I don't know who requires it.
There is also the python2 version of make_deb, because people wanted that
:archive can probably convert, but I don't know if docker is ready for that.