### PR TITLE
Fix `pkg_rpm` `source_date_epoch` attribute

### DIFF
--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -52,8 +52,8 @@ def _pkg_rpm_impl(ctx):
             fail("Both source_date_epoch and source_date_epoch_file attributes were specified")
         args += ["--source_date_epoch=@" + ctx.file.source_date_epoch_file.path]
         files += [ctx.file.source_date_epoch_file]
-    elif ctx.attr.source_date_epoch:
-        args += ["--source_date_epoch=" + ctx.attr.source_date_epoch]
+    elif ctx.attr.source_date_epoch != None:
+        args += ["--source_date_epoch=" + str(ctx.attr.source_date_epoch)]
 
     if ctx.attr.architecture:
         args += ["--arch=" + ctx.attr.architecture]


### PR DESCRIPTION
The existing `source_date_epoch` attribute for `pkg_rpm` is passed in as
an `int`, and is then appended to a string.  This, naturally, fails.
The `int` needs to be stringified first.

Additionally, since the [SOURCE_DATE_EPOCH] value can be any valid UNIX
epoch value, account for the possibility of it being set to 0 in the
Starlark code.

[SOURCE_DATE_EPOCH]: https://reproducible-builds.org/specs/source-date-epoch/#idm55