### PR TITLE
use runfiles for pkg_tar_test to enable on Windows

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -31,5 +31,4 @@ tasks:
     # one that works and can add to the list as we fix the broken behavior or
     # broken test.
     test_targets:
-    - "//tests:pkg_tar_test"
     - "//tests:zip_test"

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -368,6 +368,9 @@ py_test(
         ":test-tar-strip_prefix-none.tar",
     ],
     python_version = "PY3",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+    ],
 )
 
 sh_test(

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -18,6 +18,8 @@ import os.path
 import tarfile
 import unittest
 
+from bazel_tools.tools.python.runfiles import runfiles
+
 PORTABLE_MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
 
 
@@ -36,7 +38,9 @@ class PkgTarTest(unittest.TestCase):
             be `{'name': 'x'}`, the missing field will be ignored. To match
             the content of a file entry, use the key 'data'.
     """
-    file_path = os.path.join(os.environ['RUNFILES_DIR'], 'rules_pkg', 'tests', file_name)
+    # NOTE: This is portable to Windows. os.path.join('rules_pkg', 'tests',
+    # filename) is not.
+    file_path = runfiles.Create().Rlocation('rules_pkg/tests/' + file_name)
     with tarfile.open(file_path, 'r:*') as f:
       i = 0
       for info in f:


### PR DESCRIPTION
Using os.environ('RUNFILES') does not work on WIndows.