### PR TITLE
Provide providers for new packaging rule interfaces

### DIFF
--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -77,9 +77,5 @@ PackageFilegroupInfo = provider(
         "pkg_files": "list of child PackageFilesInfo providers",
         "pkg_dirs": "list of child PackageDirInfo providers",
         "pkg_symlinks": "list of child PackageSymlinkInfo providers",
-
-        # TODO: does this really belong here?  Seems like the rerooting should
-        # just be done by the rule that creates this provider.
-        "prefix": """string: Base path of all the destinations in the 'children' attribute""",
     },
 )

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -74,7 +74,9 @@ PackageSymlinkInfo = provider(
 PackageFilegroupInfo = provider(
     doc = """Provider representing a collection of related packaging providers""",
     fields = {
-        "children": """list of child providers, one of PackageFilesInfo, PackageDirInfo, or PackageSymlinkInfo""",
+        "pkg_files": "list of child PackageFilesInfo providers",
+        "pkg_dirs": "list of child PackageDirInfo providers",
+        "pkg_symlinks": "list of child PackageSymlinkInfo providers",
 
         # TODO: does this really belong here?  Seems like the rerooting should
         # just be done by the rule that creates this provider.

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -14,12 +14,11 @@
 
 """Packaging related providers."""
 
-
 PackageArtifactInfo = provider(
     doc = """Metadata about a package artifact.""",
     fields = {
-        "label": "Label which produced it",
         "file_name": "The file name of the artifact.",
+        "label": "Label which produced it",
     },
 )
 
@@ -27,5 +26,71 @@ PackageVariablesInfo = provider(
     doc = """Variables which may be substituted into package names and content.""",
     fields = {
         "values": "Dict of name/value pairs",
+    },
+)
+
+# For the below, attributes always look something like this:
+#
+# ```
+#   {"unix": ["0755", "root", "root"]}
+# ```
+#
+
+# TODO: should all of these be singluar or plural?
+#
+# Seems like there's no harm in specifying a plural, even in rules: it would
+# allow some degree of simplification of rules without needing to specify a
+# custom manifest.
+
+# TODO: should we note exceptions from groups of files/labels?  I feel that
+# information is best encoded at the rule level, which seems to necessitate a
+# "plural" structure as defined below.
+PackageFilesInfo = provider(
+    doc = """Provider representing the installation of one or more files to destination with attributes""",
+    fields = {
+        "attributes": """dict of string -> string list: Attributes to apply to installed file(s)""",
+        "source_dest_map": """dict of File -> string: source-destination map""",
+    },
+)
+
+PackageDirInfo = provider(
+    doc = """Provider representing the creation of a single directory in a package""",
+    fields = {
+        "attributes": """dict of string -> string list: Attributes to apply to created directory""",
+        "destination": """string: Installed directory name""",
+    },
+)
+
+PackageSymlinkInfo = provider(
+    doc = """Provider representing the creation of a single symbolic link in a package""",
+    fields = {
+        "attributes": """dict of string -> string list: Attributes to apply to created symlink""",
+        "destination": """string: Filesystem link 'name'""",
+        "source": """string: Filesystem link 'target'""",
+    },
+)
+
+# Grouping provider: the only one that needs to be consumed by packaging (or
+# other) rules that materialize paths.
+
+PackageFilegroupInfo = provider(
+    doc = """Provider representing a collection of related packaging providers""",
+    fields = {
+        "children": """list of child providers, one of PackageFilesInfo, PackageDirInfo, or PackageSymlinkInfo""",
+
+        # TODO: does this really belong here?  Seems like the rerooting should
+        # just be done by the rule that creates this provider.
+        "prefix": """string: Base path of all the destinations in the 'children' attribute""",
+
+        # TODO: I'm increasingly unsure of where "section" should go.  From a
+        # high-level view, it makes sense that a "section" applies to a grouping
+        # of files, but it's hard to tell what a "section" actually is.
+        #
+        # For example, one can imagine a section of "documentation", or
+        # "config," files but then each "config" file may have different
+        # properties, but are still "config" files.
+        #
+        # Feels clumsy to me.
+        "section": """string: related file properties, such as "config", "config(noreplace)", "config(missingok)", "doc" """,
     },
 )

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -36,26 +36,25 @@ PackageVariablesInfo = provider(
 # ```
 #
 
-# TODO: should all of these be singluar or plural?
-#
-# Seems like there's no harm in specifying a plural, even in rules: it would
-# allow some degree of simplification of rules without needing to specify a
-# custom manifest.
 PackageFilesInfo = provider(
     doc = """Provider representing the installation of one or more files to destination with attributes""",
     fields = {
         "attributes": """dict of string -> string list: Attributes to apply to installed file(s)""",
-        # TODO(nacl): determine what types actually should represent the sources here.  Files, or Labels?
-        # TODO(nacl): Should this be a map of destination -> source instead?
-        "source_dest_map": """Map of file sources to destinations""",
+        # TODO(nacl): determine what types actually should represent the sources
+        # here.  Files, or Labels?
+
+        # This is a mapping of destinations to sources to allow for the same
+        # target to be installed to multiple locations within a package within a
+        # single provider.
+        "dest_src_map": """Map of file destinations to sources""",
     },
 )
 
-PackageDirInfo = provider(
-    doc = """Provider representing the creation of a single directory in a package""",
+PackageDirsInfo = provider(
+    doc = """Provider representing the creation of one or more directories in a package""",
     fields = {
-        "attributes": """dict of string -> string list: Attributes to apply to created directory""",
-        "destination": """string: Installed directory name""",
+        "attributes": """dict of string -> string list: Attributes to apply to created directories""",
+        "dirs": """string list: installed directory names""",
     },
 )
 
@@ -64,13 +63,12 @@ PackageSymlinkInfo = provider(
     fields = {
         "attributes": """dict of string -> string list: Attributes to apply to created symlink""",
         "destination": """string: Filesystem link 'name'""",
-        "source": """string: Filesystem link 'target'""",
+        "source": """string or Label: Filesystem link 'target'""",
     },
 )
 
 # Grouping provider: the only one that needs to be consumed by packaging (or
 # other) rules that materialize paths.
-
 PackageFilegroupInfo = provider(
     doc = """Provider representing a collection of related packaging providers""",
     fields = {

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -41,15 +41,13 @@ PackageVariablesInfo = provider(
 # Seems like there's no harm in specifying a plural, even in rules: it would
 # allow some degree of simplification of rules without needing to specify a
 # custom manifest.
-
-# TODO: should we note exceptions from groups of files/labels?  I feel that
-# information is best encoded at the rule level, which seems to necessitate a
-# "plural" structure as defined below.
 PackageFilesInfo = provider(
     doc = """Provider representing the installation of one or more files to destination with attributes""",
     fields = {
         "attributes": """dict of string -> string list: Attributes to apply to installed file(s)""",
-        "source_dest_map": """dict of File -> string: source-destination map""",
+        # TODO(nacl): determine what types actually should represent the sources here.  Files, or Labels?
+        # TODO(nacl): Should this be a map of destination -> source instead?
+        "source_dest_map": """Map of file sources to destinations""",
     },
 )
 
@@ -81,16 +79,5 @@ PackageFilegroupInfo = provider(
         # TODO: does this really belong here?  Seems like the rerooting should
         # just be done by the rule that creates this provider.
         "prefix": """string: Base path of all the destinations in the 'children' attribute""",
-
-        # TODO: I'm increasingly unsure of where "section" should go.  From a
-        # high-level view, it makes sense that a "section" applies to a grouping
-        # of files, but it's hard to tell what a "section" actually is.
-        #
-        # For example, one can imagine a section of "documentation", or
-        # "config," files but then each "config" file may have different
-        # properties, but are still "config" files.
-        #
-        # Feels clumsy to me.
-        "section": """string: related file properties, such as "config", "config(noreplace)", "config(missingok)", "doc" """,
     },
 )


### PR DESCRIPTION
This change provides a set of three providers that can be used to represent
actions, and one that can represent a group of related actions.

These are intended to be used in rules like the `pkg_filegroup` interfaces used
in pkg/experimental, but with more flexibility and standardization.

`buildifier` was also applied opportunistically.

These are based on the comments discussed in our call earlier this week.

NOTE: there are still some points I would like to iron out, marked as TODO's in the code.  Nothing too terribly complicated, but they do impact the "meaning" behind some of the fields.