### PR TITLE
Add a minimal WORKSPACE file to the distributon.

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -21,6 +21,8 @@ filegroup(
     visibility = ["@//distro:__pkg__"],
 )
 
+exports_files(["WORKSPACE"], visibility = ["@//distro:__pkg__"])
+
 py_library(
     name = "archive",
     srcs = [

--- a/pkg/WORKSPACE
+++ b/pkg/WORKSPACE
@@ -23,7 +23,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-### INTERNAL ONLY
+### INTERNAL ONLY - lines after this are not included in the release packaging.
 #
 # Include dependencies which are only needed for development here.
 

--- a/pkg/WORKSPACE
+++ b/pkg/WORKSPACE
@@ -23,6 +23,10 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+### INTERNAL ONLY
+#
+# Include dependencies which are only needed for development here.
+
 http_archive(
     name = "bazel_stardoc",
     url = "https://github.com/bazelbuild/stardoc/archive/0.4.0.zip",

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -13,6 +13,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 pkg_tar(
     name = "rules_pkg-%s" % version,
     srcs = [
+        ":small_workspace",
         "//:standard_package",
         "//releasing:standard_package",
     ],
@@ -23,6 +24,13 @@ pkg_tar(
     owner = "0.0",
     package_dir = ".",
     strip_prefix = ".",
+)
+
+genrule(
+    name = "small_workspace",
+    srcs = ["//:WORKSPACE"],
+    outs = ["WORKSPACE"],
+    cmd = "sed -e '/### INTERNAL ONLY/,$$d' $(location //:WORKSPACE) >$@",
 )
 
 print_rel_notes(


### PR DESCRIPTION
We extract this from the top level workspace so it is easier to keep in sync.

I don't really like using sed for this, as it is another portability problem. OTOH, this is not a runtime problem, only distribution time, and we are very far away from being able to create distributions on windows.

Fixes #171 