### PR TITLE
Drop dependency on xzcat

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -31,13 +31,25 @@ py_library(
     srcs = [
         "__init__.py",
         "archive.py",
+    ],
+    srcs_version = "PY3",
+    visibility = [
+        "//experimental:__pkg__",
+        "//tests:__pkg__",
+    ],
+)
+
+py_library(
+    name = "helpers",
+    srcs = [
+        "__init__.py",
         "helpers.py",
     ],
     srcs_version = "PY2AND3",
-    # This build rule is not intended for public use, but needs to
-    # be publicly visible because existing projects rely on it.
-    # Use at your own risk.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//experimental:__pkg__",
+        "//tests:__pkg__",
+    ],
 )
 
 py_binary(
@@ -57,7 +69,10 @@ py_binary(
     python_version = "PY3",
     srcs_version = "PY3",
     visibility = ["//visibility:public"],
-    deps = [":archive"],
+    deps = [
+        ":archive",
+        ":helpers",
+    ],
 )
 
 py_binary(
@@ -66,7 +81,7 @@ py_binary(
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
-        ":archive",
+        ":helpers",
     ],
 )
 
@@ -78,7 +93,7 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        ":archive",
+        ":helpers",
     ],
 )
 
@@ -99,5 +114,12 @@ py_library(
     name = "make_rpm_lib",
     srcs = ["make_rpm.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//experimental:__pkg__",
+        "//tests:__pkg__",
+    ],
+    deps = [
+        ":archive",
+        ":helpers",
+    ],
 )

--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -30,7 +30,7 @@ py_binary(
     srcs_version = "PY2AND3",
     visibility = ["//visibility:public"],
     deps = [
-        "//:archive",
+        "//:helpers",
         "//:make_rpm_lib",
     ],
 )

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -162,7 +162,6 @@ py_test(
         "no_windows",
     ],
     deps = [
-        "//:archive",
         "//:make_rpm_lib",
     ],
 )
@@ -173,7 +172,7 @@ py_test(
     python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [
-        "//:archive",
+        "//:helpers",
     ],
 )
 


### PR DESCRIPTION
Fixes #31 and simplifies the code.
Fixes #200 but makes the BUILD files a little more complex. 

The BUILD refactoring is done because we need to insist on python3 for archive.py, but make_deb2 requires py2 sources. This is easy enough because make_deb2 did not actually depend on archive.py