### PR TITLE
Add licenses clauses to BUILD files

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files(
     glob(["*.bzl"]),
@@ -21,14 +21,17 @@ filegroup(
     visibility = ["@//distro:__pkg__"],
 )
 
-exports_files(["WORKSPACE"], visibility = ["@//distro:__pkg__"])
+exports_files(
+    ["WORKSPACE"],
+    visibility = ["@//distro:__pkg__"],
+)
 
 py_library(
     name = "archive",
     srcs = [
         "__init__.py",
         "archive.py",
-        "helpers.py"
+        "helpers.py",
     ],
     srcs_version = "PY2AND3",
     # This build rule is not intended for public use, but needs to

--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -1,13 +1,15 @@
-package(
-    default_visibility = ["//visibility:private"],
-)
-
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
 load("@rules_pkg//:version.bzl", "version")
 load("@rules_python//python:defs.bzl", "py_test")
+
+licenses(["notice"])
+
+package(
+    default_visibility = ["//visibility:private"],
+)
 
 # Build the artifact to put on the github release page.
 pkg_tar(

--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+licenses(["notice"])
+
 exports_files(
     glob([
         "*.bzl",

--- a/pkg/experimental/tests/BUILD
+++ b/pkg/experimental/tests/BUILD
@@ -17,6 +17,8 @@ load("@rules_pkg//experimental:pkg_filegroup.bzl", "pkg_filegroup", "pkg_mkdirs"
 load("@rules_pkg//experimental:rpm.bzl", "pkg_rpm")
 load("@rules_python//python:defs.bzl", "py_test")
 
+licenses(["notice"])
+
 pkg_filegroup_analysis_tests()
 
 pkg_filegroup_unit_tests()

--- a/pkg/experimental/tests/external_repo/BUILD
+++ b/pkg/experimental/tests/external_repo/BUILD
@@ -13,3 +13,6 @@
 # limitations under the License.
 
 # Intenionally empty; defines package boundaries
+
+licenses(["notice"])
+

--- a/pkg/experimental/tests/external_repo/pkg/BUILD
+++ b/pkg/experimental/tests/external_repo/pkg/BUILD
@@ -15,6 +15,8 @@
 load("@rules_pkg//experimental:pkg_filegroup.bzl", "make_strip_prefix", "pkg_filegroup")
 load("test.bzl", "test_referencing_remote_file")
 
+licenses(["notice"])
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(

--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -1,5 +1,7 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
+licenses(["notice"])
+
 package(
     default_visibility = ["//visibility:public"],
 )

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar", "pkg_zip")
 load("@rules_pkg//:rpm.bzl", "pkg_rpm")
@@ -19,7 +19,7 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    package_dir = "/package"
+    package_dir = "/package",
 )
 
 pkg_tar(
@@ -27,7 +27,7 @@ pkg_tar(
     srcs = [
         ":etc/nsswitch.conf",
     ],
-    package_dir_file = "testdata/test_tar_package_dir_file.txt"
+    package_dir_file = "testdata/test_tar_package_dir_file.txt",
 )
 
 pkg_zip(
@@ -101,8 +101,8 @@ py_test(
         "test_zip_package_dir2.zip",
     ],
     deps = [
-        "@rules_pkg//:build_zip",
         "@bazel_tools//tools/python/runfiles",
+        "@rules_pkg//:build_zip",
     ],
 )
 
@@ -110,7 +110,7 @@ filegroup(
     name = "archive_testdata",
     srcs = glob(["testdata/**"]) + [
         ":test_tar_package_dir",
-        ":test_tar_package_dir_file"
+        ":test_tar_package_dir_file",
     ],
     visibility = ["//visibility:private"],
 )
@@ -128,8 +128,8 @@ py_test(
         "no_windows",
     ],
     deps = [
-        "@rules_pkg//:archive",
         "@bazel_tools//tools/python/runfiles",
+        "@rules_pkg//:archive",
     ],
 )
 
@@ -150,8 +150,8 @@ py_test(
         "no_windows",
     ],
     deps = [
-        "@rules_pkg//:make_rpm_lib",
         "@rules_pkg//:archive",
+        "@rules_pkg//:make_rpm_lib",
     ],
 )
 
@@ -173,6 +173,7 @@ genrule(
 
 pkg_deb(
     name = "test-deb",
+    breaks = ["oldbrokenpkg"],
     built_using = "some_test_data (0.1.2)",
     conffiles = [
         "/etc/nsswitch.conf",
@@ -189,25 +190,25 @@ pkg_deb(
     maintainer = "soméone@somewhere.com",
     make_deb = "@rules_pkg//:make_deb",
     package = "titi",
-    breaks = ["oldbrokenpkg"],
+    preinst = ":test-deb-preinst",
     replaces = ["oldpkg"],
     templates = ":testdata/templates",
-    preinst = ":test-deb-preinst",
     urgency = "low",
     version = "test",
 )
 
 pkg_rpm(
     name = "test-rpm",
-    version = "1",
-    release = "0",
     data = [":archive_testdata"],
-    spec_file = "test_rpm.spec",
     debug = 1,
+    release = "0",
+    spec_file = "test_rpm.spec",
+    version = "1",
 )
 
 pkg_deb(
     name = "test-deb-py2",
+    breaks = ["oldbrokenpkg"],
     built_using = "some_test_data (0.1.2)",
     conffiles = [
         "/etc/nsswitch.conf",
@@ -224,10 +225,9 @@ pkg_deb(
     maintainer = "soméone@somewhere.com",
     make_deb = "@rules_pkg//:make_deb_py2",
     package = "titi",
-    breaks = ["oldbrokenpkg"],
+    preinst = ":test-deb-preinst",
     replaces = ["oldpkg"],
     templates = ":testdata/templates",
-    preinst = ":test-deb-preinst",
     urgency = "low",
     version = "test_py2",
 )

--- a/pkg/third_party/test/shell/BUILD
+++ b/pkg/third_party/test/shell/BUILD
@@ -1,3 +1,4 @@
+licenses(["notice"])
 
 sh_library(
     name = "bashunit",


### PR DESCRIPTION
This is not strictly needed, but it makes import to companies that do strict license checks (like Google) easier.
Also run buildifer on the changed files.