### PR TITLE
Add attribute strip_prefix to pkg_zip

### DIFF
--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -392,9 +392,6 @@ def pkg_deb(name, package, **kwargs):
         **kwargs
     )
 
-def _format_zip_file_arg(f):
-    return "%s=%s" % (_quote(f.path), dest_path(f, strip_prefix = None))
-
 def _pkg_zip_impl(ctx):
     args = ctx.actions.args()
 
@@ -403,10 +400,12 @@ def _pkg_zip_impl(ctx):
     args.add("-t", ctx.attr.timestamp)
     args.add("-m", ctx.attr.mode)
 
-    args.add_all(
-        ctx.files.srcs,
-        map_each = _format_zip_file_arg,
-    )
+    for f in ctx.files.srcs:
+        arg = "%s=%s" % (
+            _quote(f.path),
+            dest_path(f, compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix))
+        )
+        args.add(arg)
 
     args.set_param_file_format("multiline")
     args.use_param_file("@%s")
@@ -436,6 +435,7 @@ pkg_zip_impl = rule(
         "timestamp": attr.int(default = 315532800),
         "mode": attr.string(default = "0555"),
         "out": attr.output(),
+        "strip_prefix": attr.string(),
         # Implicit dependencies.
         "build_zip": attr.label(
             default = Label("//:build_zip"),

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load("//:pkg.bzl", "pkg_deb", "pkg_tar", "pkg_zip")
 load("//:rpm.bzl", "pkg_rpm")
 load("@rules_python//python:defs.bzl", "py_test")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 genrule(
     name = "generate_files",
@@ -13,6 +14,12 @@ genrule(
         "usr/titi",
     ],
     cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+)
+
+copy_file(
+    name = "zipcontent_loremipsum",
+    src = "testdata/loremipsum.txt",
+    out = "zipcontent/loremipsum.txt",
 )
 
 pkg_tar(
@@ -79,6 +86,47 @@ pkg_zip(
     timestamp = 0,
 )
 
+pkg_zip(
+    name = "test-zip-strip_prefix-empty",
+    srcs = [
+        "zipcontent_loremipsum",
+    ],
+    strip_prefix = "",
+)
+
+pkg_zip(
+    name = "test-zip-strip_prefix-none",
+    srcs = [
+        "zipcontent_loremipsum",
+    ],
+)
+
+pkg_zip(
+    name = "test-zip-strip_prefix-zipcontent",
+    srcs = [
+        "zipcontent_loremipsum",
+    ],
+    strip_prefix = "zipcontent",
+)
+
+pkg_zip(
+    name = "test-zip-strip_prefix-dot",
+    srcs = [
+        "zipcontent_loremipsum",
+    ],
+    strip_prefix = ".",
+)
+
+filegroup(
+    name = "test_zip_strip_prefix",
+    srcs = [
+        "test-zip-strip_prefix-empty",
+        "test-zip-strip_prefix-none",
+        "test-zip-strip_prefix-zipcontent",
+        "test-zip-strip_prefix-dot",
+    ],
+)
+
 # All of these should produce the same zip file.
 [pkg_zip(
     name = "test_zip_package_dir" + str(idx),
@@ -104,6 +152,10 @@ py_test(
         "test_zip_package_dir0.zip",
         "test_zip_timestamp.zip",
         "test_zip_permissions.zip",
+        "test-zip-strip_prefix-empty.zip",
+        "test-zip-strip_prefix-none.zip",
+        "test-zip-strip_prefix-zipcontent.zip",
+        "test-zip-strip_prefix-dot.zip",
 
         # these could be replaced with diff_test() rules (from skylib)
         "test_zip_basic_timestamp_before_epoch.zip",

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -82,7 +82,7 @@ class ZipContentsCase(ZipTest):
         self.assertZipFileContent(
             "test_zip_permissions.zip",
             [
-                { 
+                {
                     "filename": "executable.sh",
                     "crc": EXECUTABLE_CRC,
                     "timestamp": 1234567890,
@@ -97,6 +97,38 @@ class ZipContentsCase(ZipTest):
             [
                 {"filename": "abc/def/hello.txt", "crc": HELLO_CRC},
                 {"filename": "abc/def/loremipsum.txt", "crc": LOREM_CRC},
+            ],
+        )
+
+    def testZipStripPrefixEmpty(self):
+        self.assertZipFileContent(
+            "test-zip-strip_prefix-empty.zip",
+            [
+                {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+            ],
+        )
+
+    def testZipStripPrefixNone(self):
+        self.assertZipFileContent(
+            "test-zip-strip_prefix-none.zip",
+            [
+                {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+            ],
+        )
+
+    def testZipStripPrefixZipcontent(self):
+        self.assertZipFileContent(
+            "test-zip-strip_prefix-zipcontent.zip",
+            [
+                {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+            ],
+        )
+
+    def testZipStripPrefixDot(self):
+        self.assertZipFileContent(
+            "test-zip-strip_prefix-dot.zip",
+            [
+                {"filename": "zipcontent/loremipsum.txt", "crc": LOREM_CRC},
             ],
         )
 


### PR DESCRIPTION
Duplicates PR #221 targeting default branch `main` instead of `master`.

* Add attribute strip_prefix to pkg_zip
* Add tests for pkg_zip strip_prefix behavior