### PR TITLE
Avoid stripping prefixes with incomplete directory names.

### DIFF
--- a/pkg/path.bzl
+++ b/pkg/path.bzl
@@ -39,10 +39,9 @@ def _short_path_dirname(path):
         return ""
     return sp[:last_pkg]
 
-def dest_path(f, strip_prefix):
+def dest_path(f, strip_prefix, data_path_without_prefix = ""):
     """Returns the short path of f, stripped of strip_prefix."""
     f_short_path = safe_short_path(f)
-
     if strip_prefix == None:
         # If no strip_prefix was specified, use the package of the
         # given input as the strip_prefix.
@@ -50,6 +49,15 @@ def dest_path(f, strip_prefix):
     if not strip_prefix:
         return f_short_path
     if f_short_path.startswith(strip_prefix):
+        # Check that the last directory in strip_prefix is a complete
+        # directory (so that we don't strip part of a dir name)
+        prefix_last_dir_index = strip_prefix.rfind("/")
+        prefix_last_dir = strip_prefix[prefix_last_dir_index + 1:]
+
+        # Avoid stripping prefix if final directory is incomplete
+        if prefix_last_dir not in f_short_path.split("/"):
+          strip_prefix = data_path_without_prefix
+
         return f_short_path[len(strip_prefix):]
     return f_short_path
 

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -39,6 +39,7 @@ def _pkg_tar_impl(ctx):
 
     # Compute the relative path
     data_path = compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix)
+    data_path_without_prefix = compute_data_path(ctx.outputs.out, '.')
 
     # Find a list of path remappings to apply.
     remap_paths = ctx.attr.remap_paths
@@ -82,7 +83,8 @@ def _pkg_tar_impl(ctx):
         file_inputs = ctx.files.srcs[:]
 
     args += [
-        "--file=%s=%s" % (_quote(f.path), _remap(remap_paths, dest_path(f, data_path)))
+        "--file=%s=%s" % (_quote(f.path), _remap(
+            remap_paths, dest_path(f, data_path, data_path_without_prefix)))
         for f in file_inputs
     ]
     for target, f_dest_path in ctx.attr.files.items():

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -279,6 +279,14 @@ pkg_tar(
 )
 
 pkg_tar(
+    name = "test-tar-strip_prefix-substring",
+    srcs = [
+        ":etc/nsswitch.conf",
+    ],
+    strip_prefix = "et",
+)
+
+pkg_tar(
     name = "test-tar-files_dict",
     files = {
         ":etc/nsswitch.conf": "not-etc/mapped-filename.conf",
@@ -335,6 +343,7 @@ py_test(
         ":test-tar-strip_prefix-empty.tar",
         ":test-tar-strip_prefix-etc.tar",
         ":test-tar-strip_prefix-none.tar",
+        ":test-tar-strip_prefix-substring.tar",
     ],
     python_version = "PY3",
     deps = [

--- a/pkg/tests/path_test.py
+++ b/pkg/tests/path_test.py
@@ -120,6 +120,14 @@ class DestPathTest(unittest.TestCase):
     path = pkg_bzl.dest_path(File('baz'), None)
     self.assertEqual('baz', path)
 
+  def testPartialDirectoryMatch(self):
+    path = pkg_bzl.dest_path(File('foo/bar/baz'), 'fo')
+    self.assertEqual('foo/bar/baz', path)
+
+  def testPartialDirectoryMatchWithDataPath(self):
+    path = pkg_bzl.dest_path(File('foo/bar/baz'), 'foo/ba', 'foo')
+    self.assertEqual('/bar/baz', path)
+
 
 class ComputeDataPathTest(unittest.TestCase):
   """Testing for _data_path_out."""

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -87,6 +87,14 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test-tar-strip_prefix-etc.tar', content)
 
+  def test_strip_prefix_substring(self):
+    content = [
+        {'name': '.', 'isdir': True},
+        {'name': './etc', 'isdir': True},
+        {'name': './etc/nsswitch.conf'},
+    ]
+    self.assertTarFileContent('test-tar-strip_prefix-substring.tar', content)
+
   def test_strip_prefix_dot(self):
     content = [
         {'name': '.'},


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_pkg/issues/207.

The only complication here was the fact that the parameters `strip_prefix` and `f` have had the output data directory prepended to them by the time they are passed into `dest_dir`, so we can't just throw out `strip_prefix` entirely if the last directory is an incomplete match; instead, we need to act as if `strip_prefix` was set to `.` (or not specified at all) for those files. This issue was caught by `:pkg_tar_test`, which prepends the directory `tests` to all outputs.

Please let me know if you can think of a better approach than calling `compute_data_path` twice in `pkg.bzl`.