### PR TITLE
Lint fixes. No functional changes

### DIFF
--- a/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
+++ b/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Register a prebuilt rpmbuild.""".
 
+# buildifier: disable=unnamed-macro
 def register_my_rpmbuild_toolchain():
+    """Register a prebuilt rpmbuild.""".
     native.register_toolchains("//local:local_rpmbuild")

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -16,14 +16,11 @@
 import argparse
 import json
 import os
-import os.path
-import sys
 import tarfile
 import tempfile
 
 import archive
-
-from helpers import GetFlagValue, SplitNameValuePairAtSeparator
+import helpers
 
 
 class TarFile(object):
@@ -196,6 +193,7 @@ class TarFile(object):
       self.add_tar(tmpfile[1])
       os.remove(tmpfile[1])
 
+
 def main():
   parser = argparse.ArgumentParser(
       description='Helper for building tar packages',
@@ -224,8 +222,8 @@ def main():
   parser.add_argument('--deb', action='append',
                       help='A debian package to add to the layer')
   parser.add_argument(
-    '--link', action='append',
-    help='Add a symlink a inside the layer pointing to b if a:b is specified')
+      '--link', action='append',
+      help='Add a symlink a inside the layer pointing to b if a:b is specified')
   # TODO(aiuto): Add back in the validation
   # flags.register_validator(
   #   'link',
@@ -237,24 +235,24 @@ def main():
   parser.add_argument('--compression',
                       help='Compression (`gz` or `bz2`), default is none.')
   parser.add_argument(
-    '--modes', action='append',
-    help='Specific mode to apply to specific file (from the file argument),'
-         ' e.g., path/to/file=0455.')
+      '--modes', action='append',
+      help='Specific mode to apply to specific file (from the file argument),'
+           ' e.g., path/to/file=0455.')
   parser.add_argument(
-    '--owners', action='append',
-    help='Specify the numeric owners of individual files, '
-         'e.g. path/to/file=0.0.')
+      '--owners', action='append',
+      help='Specify the numeric owners of individual files, '
+           'e.g. path/to/file=0.0.')
   parser.add_argument(
-    '--owner', default='0.0',
-    help='Specify the numeric default owner of all files,'
-         ' e.g., 0.0')
+      '--owner', default='0.0',
+      help='Specify the numeric default owner of all files,'
+           ' e.g., 0.0')
   parser.add_argument(
       '--owner_name',
       help='Specify the owner name of all files, e.g. root.root.')
   parser.add_argument(
-    '--owner_names', action='append',
-    help='Specify the owner names of individual files, e.g. '
-         'path/to/file=root.root.')
+      '--owner_names', action='append',
+      help='Specify the owner names of individual files, e.g. '
+           'path/to/file=root.root.')
   parser.add_argument('--root_directory', default='./',
                       help='Default root directory is named "."')
   options = parser.parse_args()
@@ -268,7 +266,7 @@ def main():
   mode_map = {}
   if options.modes:
     for filemode in options.modes:
-      (f, mode) = SplitNameValuePairAtSeparator(filemode, '=')
+      (f, mode) = helpers.SplitNameValuePairAtSeparator(filemode, '=')
       if f[0] == '/':
         f = f[1:]
       mode_map[f] = int(mode, 8)
@@ -279,7 +277,7 @@ def main():
   names_map = {}
   if options.owner_names:
     for file_owner in options.owner_names:
-      (f, owner) = SplitNameValuePairAtSeparator(file_owner, '=')
+      (f, owner) = helpers.SplitNameValuePairAtSeparator(file_owner, '=')
       (user, group) = owner.split('.', 1)
       if f[0] == '/':
         f = f[1:]
@@ -290,7 +288,7 @@ def main():
   ids_map = {}
   if options.owners:
     for file_owner in options.owners:
-      (f, owner) = SplitNameValuePairAtSeparator(file_owner, '=')
+      (f, owner) = helpers.SplitNameValuePairAtSeparator(file_owner, '=')
       (user, group) = owner.split('.', 1)
       if f[0] == '/':
         f = f[1:]
@@ -298,7 +296,7 @@ def main():
 
   # Add objects to the tar file
   with TarFile(
-      options.output, GetFlagValue(options.directory),
+      options.output, helpers.GetFlagValue(options.directory),
       options.compression, options.root_directory, options.mtime) as output:
 
     def file_attributes(filename):
@@ -329,7 +327,7 @@ def main():
           output.add_deb(deb)
 
     for f in options.file or []:
-      (inf, tof) = SplitNameValuePairAtSeparator(f, '=')
+      (inf, tof) = helpers.SplitNameValuePairAtSeparator(f, '=')
       output.add_file(inf, tof, **file_attributes(tof))
     for f in options.empty_file or []:
       output.add_empty_file(f, **file_attributes(f))
@@ -342,7 +340,7 @@ def main():
     for deb in options.deb or []:
       output.add_deb(deb)
     for link in options.link or []:
-      l = SplitNameValuePairAtSeparator(link, ':')
+      l = helpers.SplitNameValuePairAtSeparator(link, ':')
       output.add_link(l[0], l[1])
 
 

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -16,9 +16,8 @@
 import argparse
 import gzip
 import hashlib
-from io import BytesIO
+import io
 import os
-import os.path
 import sys
 import tarfile
 import textwrap
@@ -95,7 +94,7 @@ def AddArFileEntry(fileobj, filename,
   """Add a AR file entry to fileobj."""
   # If we got the content as a string, turn it into a file like thing.
   if isinstance(content, (str, bytes)):
-    content_len, content = ConvertToFileLike(content, content_len, BytesIO)
+    content_len, content = ConvertToFileLike(content, content_len, io.BytesIO)
   inputs = [
       (filename + '/').ljust(16),  # filename (SysV)
       str(timestamp).ljust(12),  # timestamp
@@ -145,21 +144,21 @@ def CreateDebControl(extrafiles=None, **kwargs):
     if values[1] or (key in kwargs and kwargs[key]):
       controlfile += MakeDebianControlField(fieldname, kwargs[key], values[2])
   # Create the control.tar file
-  tar = BytesIO()
+  tar = io.BytesIO()
   with gzip.GzipFile('control.tar.gz', mode='w', fileobj=tar, mtime=0) as gz:
     with tarfile.open('control.tar.gz', mode='w', fileobj=gz,
                       format=tarfile.GNU_FORMAT) as f:
       tarinfo = tarfile.TarInfo('./control')
       control_file_data = controlfile.encode('utf-8')
       tarinfo.size = len(control_file_data)
-      f.addfile(tarinfo, fileobj=BytesIO(control_file_data))
+      f.addfile(tarinfo, fileobj=io.BytesIO(control_file_data))
       if extrafiles:
         for name, (data, mode) in extrafiles.items():
           tarinfo = tarfile.TarInfo('./' + name)
           data_encoded = data.encode('utf-8')
           tarinfo.size = len(data_encoded)
           tarinfo.mode = mode
-          f.addfile(tarinfo, fileobj=BytesIO(data_encoded))
+          f.addfile(tarinfo, fileobj=io.BytesIO(data_encoded))
   control = tar.getvalue()
   tar.close()
   return control

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -347,6 +347,8 @@ def pkg_tar(name, **kwargs):
         if "files" in kwargs:
             if not hasattr(kwargs["files"], "items"):
                 label = "%s//%s:%s" % (native.repository_name(), native.package_name(), kwargs["name"])
+
+                # buildifier: disable=print
                 print("%s: you provided a non dictionary to the pkg_tar `files` attribute. " % (label,) +
                       "This attribute was renamed to `srcs`. " +
                       "Consider renaming it in your BUILD file.")
@@ -356,6 +358,8 @@ def pkg_tar(name, **kwargs):
     if archive_name:
         if kwargs.get("package_file_name"):
             fail("You may not set both archive_name and package_file_name")
+
+        # buildifier: disable=print
         print("archive_name is deprecated. Use package_file_name instead.")
         kwargs["package_file_name"] = archive_name + "." + extension
     pkg_tar_impl(

--- a/pkg/releasing/defs.bzl
+++ b/pkg/releasing/defs.bzl
@@ -1,8 +1,13 @@
-
-
-def print_rel_notes(name, repo, version, outs=None, setup_file="",
-                    deps_method="", toolchains_method="", org="bazelbuild",
-                    mirror_host=None):
+def print_rel_notes(
+        name,
+        repo,
+        version,
+        outs = None,
+        setup_file = "",
+        deps_method = "",
+        toolchains_method = "",
+        org = "bazelbuild",
+        mirror_host = None):
     tarball_name = ":%s-%s.tar.gz" % (repo, version)
     cmd = [
         "$(location //releasing:print_rel_notes)",
@@ -12,13 +17,13 @@ def print_rel_notes(name, repo, version, outs=None, setup_file="",
         "--tarball=$(location %s)" % tarball_name,
     ]
     if setup_file:
-      cmd.append("--setup_file=%s" % setup_file)
+        cmd.append("--setup_file=%s" % setup_file)
     if deps_method:
-      cmd.append("--deps_method=%s" % deps_method)
+        cmd.append("--deps_method=%s" % deps_method)
     if toolchains_method:
-      cmd.append("--toolchains_method=%s" % toolchains_method)
+        cmd.append("--toolchains_method=%s" % toolchains_method)
     if mirror_host:
-      cmd.append("--mirror_host=%s" % mirror_host)
+        cmd.append("--mirror_host=%s" % mirror_host)
     cmd.append(">$@")
     native.genrule(
         name = "relnotes",

--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -62,7 +62,12 @@ def print_notes(org, repo, version, tarball_path, mirror_host=None,
   }))
   if mirror_url:
     file = os.path.basename(tarball_path)
-    path = 'github.com/${org}/${repo}/releases/download/${version}/${file}'
+    path = 'github.com/{org}/{repo}/releases/download/{version}/{file}'.format(
+        org=org,
+        repo=repo,
+        version=version,
+        file=file
+    )
     mirroring_template = string.Template(textwrap.dedent(
         """
 

