### PR TITLE
Add capability for a mirror url to print_rel_notes()

### DIFF
--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -39,8 +39,10 @@ print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
     deps_method = "rules_pkg_dependencies",
+    org = 'bazelbuild',
     repo = "rules_pkg",
     version = version,
+    mirror_host = 'mirror.bazel.build'
 )
 
 py_test(

--- a/pkg/releasing/defs.bzl
+++ b/pkg/releasing/defs.bzl
@@ -1,10 +1,12 @@
 
 
 def print_rel_notes(name, repo, version, outs=None, setup_file="",
-                    deps_method="", toolchains_method=""):
+                    deps_method="", toolchains_method="", org="bazelbuild",
+                    mirror_host=None):
     tarball_name = ":%s-%s.tar.gz" % (repo, version)
     cmd = [
         "$(location //releasing:print_rel_notes)",
+        "--org=%s" % org,
         "--repo=%s" % repo,
         "--version=%s" % version,
         "--tarball=$(location %s)" % tarball_name,
@@ -15,6 +17,8 @@ def print_rel_notes(name, repo, version, outs=None, setup_file="",
       cmd.append("--deps_method=%s" % deps_method)
     if toolchains_method:
       cmd.append("--toolchains_method=%s" % toolchains_method)
+    if mirror_host:
+      cmd.append("--mirror_host=%s" % mirror_host)
     cmd.append(">$@")
     native.genrule(
         name = "relnotes",

--- a/pkg/releasing/release_tools.py
+++ b/pkg/releasing/release_tools.py
@@ -25,7 +25,9 @@ WORKSPACE_STANZA_TEMPLATE = Template(textwrap.dedent(
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
         name = "${repo}",
-        url = "${url}",
+        urls = [
+            ${urls},
+        ],
         sha256 = "${sha256}",
     )
     """).strip())
@@ -52,9 +54,10 @@ def workspace_content(
     url,
     repo,
     sha256,
+    deps_method=None,
+    mirror_url=None,
     rename_repo=None,
     setup_file=None,
-    deps_method=None,
     toolchains_method=None):
   # Create the WORKSPACE stanza needed for this rule set.
   if setup_file and not (deps_method or toolchains_method):
@@ -78,8 +81,13 @@ def workspace_content(
   # Correct the common mistake of not putting a ':' in your setup file name
   if setup_file and ':' not in setup_file:
     setup_file = ':' + setup_file
+  if mirror_url:
+    # this could be more elegant
+    urls = '"%s",\n        "%s"' % (mirror_url, url)
+  else:
+    urls = '"%s"' % url
   ret = WORKSPACE_STANZA_TEMPLATE.substitute({
-      'url': url,
+      'urls': urls,
       'sha256': sha256,
       'repo': repo,
   })

--- a/pkg/releasing/release_tools_test.py
+++ b/pkg/releasing/release_tools_test.py
@@ -69,6 +69,18 @@ class ReleaseToolsTest(unittest.TestCase):
         sha256='@computed@')
     self.assertTrue(content.find('\nload("@foo_bar') < 0)
 
+  def test_workspace_content_mirror(self):
+    content = release_tools.workspace_content(
+        url='http://github.com/foo/bar',
+        mirror_url='http://mirror/github.com/foo/bar',
+        repo='foo-bar',
+        sha256='@computed@')
+    url_pos = content.find('http://github.com/foo/bar')
+    mirror_pos = content.find('http://mirror/github.com/foo/bar')
+    self.assertTrue(url_pos > 0)
+    self.assertTrue(mirror_pos > 0)
+    self.assertTrue(mirror_pos < url_pos)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add capability for a mirror url to print_rel_notes()
- Adds the mirror url to the sample WORKSPACE stanza.
- Adds a note to remind you to push to the mirror with a sample command.
  The command assumes you use gsutil and want to match the path of URLs
  in the same way the Bazel team does for their dependencies. This is an
  incomplete solution, but it covers a lot of uses with minimal effort.

Example:
```
**WORKSPACE setup**

` ` `
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "rules_pkg",
    urls = [
        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
        "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
    ],
    sha256 = "c74b78ad96ad808a3231cc7fb13af4deb5d944d43de07fdff16b49bb9f5ead5d",
)
load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
rules_pkg_dependencies()
` ` `

**Using the rules**

See [the source](https://github.com/bazelbuild/rules_pkg/tree/0.3.0).
------------------------ snip ----------------------------
!!!: Make sure to copy the file to the release notes.
If you are using Google Cloud Storage, you might use a command like
gsutil cp bazel-bin/distro/rules_pkg-0.3.0.tar.gz gs://bazel-mirror/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz
```

RELNOTES:
Add `mirror_host` attribute to `print_rel_notes`.
If specified, the example WORKSPACE stanza will contain a second URL in the
style used by most bazel packages. That is, if the package url is
`https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz`
then the mirror url will be
`https://$MIRROR_HOST/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz`