### PR TITLE
Stop using the bazel_tools runfiles library in tests.

### DIFF
--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -61,7 +61,6 @@ py_test(
         "noci",
     ],
     deps = [
-        "@bazel_tools//tools/python/runfiles",
         "//releasing:release_utils",
     ],
 )

--- a/pkg/distro/packaging_test.py
+++ b/pkg/distro/packaging_test.py
@@ -18,7 +18,6 @@ import os
 import subprocess
 import unittest
 
-from bazel_tools.tools.python.runfiles import runfiles
 from releasing import release_tools
 from distro import release_version
 
@@ -29,7 +28,7 @@ class PackagingTest(unittest.TestCase):
   """Test the distribution packaging."""
 
   def setUp(self):
-    self.data_files = runfiles.Create()
+    self.data_files = os.environ.get("TEST_SRCDIR")
     self.source_repo = 'rules_pkg'
     self.dest_repo = 'not_named_rules_pkg'
     self.version = release_version.RELEASE_VERSION
@@ -41,8 +40,7 @@ class PackagingTest(unittest.TestCase):
       os.makedirs(tempdir)
     with open(os.path.join(tempdir, 'WORKSPACE'), 'w') as workspace:
       file_name = release_tools.package_basename(self.source_repo, self.version)
-      local_path = runfiles.Create().Rlocation(
-          os.path.join('rules_pkg', 'distro', file_name))
+      local_path = os.path.join(self.data_files, 'rules_pkg', 'distro', file_name)
       sha256 = release_tools.get_package_sha256(local_path)
       workspace_content = '\n'.join((
         'workspace(name = "test_rules_pkg_packaging")',
@@ -60,8 +58,8 @@ class PackagingTest(unittest.TestCase):
     # We do a little dance of renaming *.tmpl to *, mostly so that we do not
     # have a BUILD file in testdata, which would create a package boundary.
     def CopyTestFile(source_name, dest_name):
-      source_path = self.data_files.Rlocation(
-          os.path.join('rules_pkg', 'distro', 'testdata', source_name))
+      source_path = os.path.join(
+          self.data_files, 'rules_pkg', 'distro', 'testdata', source_name)
       with open(source_path) as inp:
         with open(os.path.join(tempdir, dest_name), 'w') as out:
           content = inp.read()

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -113,7 +113,6 @@ py_test(
     python_version = "PY3",
     deps = [
         "//:build_zip",
-        "@bazel_tools//tools/python/runfiles",
     ],
 )
 
@@ -140,7 +139,6 @@ py_test(
     ],
     deps = [
         "//:archive",
-        "@bazel_tools//tools/python/runfiles",
     ],
 )
 
@@ -300,11 +298,12 @@ pkg_tar(
     strip_prefix = "etc",
 )
 
+# Test that strip_prefix='.' removes the current workspace path from the paths
 pkg_tar(
     name = "test-tar-strip_prefix-dot",
     srcs = [
         ":etc/nsswitch.conf",
-        "@bazel_tools//tools/python/runfiles",
+        "//tests_extra:generate_files",
     ],
     strip_prefix = ".",
 )

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -19,14 +19,13 @@ import tarfile
 import unittest
 
 from rules_pkg import archive
-from bazel_tools.tools.python.runfiles import runfiles
 
 
 class SimpleArFileTest(unittest.TestCase):
   """Testing for SimpleArFile class."""
 
   def setUp(self):
-    self.data_files = runfiles.Create()
+    self.data_files = os.environ.get("TEST_SRCDIR")
 
   def assertArFileContent(self, arfile, content):
     """Assert that arfile contains exactly the entry described by `content`.
@@ -64,13 +63,12 @@ class SimpleArFileTest(unittest.TestCase):
 
   def testEmptyArFile(self):
     self.assertArFileContent(
-        self.data_files.Rlocation(
-            os.path.join("rules_pkg", "tests", "testdata", "empty.ar")),
+        os.path.join(self.data_files, "rules_pkg", "tests", "testdata", "empty.ar"),
         [])
 
   def assertSimpleFileContent(self, names):
-    datafile = self.data_files.Rlocation(
-        os.path.join("rules_pkg", "tests", "testdata", "_".join(names) + ".ar"))
+    datafile = os.path.join(
+        self.data_files, "rules_pkg", "tests", "testdata", "_".join(names) + ".ar")
     content = [{"filename": n,
                 "size": len(n.encode("utf-8")),
                 "data": n.encode("utf-8")}
@@ -136,7 +134,7 @@ class TarFileWriterTest(unittest.TestCase):
 
   def setUp(self):
     self.tempfile = os.path.join(os.environ["TEST_TMPDIR"], "test.tar")
-    self.data_files = runfiles.Create()
+    self.data_files = os.environ.get("TEST_SRCDIR")
 
   def tearDown(self):
     if os.path.exists(self.tempfile):
@@ -209,8 +207,10 @@ class TarFileWriterTest(unittest.TestCase):
         ]
     for ext in ["", ".gz", ".bz2", ".xz"]:
       with archive.TarFileWriter(self.tempfile) as f:
-        datafile = self.data_files.Rlocation(
-            os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar" + ext))
+        datafile = os.path.join(
+            self.data_files,
+            "rules_pkg", "tests", "testdata",
+            "tar_test.tar" + ext)
         f.add_tar(datafile, name_filter=lambda n: n != "./b")
       self.assertTarFileContent(self.tempfile, content)
 
@@ -222,8 +222,8 @@ class TarFileWriterTest(unittest.TestCase):
         {"name": "./foo/ab", "data": b"ab"},
         ]
     with archive.TarFileWriter(self.tempfile) as f:
-      datafile = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+      datafile = os.path.join(
+          self.data_files, "rules_pkg", "tests", "testdata", "tar_test.tar")
       f.add_tar(datafile, name_filter=lambda n: n != "./b", root="/foo")
     self.assertTarFileContent(self.tempfile, content)
 
@@ -241,8 +241,8 @@ class TarFileWriterTest(unittest.TestCase):
 
   def testPreserveTarMtimesTrueByDefault(self):
     with archive.TarFileWriter(self.tempfile) as f:
-      input_tar_path = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+      input_tar_path = os.path.join(
+          self.data_files, "rules_pkg", "tests", "testdata", "tar_test.tar")
       f.add_tar(input_tar_path)
       input_tar = tarfile.open(input_tar_path, "r")
       for file_name in f.members:
@@ -252,8 +252,8 @@ class TarFileWriterTest(unittest.TestCase):
 
   def testPreserveTarMtimesFalse(self):
     with archive.TarFileWriter(self.tempfile, preserve_tar_mtimes=False) as f:
-      input_tar_path = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+      input_tar_path = os.path.join(
+          self.data_files, "rules_pkg", "tests", "testdata", "tar_test.tar")
       f.add_tar(input_tar_path)
       for output_file in f.tar:
         self.assertEqual(output_file.mtime, 0)
@@ -377,10 +377,10 @@ class TarFileWriterTest(unittest.TestCase):
       Verifies that passing package_dir (string) and package_dir_file(label)
       to pkg_tar yields identical results
       """
-      package_dir = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir.tar"))
-      package_dir_file = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir_file.tar"))
+      package_dir = os.path.join(
+          self.data_files, "rules_pkg", "tests", "test_tar_package_dir.tar")
+      package_dir_file = os.path.join(
+          self.data_files, "rules_pkg", "tests", "test_tar_package_dir_file.tar")
 
       expected_content = [
           {'name': '.'},

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -83,17 +83,20 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test-tar-strip_prefix-etc.tar', content)
 
+  # TODO(https://github.com/bazelbuild/rules_pkg/issues/207): The "tests"
+  # from "tests_extra" should not be stripped.
   def test_strip_prefix_dot(self):
     content = [
         {'name': '.'},
         {'name': './etc'},
         {'name': './etc/nsswitch.conf'},
-        {'name': './external'},
-        {'name': './external/bazel_tools'},
-        {'name': './external/bazel_tools/tools'},
-        {'name': './external/bazel_tools/tools/python'},
-        {'name': './external/bazel_tools/tools/python/runfiles'},
-        {'name': './external/bazel_tools/tools/python/runfiles/runfiles.py'},
+        {'name': './_extra'},
+        {'name': './_extra/a'},
+        {'name': './_extra/b'},
+        {'name': './_extra/b/c'},
+        {'name': './_extra/d'},
+        {'name': './_extra/d/e'},
+        {'name': './_extra/d/e/f'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-dot.tar', content)
 

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -26,7 +26,7 @@ EXECUTABLE_CRC = 342626072
 class ZipTest(unittest.TestCase):
     def get_test_zip(self, zipfile):
         """Get the file path to a generated zip in the runfiles."""
-        data_files = os.environ.get("TEST_SRCDIR").replace('/', os.path.sep)
+        data_files = os.environ.get("PYTHON_RUNFILES").replace('/', os.path.sep)
         return os.path.join(data_files, "rules_pkg", "tests", zipfile)
 
 

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -26,7 +26,7 @@ EXECUTABLE_CRC = 342626072
 class ZipTest(unittest.TestCase):
     def get_test_zip(self, zipfile):
         """Get the file path to a generated zip in the runfiles."""
-        data_files = os.environ.get("TEST_SRCDIR")
+        data_files = os.environ.get("TEST_SRCDIR").replace('/', os.path.sep)
         return os.path.join(data_files, "rules_pkg", "tests", zipfile)
 
 

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -26,7 +26,7 @@ EXECUTABLE_CRC = 342626072
 class ZipTest(unittest.TestCase):
     def get_test_zip(self, zipfile):
         """Get the file path to a generated zip in the runfiles."""
-        data_files = os.environ.get("PYTHON_RUNFILES").replace('/', os.path.sep)
+        data_files = os.environ.get("RUNFILES_DIR").replace('/', os.path.sep)
         return os.path.join(data_files, "rules_pkg", "tests", zipfile)
 
 

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -15,9 +15,9 @@
 import filecmp
 import os
 import unittest
-from bazel_tools.tools.python.runfiles import runfiles
-from build_zip import parse_date, ZIP_EPOCH
 from zipfile import ZipFile
+
+from build_zip import parse_date, ZIP_EPOCH
 
 HELLO_CRC = 2069210904
 LOREM_CRC = 2178844372
@@ -26,13 +26,9 @@ EXECUTABLE_CRC = 342626072
 class ZipTest(unittest.TestCase):
     def get_test_zip(self, zipfile):
         """Get the file path to a generated zip in the runfiles."""
+        data_files = os.environ.get("TEST_SRCDIR")
+        return os.path.join(data_files, "rules_pkg", "tests", zipfile)
 
-        return self.data_files.Rlocation(
-            "rules_pkg/tests/" + zipfile
-        )
-
-    def setUp(self):
-        self.data_files = runfiles.Create()
 
 class ZipContentsCase(ZipTest):
     """Use zipfile to check the contents of some generated zip files."""

--- a/pkg/tests_extra/BUILD
+++ b/pkg/tests_extra/BUILD
@@ -1,0 +1,14 @@
+# This package contains extra test data that should not be contained mixed with
+# the regular test data.
+
+package(default_visibility = ["//tests:__pkg__"])
+
+genrule(
+    name = "generate_files",
+    outs = [
+        "a",
+        "b/c",
+        "d/e/f"
+    ],
+    cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+)


### PR DESCRIPTION
Using runfiles make it difficult to run the tests with Google's blaze. That slows down the progress for eventually converging the tools.

This also pointed out a bug in strip_prefix=.
https://github.com/bazelbuild/rules_pkg/issues/207