--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -17,8 +17,7 @@
 
 import argparse
 import os
-import sys
-from string import Template
+import string
 import textwrap
 
 from releasing import release_tools
@@ -36,7 +35,7 @@ def print_notes(org, repo, version, tarball_path, mirror_host=None,
   workspace_stanza = release_tools.workspace_content(
       url, repo, sha256, mirror_url=mirror_url, setup_file=setup_file,
       deps_method=deps_method, toolchains_method=toolchains_method)
-  relnotes_template = Template(textwrap.dedent(
+  relnotes_template = string.Template(textwrap.dedent(
       """
       ------------------------ snip ----------------------------
       **New Features**
@@ -64,20 +63,21 @@ def print_notes(org, repo, version, tarball_path, mirror_host=None,
   if mirror_url:
     file = os.path.basename(tarball_path)
     path = 'github.com/${org}/${repo}/releases/download/${version}/${file}'
-    mirroring_template = Template(textwrap.dedent(
+    mirroring_template = string.Template(textwrap.dedent(
         """
 
         !!!: Make sure to copy the file to the release notes.
         If you are using Google Cloud Storage, you might use a command like
-        gsutil cp bazel-bin/distro/${file} gs://bazel-mirror/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/${file}
+        gsutil cp bazel-bin/distro/${file} gs://bazel-mirror/${path}
         """).strip())
     print(mirroring_template.substitute({
-      'org': org,
-      'repo': repo,
-      'version': version,
-      'file': file,
+        'org': org,
+        'repo': repo,
+        'version': version,
+        'file': file,
+        'path': path,
     }))
-    
+
 
 def main():
   parser = argparse.ArgumentParser(

--- a/pkg/releasing/release_tools.py
+++ b/pkg/releasing/release_tools.py
@@ -14,13 +14,12 @@
 """Utilities to help create a rule set release."""
 
 import hashlib
-import os
-from string import Template
+import string
 import sys
 import textwrap
 
 
-WORKSPACE_STANZA_TEMPLATE = Template(textwrap.dedent(
+WORKSPACE_STANZA_TEMPLATE = string.Template(textwrap.dedent(
     """
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
@@ -33,11 +32,10 @@ WORKSPACE_STANZA_TEMPLATE = Template(textwrap.dedent(
     """).strip())
 
 
-DEPS_STANZA_TEMPLATE = Template(textwrap.dedent(
+DEPS_STANZA_TEMPLATE = string.Template(textwrap.dedent(
     """
     load("@${repo}//${setup_file}", ${to_load})
     """).strip())
-
 
 
 def package_basename(repo, version):
@@ -61,12 +59,12 @@ def workspace_content(
     toolchains_method=None):
   # Create the WORKSPACE stanza needed for this rule set.
   if setup_file and not (deps_method or toolchains_method):
-      print(
-            "setup_file can only be set if at least one of (deps_method, toolchains_method) is set.",
-            flush=True,
-            file=sys.stderr,
-      )
-      sys.exit(1)
+    print(
+        'setup_file can only be set if at least one of (deps_method, toolchains_method) is set.',
+        flush=True,
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
   methods = []
   if deps_method:
@@ -97,7 +95,7 @@ def workspace_content(
         'setup_file': setup_file or ':deps.bzl',
         'to_load': ', '.join('"%s"' % m for m in methods),
     })
-    ret += "\n%s\n" % deps
+    ret += '\n%s\n' % deps
 
   for m in methods:
     ret += '%s()\n' % m

--- a/pkg/releasing/release_tools_test.py
+++ b/pkg/releasing/release_tools_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import filecmp
-import os
 import unittest
 
 import release_tools
@@ -80,5 +78,5 @@ class ReleaseToolsTest(unittest.TestCase):
     self.assertLess(mirror_pos, url_pos)
 
 
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == '__main__':
+  unittest.main()

--- a/pkg/releasing/release_tools_test.py
+++ b/pkg/releasing/release_tools_test.py
@@ -29,12 +29,12 @@ class ReleaseToolsTest(unittest.TestCase):
         setup_file='my_setup.bzl',
         deps_method='my_deps',
         toolchains_method='my_tools')
-    self.assertTrue(content.find(' name = "foo_bar",') > 0, content)
-    self.assertTrue(content.find(
-        '\nload("@foo_bar//:my_setup.bzl", "my_deps", "my_tools")\n') > 0,
-        content)
-    self.assertTrue(content.find('\nmy_deps()\n') > 0)
-    self.assertTrue(content.find('\nmy_tools()\n') > 0, content)
+    self.assertGreater(content.find(' name = "foo_bar",'), 0, content)
+    self.assertGreater(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_deps", "my_tools")\n'), 0,
+                       content)
+    self.assertGreater(content.find('\nmy_deps()\n'), 0)
+    self.assertGreater(content.find('\nmy_tools()\n'), 0, content)
 
   def test_workspace_content_notools(self):
     content = release_tools.workspace_content(
@@ -43,11 +43,10 @@ class ReleaseToolsTest(unittest.TestCase):
         sha256='@computed@',
         setup_file='my_setup.bzl',
         deps_method='my_deps')
-    self.assertTrue(content.find(
-        '\nload("@foo_bar//:my_setup.bzl", "my_deps")\n') > 0,
-        content)
-    self.assertTrue(content.find('\nmy_deps()\n') > 0)
-    self.assertTrue(content.find('\nmy_tools()\n') < 0)
+    self.assertGreater(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_deps")\n'), 0, content)
+    self.assertGreater(content.find('\nmy_deps()\n'), 0)
+    self.assertLess(content.find('\nmy_tools()\n'), 0)
 
   def test_workspace_content_nodeps(self):
     content = release_tools.workspace_content(
@@ -56,18 +55,17 @@ class ReleaseToolsTest(unittest.TestCase):
         sha256='@computed@',
         setup_file='my_setup.bzl',
         toolchains_method='my_tools')
-    self.assertTrue(content.find(
-        '\nload("@foo_bar//:my_setup.bzl", "my_tools")\n') > 0,
-        content)
-    self.assertTrue(content.find('\nmy_deps()\n') < 0)
-    self.assertTrue(content.find('\nmy_tools()\n') > 0)
+    self.assertGreater(content.find(
+        '\nload("@foo_bar//:my_setup.bzl", "my_tools")\n'), 0, content)
+    self.assertLess(content.find('\nmy_deps()\n'), 0)
+    self.assertGreater(content.find('\nmy_tools()\n'), 0)
 
   def test_workspace_content_minimal(self):
     content = release_tools.workspace_content(
         url='http://github.com',
         repo='foo-bar',
         sha256='@computed@')
-    self.assertTrue(content.find('\nload("@foo_bar') < 0)
+    self.assertLess(content.find('\nload("@foo_bar'), 0)
 
   def test_workspace_content_mirror(self):
     content = release_tools.workspace_content(
@@ -77,9 +75,9 @@ class ReleaseToolsTest(unittest.TestCase):
         sha256='@computed@')
     url_pos = content.find('http://github.com/foo/bar')
     mirror_pos = content.find('http://mirror/github.com/foo/bar')
-    self.assertTrue(url_pos > 0)
-    self.assertTrue(mirror_pos > 0)
-    self.assertTrue(mirror_pos < url_pos)
+    self.assertGreater(url_pos, 0)
+    self.assertGreater(mirror_pos, 0)
+    self.assertLess(mirror_pos, url_pos)
 
 
 if __name__ == "__main__":

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -37,13 +37,15 @@ def _pkg_rpm_impl(ctx):
 
     if ctx.attr.rpmbuild_path:
         args += ["--rpmbuild=" + ctx.attr.rpmbuild_path]
-        print('rpmbuild_path is deprecated. See the README for instructions on how'
-              + ' to migrate to toolchains')
+
+        # buildifier: disable=print
+        print("rpmbuild_path is deprecated. See the README for instructions on how" +
+              " to migrate to toolchains")
     else:
         toolchain = ctx.toolchains["@rules_pkg//toolchains:rpmbuild_toolchain_type"].rpmbuild
         if not toolchain.valid:
-            fail("The rpmbuild_toolchain is not properly configured: "
-                 + toolchain.name)
+            fail("The rpmbuild_toolchain is not properly configured: " +
+                 toolchain.name)
         if toolchain.path:
             args += ["--rpmbuild=" + toolchain.path]
         else:

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -32,12 +32,12 @@ class SimpleArFileTest(unittest.TestCase):
     """Assert that arfile contains exactly the entry described by `content`.
 
     Args:
-        arfile: the path to the AR file to test.
-        content: an array describing the expected content of the AR file.
-            Each entry in that list should be a dictionary where each field
-            is a field to test in the corresponding SimpleArFileEntry. For
-            testing the presence of a file "x", then the entry could simply
-            be `{"filename": "x"}`, the missing field will be ignored.
+      arfile: the path to the AR file to test.
+      content: an array describing the expected content of the AR file.
+          Each entry in that list should be a dictionary where each field
+          is a field to test in the corresponding SimpleArFileEntry. For
+          testing the presence of a file "x", then the entry could simply
+          be `{"filename": "x"}`, the missing field will be ignored.
     """
     print("READING: %s" % arfile)
     with archive.SimpleArFile(arfile) as f:

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -14,18 +14,18 @@
 """Testing for archive."""
 
 import os
-import os.path
 import tarfile
 import unittest
 
-from rules_pkg import archive
 from bazel_tools.tools.python.runfiles import runfiles
+from rules_pkg import archive
 
 
 class SimpleArFileTest(unittest.TestCase):
   """Testing for SimpleArFile class."""
 
   def setUp(self):
+    super(SimpleArFileTest, self).setUp()
     self.data_files = runfiles.Create()
 
   def assertArFileContent(self, arfile, content):
@@ -48,7 +48,7 @@ class SimpleArFileTest(unittest.TestCase):
             arfile,
             current.filename
             )
-        self.assertTrue(i < len(content), error_msg)
+        self.assertLess(i, len(content), error_msg)
         for k, v in content[i].items():
           value = getattr(current, k)
           error_msg = " ".join([
@@ -71,6 +71,7 @@ class SimpleArFileTest(unittest.TestCase):
   def assertSimpleFileContent(self, names):
     datafile = self.data_files.Rlocation(
         os.path.join("rules_pkg", "tests", "testdata", "_".join(names) + ".ar"))
+    # pylint: disable=g-complex-comprehension
     content = [{"filename": n,
                 "size": len(n.encode("utf-8")),
                 "data": n.encode("utf-8")}
@@ -118,7 +119,7 @@ class TarFileWriterTest(unittest.TestCase):
             tar,
             current.name
             )
-        self.assertTrue(i < len(content), error_msg)
+        self.assertLess(i, len(content), error_msg)
         for k, v in content[i].items():
           if k == "data":
             value = f.extractfile(current).read()
@@ -135,10 +136,12 @@ class TarFileWriterTest(unittest.TestCase):
         self.fail("Missing file %s in archive %s" % (content[i], tar))
 
   def setUp(self):
+    super(TarFileWriterTest, self).setUp()
     self.tempfile = os.path.join(os.environ["TEST_TMPDIR"], "test.tar")
     self.data_files = runfiles.Create()
 
   def tearDown(self):
+    super(TarFileWriterTest, self).tearDown()
     if os.path.exists(self.tempfile):
       os.remove(self.tempfile)
 
@@ -151,6 +154,7 @@ class TarFileWriterTest(unittest.TestCase):
     with archive.TarFileWriter(self.tempfile) as f:
       for n in names:
         f.add_file(n, content=n)
+    # pylint: disable=g-complex-comprehension
     content = ([{"name": "."}] +
                [{"name": n,
                  "size": len(n.encode("utf-8")),
@@ -209,8 +213,8 @@ class TarFileWriterTest(unittest.TestCase):
         ]
     for ext in ["", ".gz", ".bz2", ".xz"]:
       with archive.TarFileWriter(self.tempfile) as f:
-        datafile = self.data_files.Rlocation(
-            os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar" + ext))
+        datafile = self.data_files.Rlocation(os.path.join(
+            "rules_pkg", "tests", "testdata", "tar_test.tar" + ext))
         f.add_tar(datafile, name_filter=lambda n: n != "./b")
       self.assertTarFileContent(self.tempfile, content)
 
@@ -371,25 +375,25 @@ class TarFileWriterTest(unittest.TestCase):
     self.assertTarFileContent(self.tempfile, content)
 
   def testPackageDirFileAttribute(self):
-      """
-      Test package_dir and package_dir_file attributes of pkg_tar
+    """Tests package_dir and package_dir_file attributes of pkg_tar.
 
-      Verifies that passing package_dir (string) and package_dir_file(label)
-      to pkg_tar yields identical results
-      """
-      package_dir = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir.tar"))
-      package_dir_file = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir_file.tar"))
+    Verifies that passing package_dir (string) and package_dir_file(label) to
+    pkg_tar yields identical results.
+    """
+    package_dir = self.data_files.Rlocation(
+        os.path.join("rules_pkg", "tests", "test_tar_package_dir.tar"))
+    package_dir_file = self.data_files.Rlocation(
+        os.path.join("rules_pkg", "tests", "test_tar_package_dir_file.tar"))
 
-      expected_content = [
-          {'name': '.'},
-          {'name': './package'},
-          {'name': './package/nsswitch.conf'},
-      ]
+    expected_content = [
+        {"name": "."},
+        {"name": "./package"},
+        {"name": "./package/nsswitch.conf"},
+    ]
 
-      self.assertTarFileContent(package_dir, expected_content)
-      self.assertTarFileContent(package_dir_file, expected_content)
+    self.assertTarFileContent(package_dir, expected_content)
+    self.assertTarFileContent(package_dir_file, expected_content)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/pkg/tests/helpers_test.py
+++ b/pkg/tests/helpers_test.py
@@ -12,85 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import tempfile
+import unittest
+
 import helpers
 
 
 class GetFlagValueTestCase(unittest.TestCase):
-    def testNonStripped(self):
-        self.assertEqual(helpers.GetFlagValue('value ', strip=False), 'value ')
 
-    def testStripped(self):
-        self.assertEqual(helpers.GetFlagValue('value ', strip=True), 'value')
+  def testNonStripped(self):
+    self.assertEqual(helpers.GetFlagValue('value ', strip=False), 'value ')
 
-    def testNonStripped_fromFile(self):
-        with tempfile.NamedTemporaryFile() as f:
-            f.write(b'value ')
-            f.flush()
-            self.assertEqual(helpers.GetFlagValue(
-                '@{}'.format(f.name),
-                strip=False), 'value ')
+  def testStripped(self):
+    self.assertEqual(helpers.GetFlagValue('value ', strip=True), 'value')
 
-    def testStripped_fromFile(self):
-        with tempfile.NamedTemporaryFile() as f:
-            f.write(b'value ')
-            f.flush()
-            self.assertEqual(helpers.GetFlagValue(
-                '@{}'.format(f.name),
-                strip=True), 'value')
+  def testNonStripped_fromFile(self):
+    with tempfile.NamedTemporaryFile() as f:
+      f.write(b'value ')
+      f.flush()
+      self.assertEqual(helpers.GetFlagValue(
+          '@{}'.format(f.name),
+          strip=False), 'value ')
+
+  def testStripped_fromFile(self):
+    with tempfile.NamedTemporaryFile() as f:
+      f.write(b'value ')
+      f.flush()
+      self.assertEqual(helpers.GetFlagValue(
+          '@{}'.format(f.name),
+          strip=True), 'value')
+
 
 class SplitNameValuePairAtSeparatorTestCase(unittest.TestCase):
-    def testNoSep(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('abc', '=')
 
-        self.assertEqual(key, 'abc')
-        self.assertEqual(val, '')
+  def testNoSep(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('abc', '=')
+    self.assertEqual(key, 'abc')
+    self.assertEqual(val, '')
 
-    def testNoSepWithEscape(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('a\\=bc', '=')
+  def testNoSepWithEscape(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('a\\=bc', '=')
+    self.assertEqual(key, 'a=bc')
+    self.assertEqual(val, '')
 
-        self.assertEqual(key, 'a=bc')
-        self.assertEqual(val, '')
+  def testNoSepWithDanglingEscape(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('abc\\', '=')
+    self.assertEqual(key, 'abc')
+    self.assertEqual(val, '')
 
-    def testNoSepWithDanglingEscape(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('abc\\', '=')
+  def testHappyCase(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('abc=xyz', '=')
+    self.assertEqual(key, 'abc')
+    self.assertEqual(val, 'xyz')
 
-        self.assertEqual(key, 'abc')
-        self.assertEqual(val, '')
+  def testHappyCaseWithEscapes(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('a\\=\\=b\\=c=xyz', '=')
+    self.assertEqual(key, 'a==b=c')
+    self.assertEqual(val, 'xyz')
 
-    def testHappyCase(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('abc=xyz', '=')
+  def testStopsAtFirstSep(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('a=b=c', '=')
+    self.assertEqual(key, 'a')
+    self.assertEqual(val, 'b=c')
 
-        self.assertEqual(key, 'abc')
-        self.assertEqual(val, 'xyz')
+  def testDoesntUnescapeVal(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('abc=x\\=yz\\', '=')
+    self.assertEqual(key, 'abc')
+    # the val doesn't get unescaped at all
+    self.assertEqual(val, 'x\\=yz\\')
 
-    def testHappyCaseWithEscapes(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('a\\=\\=b\\=c=xyz', '=')
+  def testUnescapesNonsepCharsToo(self):
+    key, val = helpers.SplitNameValuePairAtSeparator('na\\xffme=value', '=')
+    # this behaviour is surprising
+    self.assertEqual(key, 'naxffme')
+    self.assertEqual(val, 'value')
 
-        self.assertEqual(key, 'a==b=c')
-        self.assertEqual(val, 'xyz')
-
-    def testStopsAtFirstSep(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('a=b=c', '=')
-
-        self.assertEqual(key, 'a')
-        self.assertEqual(val, 'b=c')
-
-    def testDoesntUnescapeVal(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('abc=x\\=yz\\', '=')
-
-        self.assertEqual(key, 'abc')
-
-        # the val doesn't get unescaped at all
-        self.assertEqual(val, 'x\\=yz\\')
-
-    def testUnescapesNonsepCharsToo(self):
-        key, val = helpers.SplitNameValuePairAtSeparator('na\\xffme=value', '=')
-
-        # this behaviour is surprising
-        self.assertEqual(key, 'naxffme')
-        self.assertEqual(val, 'value')
-
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == '__main__':
+  unittest.main()

--- a/pkg/tests/path_test.py
+++ b/pkg/tests/path_test.py
@@ -13,30 +13,33 @@
 # limitations under the License.
 """Testing for helper functions."""
 
+import collections
 import imp
-import os.path
+import os
 import unittest
 
-from collections import namedtuple
 
 pkg_bzl = imp.load_source('pkg_bzl', 'path.bzl')
 
-Owner = namedtuple("Owner", ["workspace_name", "workspace_root"])
-Root = namedtuple("Root", ["path"])
+Owner = collections.namedtuple('Owner', ['workspace_name', 'workspace_root'])
+Root = collections.namedtuple('Root', ['path'])
+
 
 class File(object):
   """Mock Skylark File class for testing."""
 
   def __init__(self, short_path, is_generated=False, is_external=False):
     self.is_source = not is_generated
-    self.root = Root("bazel-out/k8-fastbuild/bin" if is_generated else "")
+    self.root = Root('bazel-out/k8-fastbuild/bin' if is_generated else '')
     if is_external:
-      self.owner = Owner("repo", "external/repo")
-      self.short_path = "../repo/" + short_path
+      self.owner = Owner('repo', 'external/repo')
+      self.short_path = '../repo/' + short_path
     else:
-      self.owner = Owner("", "")
+      self.owner = Owner('', '')
       self.short_path = short_path
-    self.path = os.path.join(self.root.path, self.owner.workspace_root, short_path)
+    self.path = os.path.join(
+        self.root.path, self.owner.workspace_root, short_path)
+
 
 class SafeShortPathTest(unittest.TestCase):
   """Testing for safe_short_path."""
@@ -54,8 +57,10 @@ class SafeShortPathTest(unittest.TestCase):
     self.assertEqual('external/repo/foo/bar/baz', path)
 
   def testSafeShortPathGenExt(self):
-    path = pkg_bzl.safe_short_path(File('foo/bar/baz', is_generated=True, is_external=True))
+    path = pkg_bzl.safe_short_path(
+        File('foo/bar/baz', is_generated=True, is_external=True))
     self.assertEqual('external/repo/foo/bar/baz', path)
+
 
 class ShortPathDirnameTest(unittest.TestCase):
   """Testing for _short_path_dirname."""
@@ -73,7 +78,8 @@ class ShortPathDirnameTest(unittest.TestCase):
     self.assertEqual('external/repo/foo/bar', path)
 
   def testShortPathDirnameGenExt(self):
-    path = pkg_bzl._short_path_dirname(File('foo/bar/baz', is_generated=True, is_external=True))
+    path = pkg_bzl._short_path_dirname(
+        File('foo/bar/baz', is_generated=True, is_external=True))
     self.assertEqual('external/repo/foo/bar', path)
 
   def testTopLevel(self):
@@ -101,7 +107,8 @@ class DestPathTest(unittest.TestCase):
     self.assertEqual('/bar/baz', path)
 
   def testDestPathExt(self):
-    path = pkg_bzl.dest_path(File('foo/bar/baz', is_external=True), 'external/repo/foo')
+    path = pkg_bzl.dest_path(
+        File('foo/bar/baz', is_external=True), 'external/repo/foo')
     self.assertEqual('/bar/baz', path)
 
   def testDestPathExtWrong(self):

--- a/pkg/tests/pkg_deb_test.py
+++ b/pkg/tests/pkg_deb_test.py
@@ -56,10 +56,11 @@ class DebInspect(object):
     raise Exception('Could not find control file: %s' % file_name)
 
 
-class PktDebTest(unittest.TestCase):
+class PkgDebTest(unittest.TestCase):
   """Testing for pkg_deb rule."""
 
   def setUp(self):
+    super(PkgDebTest, self).setUp()
     self.runfiles = runfiles.Create()
     # Note: Rlocation requires forward slashes. os.path.join() will not work.
     self.deb_path = self.runfiles.Rlocation('rules_pkg/tests/titi_test_all.deb')

--- a/pkg/tests/pkg_deb_test.py
+++ b/pkg/tests/pkg_deb_test.py
@@ -18,12 +18,12 @@
 import codecs
 from io import BytesIO
 import os
-import tarfile
 import sys
+import tarfile
 import unittest
 
-from rules_pkg import archive
 from bazel_tools.tools.python.runfiles import runfiles
+from rules_pkg import archive
 
 
 class DebInspect(object):
@@ -36,15 +36,15 @@ class DebInspect(object):
     with archive.SimpleArFile(deb_file) as f:
       info = f.next()
       while info:
-       if info.filename == 'debian-binary':
-         self.deb_version = info.data
-       elif info.filename == 'control.tar.gz':
-         self.control = info.data
-       elif info.filename == 'data.tar.gz':
-         self.data = info.data
-       else:
-         raise Exception('Unexpected file: %s' % info.filename)
-       info = f.next()
+        if info.filename == 'debian-binary':
+          self.deb_version = info.data
+        elif info.filename == 'control.tar.gz':
+          self.control = info.data
+        elif info.filename == 'data.tar.gz':
+          self.data = info.data
+        else:
+          raise Exception('Unexpected file: %s' % info.filename)
+        info = f.next()
 
   def get_deb_ctl_file(self, file_name):
     """Extract a control file."""
@@ -81,7 +81,7 @@ class PktDebTest(unittest.TestCase):
     """Assert that tarfile contains exactly the entry described by `expected`.
 
     Args:
-        file_name: the path to the TAR file to test.
+        data: the tar file stream to check.
         expected: an array describing the expected content of the TAR file.
             Each entry in that list should be a dictionary where each field
             is a field to test in the corresponding TarInfo. For
@@ -105,7 +105,7 @@ class PktDebTest(unittest.TestCase):
         error_msg = 'Extraneous file at end of archive: %s' % (
             info.name
             )
-        self.assertTrue(i < len(expected), error_msg)
+        self.assertLess(i, len(expected), error_msg)
         name_in_tar_file = getattr(info, 'name')
         if match_order:
           want = expected[i]
@@ -130,7 +130,7 @@ class PktDebTest(unittest.TestCase):
           self.assertEqual(value, v, error_msg)
         i += 1
       if i < len(expected):
-        self.fail('Missing file %s in archive %s' % (expected[i], file_path))
+        self.fail('Missing file %s' % expected[i])
 
   def test_expected_files(self):
     # Check the set of 'test-tar-basic-*' smoke test.
@@ -203,22 +203,20 @@ class PktDebTest(unittest.TestCase):
 
   def test_templates(self):
     templates = self.deb_file.get_deb_ctl_file('templates')
-    for field in (
-	'Template: titi/test',
-	'Type: string'):
+    for field in ('Template: titi/test', 'Type: string'):
       if templates.find(field) < 0:
         self.fail('Missing template field: <%s> in <%s>' % (field, templates))
 
   def test_changes(self):
-     changes_path = self.runfiles.Rlocation(
-         'rules_pkg/tests/titi_test_all.changes')
-     with open(changes_path, 'r', encoding='utf-8') as f:
-       content = f.read()
-       for field in (
-           'Urgency: low',
-           'Distribution: trusty'):
-         if content.find(field) < 0:
-           self.fail('Missing template field: <%s> in <%s>' % (field, content))
+    changes_path = self.runfiles.Rlocation(
+        'rules_pkg/tests/titi_test_all.changes')
+    with open(changes_path, 'r', encoding='utf-8') as f:
+      content = f.read()
+      for field in (
+          'Urgency: low',
+          'Distribution: trusty'):
+        if content.find(field) < 0:
+          self.fail('Missing template field: <%s> in <%s>' % (field, content))
 
 
 if __name__ == '__main__':

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Testing for archive."""
 
-import os
 import tarfile
 import unittest
 

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -14,7 +14,6 @@
 """Testing for archive."""
 
 import os
-import os.path
 import tarfile
 import unittest
 
@@ -48,7 +47,7 @@ class PkgTarTest(unittest.TestCase):
             file_path,
             info.name
             )
-        self.assertTrue(i < len(content), error_msg)
+        self.assertLess(i, len(content), error_msg)
         for k, v in content[i].items():
           if k == 'data':
             value = f.extractfile(info).read()
@@ -129,7 +128,7 @@ class PkgTarTest(unittest.TestCase):
     content = [
         {'name': '.'},
         {'name': './tmp', 'isdir': True, 'size': 0, 'uid': 0,
-         'mtime': PORTABLE_MTIME },
+         'mtime': PORTABLE_MTIME},
         {'name': './pmt', 'isdir': True, 'size': 0, 'uid': 0,
          'mtime': PORTABLE_MTIME},
     ]

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -14,10 +14,10 @@
 
 import filecmp
 import unittest
-from zipfile import ZipFile
+import zipfile
 
 from bazel_tools.tools.python.runfiles import runfiles
-from build_zip import parse_date, ZIP_EPOCH
+import build_zip
 
 HELLO_CRC = 2069210904
 LOREM_CRC = 2178844372
@@ -26,11 +26,11 @@ EXECUTABLE_CRC = 342626072
 
 class ZipTest(unittest.TestCase):
 
-  def get_test_zip(self, zipfile):
+  def get_test_zip(self, zip_file):
     """Get the file path to a generated zip in the runfiles."""
 
     return self.data_files.Rlocation(
-        "rules_pkg/tests/" + zipfile
+        "rules_pkg/tests/" + zip_file
     )
 
   def setUp(self):
@@ -41,15 +41,15 @@ class ZipTest(unittest.TestCase):
 class ZipContentsCase(ZipTest):
   """Use zipfile to check the contents of some generated zip files."""
 
-  def assertZipFileContent(self, zipfile, content):
-    """Assert that zipfile contains the entries described by content.
+  def assertZipFileContent(self, zip_file, content):
+    """Assert that zip_file contains the entries described by content.
 
     Args:
-        zipfile: the test-package-relative path to a zip file to test.
+        zip_file: the test-package-relative path to a zip file to test.
         content: an array of dictionaries containing a filename and crc key,
                  and optionally a timestamp key.
     """
-    with ZipFile(self.get_test_zip(zipfile)) as f:
+    with zipfile.ZipFile(self.get_test_zip(zip_file)) as f:
       infos = f.infolist()
       self.assertEqual(len(infos), len(content))
 
@@ -57,7 +57,8 @@ class ZipContentsCase(ZipTest):
         self.assertEqual(info.filename, expected["filename"])
         self.assertEqual(info.CRC, expected["crc"])
 
-        ts = parse_date(expected.get("timestamp", ZIP_EPOCH))
+        ts = build_zip.parse_date(
+            expected.get("timestamp", build_zip.ZIP_EPOCH))
         self.assertEqual(info.date_time, ts)
         self.assertEqual(info.external_attr >> 16, expected.get("attr", 0o555))
 

--- a/pkg/toolchains/rpmbuild_configure.bzl
+++ b/pkg/toolchains/rpmbuild_configure.bzl
@@ -30,9 +30,9 @@ def _find_system_rpmbuild_impl(rctx):
     rpmbuild_path = rctx.which("rpmbuild")
     if rctx.attr.verbose:
         if rpmbuild_path:
-            print("Found rpmbuild at '%s'" % rpmbuild_path)
+            print("Found rpmbuild at '%s'" % rpmbuild_path)  # buildifier: disable=print
         else:
-            print("No system rpmbuild found.")
+          print("No system rpmbuild found.")  # buildifier: disable=print
     _write_build(rctx = rctx, path = rpmbuild_path)
 
 _find_system_rpmbuild = repository_rule(


### PR DESCRIPTION
Fix a bunch of things Google's strident python lint complains about.  To be fair, the lint warnings did actually catch a real error in print_relnotes.py.