### PR TITLE
Use symlink actions for RPM packages instead of custom actions

### DIFF
--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -399,28 +399,16 @@ install -d %{{buildroot}}/{0}
     #### Output construction
 
     # Link the RPM to the expected output name.
-    ctx.actions.run(
-        executable = "ln",
-        arguments = [
-            "-s",
-            ctx.outputs.rpm.basename,
-            ctx.outputs.out.path,
-        ],
-        inputs = [ctx.outputs.rpm],
-        outputs = [ctx.outputs.out],
+    ctx.actions.symlink(
+        output = ctx.outputs.out,
+        target_file = ctx.outputs.rpm
     )
 
-    # Link the RPM to the RPM-recommended output name.
+    # Link the RPM to the RPM-recommended output name if possible.
     if "rpm_nvra" in dir(ctx.outputs):
-        ctx.actions.run(
-            executable = "ln",
-            arguments = [
-                "-s",
-                ctx.outputs.rpm.basename,
-                ctx.outputs.rpm_nvra.path,
-            ],
-            inputs = [ctx.outputs.rpm],
-            outputs = [ctx.outputs.rpm_nvra],
+        ctx.actions.symlink(
+            output = ctx.outputs.rpm_nvra,
+            target_file = ctx.outputs.rpm
         )
 
 # TODO(nacl): this relies on deprecated behavior (should use Providers

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -106,28 +106,16 @@ def _pkg_rpm_impl(ctx):
     )
 
     # Link the RPM to the expected output name.
-    ctx.actions.run(
-        executable = "ln",
-        arguments = [
-            "-s",
-            ctx.outputs.rpm.basename,
-            ctx.outputs.out.path,
-        ],
-        inputs = [ctx.outputs.rpm],
-        outputs = [ctx.outputs.out],
+    ctx.actions.symlink(
+        output = ctx.outputs.out,
+        target_file = ctx.outputs.rpm
     )
 
-    # Link the RPM to the RPM-recommended output name.
+    # Link the RPM to the RPM-recommended output name if possible.
     if "rpm_nvra" in dir(ctx.outputs):
-        ctx.actions.run(
-            executable = "ln",
-            arguments = [
-                "-s",
-                ctx.outputs.rpm.basename,
-                ctx.outputs.rpm_nvra.path,
-            ],
-            inputs = [ctx.outputs.rpm],
-            outputs = [ctx.outputs.rpm_nvra],
+        ctx.actions.symlink(
+            output = ctx.outputs.rpm_nvra,
+            target_file = ctx.outputs.rpm
         )
 
 def _pkg_rpm_outputs(version, release):


### PR DESCRIPTION
Like #232, but in the RPM builders.  No other callouts to `ln(1)` are made
directly by `rules_pkg`.