### PR TITLE
Fix broken link in README.md

### DIFF
--- a/deb_packages/tools/README.md
+++ b/deb_packages/tools/README.md
@@ -5,4 +5,4 @@
 A tool to update the path and SHA256 hash of packages referred to by `deb_packages` rules in WORKSPACE files.
 (Essentially `apt-get update && apt-get upgrade` for `deb_packages` rules in the current WORKSPACE.)
 
-(Documentation here)[https://github.com/bazelbuild/rules_pkg/blob/master/tools/update_deb_packages/README.md]
+[(Documentation here)](https://github.com/bazelbuild/rules_pkg/tree/master/deb_packages/tools/update_deb_packages)


### PR DESCRIPTION
This fixed a invalid markdown link to `update_deb_packages`.

Rather than linking the README.md, directly, I am linking the parent directory, since in GitHub's web UI this will both show the README and also allow users to browse the source, which is usually what people expect.