### PR TITLE
`pkg_rpm_ex`: Provide in-rule dependency specifications

### DIFF
--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -79,6 +79,20 @@ def _pkg_rpm_impl(ctx):
         preamble_pieces.append("License: " + ctx.attr.license)
     if ctx.attr.group:
         preamble_pieces.append("Group: " + ctx.attr.group)
+    if ctx.attr.provides:
+        preamble_pieces.extend(["Provides: " + p for p in ctx.attr.provides])
+    if ctx.attr.conflicts:
+        preamble_pieces.extend(["Conflicts: " + c for c in ctx.attr.conflicts])
+    if ctx.attr.requires:
+        preamble_pieces.extend(["Requires: " + r for r in ctx.attr.requires])
+    if ctx.attr.requires_contextual:
+        preamble_pieces.extend(
+            [
+                "Requires({}): {}".format(scriptlet, capability)
+                for scriptlet in ctx.attr.requires_contextual.keys()
+                for capability in ctx.attr.requires_contextual[scriptlet]
+            ],
+        )
 
     # TODO: BuildArch is usually not hardcoded in spec files, unless the package
     # is indeed restricted to a particular CPU architecture, or is actually
@@ -626,6 +640,68 @@ pkg_rpm = rule(
         "postun_scriptlet_file": attr.label(
             doc = """File containing the RPM `%postun` scriptlet""",
             allow_single_file = True,
+        ),
+        "conflicts": attr.string_list(
+            doc = """List of capabilities that conflict with this package when it is installed.
+
+            Cooresponds to the "Conflicts" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "provides": attr.string_list(
+            doc = """List of rpm capabilities that this package provides.
+
+            Cooresponds to the "Provides" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "requires": attr.string_list(
+            doc = """List of rpm capability expressions that this package requires.
+
+            Corresponds to the "Requires" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "requires_contextual": attr.string_list_dict(
+            doc = """Contextualized requirement specifications
+
+            This is a map of various properties (often scriptlet types) to
+            capability name specifications, e.g.:
+
+            ```python
+            {"pre": ["GConf2"],"post": ["GConf2"], "postun": ["GConf2"]}
+            ```
+
+            Which causes the below to be added to the spec file's preamble:
+
+            ```
+            Requires(pre): GConf2
+            Requires(post): GConf2
+            Requires(postun): GConf2
+            ```
+
+            This is most useful for ensuring that required tools exist when
+            scriptlets are run, although other properties are known.  Valid keys
+            for this attribute may include, but are not limited to:
+
+            - `pre`
+            - `post`
+            - `preun`
+            - `postun`
+            - `pretrans`
+            - `posttrans`
+
+            For capabilities that are always required by packages at runtime,
+            use the `requires` attribute instead.
+
+            See also: https://rpm.org/user_doc/more_dependencies.html
+
+            NOTE: `pkg_rpm` does not check if the keys of this dictionary are
+            acceptable to `rpm(8)`.
+            """,
         ),
 
         # TODO(nacl): this should be a toolchain

--- a/pkg/experimental/tests/BUILD
+++ b/pkg/experimental/tests/BUILD
@@ -64,6 +64,7 @@ pkg_mklinks(
 pkg_rpm(
     name = "test_rpm",
     architecture = "noarch",
+    conflicts = ["not-a-test"],
     data = [
         ":ars_pfg",
         ":test_links",
@@ -75,7 +76,10 @@ pkg_rpm(
     postun_scriptlet = """echo postun""",
     pre_scriptlet = """echo pre""",
     preun_scriptlet = """echo preun""",
+    provides = ["test"],
     release = "2222",
+    requires = ["test-lib > 1.0"],
+    requires_contextual = {"preun": ["bash"]},
     spec_template = "template-test.spec.in",
     summary = "pkg_rpm test rpm summary",
     version = "1.1.1",
@@ -85,7 +89,7 @@ pkg_rpm(
 genrule(
     name = "test_rpm_manifest",
     srcs = [":ars"],
-    outs = ["manifest.txt"],
+    outs = ["manifest.csv"],
     # Keep the header (the first line echo'd below) in sync with
     # rpm_queryformat_fieldnames in pkg_rpm_basic_test.py
     cmd = """
@@ -119,6 +123,46 @@ genrule(
     """,
 )
 
+genrule(
+    name = "test_rpm_metadata",
+    srcs = [],
+    outs = [
+        "conflicts.csv",
+        "provides.csv",
+        "requires.csv",
+    ],
+    # In the below, we don't use the "," separator for everything, because the
+    # query tags used to get the associated dependency types
+    # (e.g. %{REQUIREFLAGS:deptype}) itself uses commas.  This makes it so the test
+    # doesn't have to rely on knowing the number of fields in each CSV file.
+    cmd = """
+    (
+        echo 'capability:sense'
+        echo 'not-a-test:manual'
+    ) > $(RULEDIR)/conflicts.csv
+    (
+        # NOTE: excludes the "self-require" (we did nothing special to make it
+        # appear)
+
+        echo 'capability:sense'
+        echo 'test:manual'
+    ) > $(RULEDIR)/provides.csv
+    (
+        # NOTE: excludes 'rpmlib' requires that may be version-dependent
+        echo 'capability:sense'
+        # Common, automatically generated
+        echo '/bin/sh:pre,interp'
+        echo '/bin/sh:post,interp'
+        echo '/bin/sh:preun,interp'
+        echo '/bin/sh:postun,interp'
+        # Hand-specified, specific dependencies
+        echo 'bash:preun'
+        # Hand-specified
+        echo 'test-lib > 1.0:manual'
+    ) > $(RULEDIR)/requires.csv
+    """,
+)
+
 # One cannot simply pass the output of pkg_rpm as runfiles content (#161).  This
 # seems to be the easiest way around this problem.
 sh_library(
@@ -127,6 +171,7 @@ sh_library(
     data = [
         ":test_rpm",
         ":test_rpm_manifest",
+        ":test_rpm_metadata",
     ],
 )
 


### PR DESCRIPTION
This change provides four additional attributes to the experimental `pkg_rpm`
rule, namely:

- `conflicts`, `string_list`, corresponding to the `Conflicts` tag
- `provides`, `string_list`, corresponding to the `Provides` tag
- `requires`, `string_list`, corresponding to the `Requires` tag

Additionally:

- `requires_contextual`, `string_list_dict`, providing the capability to specify
  tags like `Requires(postun)`.

Unit tests were also provided.  Non-rpm input files for the `pkg_rpm_ex` output
test have now been given the ".csv" extension to better help identify that they
are delimited files (but not strictly comma-delimited).

Note that these changes only impact the "strong" dependencies between packages;
[weak dependencies] like "Suggests" and "Recommends" are not explicitly
supported, but can be added in the future following a similar pattern.

Fixes #223.

[weak dependencies]: https://rpm.org/user_doc/dependencies.html#weak-dependencies