### PR TITLE
Make archive_test and pkg_tar_test work on Windows

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -31,7 +31,6 @@ tasks:
     # broken test.
     test_targets:
     - "//tests:archive_test"
-    - "//tests:helpers_test"
     - "//tests:pkg_deb_test"
     - "//tests:pkg_tar_test"
     - "//tests:zip_test"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -31,6 +31,7 @@ tasks:
     # broken test.
     test_targets:
     - "//tests:archive_test"
+    - "//tests:helpers_test"
     - "//tests:pkg_deb_test"
     - "//tests:pkg_tar_test"
     - "//tests:zip_test"

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -30,6 +30,7 @@ tasks:
     # one that works and can add to the list as we fix the broken behavior or
     # broken test.
     test_targets:
-    - "//tests:zip_test"
+    - "//tests:archive_test"
     - "//tests:pkg_deb_test"
+    - "//tests:zip_test"
 

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -32,5 +32,6 @@ tasks:
     test_targets:
     - "//tests:archive_test"
     - "//tests:pkg_deb_test"
+    - "//tests:pkg_tar_test"
     - "//tests:zip_test"
 

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -364,7 +364,8 @@ class TarFileWriter(object):
         name = tarinfo.name
         if (not name.startswith('/') and
             not name.startswith(self.root_directory)):
-          name = os.path.join(self.root_directory, name)
+          #XXX name = os.path.join(self.root_directory, name)
+          name = self.root_directory + '/' + name
         if root is not None:
           if name.startswith('.'):
             name = '.' + root + name.lstrip('.')

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -186,7 +186,8 @@ class TarFileWriter(object):
     """
     if not (name == self.root_directory or name.startswith('/') or
             name.startswith(self.root_directory + '/')):
-      name = os.path.join(self.root_directory, name)
+      # XXXX name = os.path.join(self.root_directory, name)
+      name = self.root_directory + '/' + name
     if mtime is None:
       mtime = self.default_mtime
     if os.path.isdir(path):

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -109,7 +109,7 @@ class TarFileWriter(object):
   def __init__(self,
                name,
                compression='',
-               root_directory='./',
+               root_directory='.',
                default_mtime=None,
                preserve_tar_mtimes=True):
     """TarFileWriter wraps tarfile.open().
@@ -169,8 +169,8 @@ class TarFileWriter(object):
     """Recursively add a directory.
 
     Args:
-      name: the destination path of the directory to add.
-      path: the path of the directory to add.
+      name: the ('/' delimited) path of the directory to add.
+      path: the (os.path.sep delimited) path of the directory to add.
       uid: owner user identifier.
       gid: owner group identifier.
       uname: owner user names.
@@ -186,16 +186,16 @@ class TarFileWriter(object):
     """
     if not (name == self.root_directory or name.startswith('/') or
             name.startswith(self.root_directory + '/')):
-      # XXXX name = os.path.join(self.root_directory, name)
       name = self.root_directory + '/' + name
     if mtime is None:
       mtime = self.default_mtime
+    path = path.rstrip('/').rstrip('\\')
     if os.path.isdir(path):
       # Remove trailing '/' (index -1 => last character)
-      if name[-1] == '/':
+      if name[-1] in ('/', '\\'):
         name = name[:-1]
       # Add the x bit to directories to prevent non-traversable directories.
-      # The x bit is set only to if the read bit is set.
+      # The x bit is set to 1 only if the read bit is also set.
       dirmode = (mode | ((0o444 & mode) >> 2)) if mode else mode
       self.add_file(name + '/',
                     tarfile.DIRTYPE,
@@ -254,7 +254,7 @@ class TarFileWriter(object):
     """Add a file to the current tar.
 
     Args:
-      name: the name of the file to add.
+      name: the ('/' delimited) path of the file to add.
       kind: the type of the file to add, see tarfile.*TYPE.
       content: a textual content to put in the file.
       link: if the file is a link, the destination of the link.
@@ -273,10 +273,9 @@ class TarFileWriter(object):
       return
     if not (name == self.root_directory or name.startswith('/') or
             name.startswith(self.root_directory + '/')):
-      #XXX name = os.path.join(self.root_directory, name)
       name = self.root_directory + '/' + name
     if kind == tarfile.DIRTYPE:
-      name = name.rstrip('/')
+      name = name.rstrip('/').rstrip('\\')
       if name in self.directories:
         return
     if mtime is None:
@@ -364,7 +363,6 @@ class TarFileWriter(object):
         name = tarinfo.name
         if (not name.startswith('/') and
             not name.startswith(self.root_directory)):
-          #XXX name = os.path.join(self.root_directory, name)
           name = self.root_directory + '/' + name
         if root is not None:
           if name.startswith('.'):

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -212,7 +212,7 @@ class TarFileWriter(object):
       filelist = os.listdir(path)
       filelist.sort()
       for f in filelist:
-        new_name = os.path.join(name, f)
+        new_name = name + '/' + f
         new_path = os.path.join(path, f)
         self.add_dir(new_name, new_path, uid, gid, uname, gname, mtime, mode,
                      depth - 1)

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -131,7 +131,7 @@ class TarFileWriter(object):
     # Support xz compression through xz... until we can use Py3
     self.xz = compression in ['xz', 'lzma']
     self.name = name
-    self.root_directory = root_directory.rstrip('/')
+    self.root_directory = root_directory.rstrip('/').rstrip('\\')
     self.preserve_mtime = preserve_tar_mtimes
     if default_mtime is None:
       self.default_mtime = 0

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -132,6 +132,7 @@ class TarFileWriter(object):
     self.xz = compression in ['xz', 'lzma']
     self.name = name
     self.root_directory = root_directory.rstrip('/').rstrip('\\')
+    self.root_directory = self.root_directory.replace('\\', '/')
     self.preserve_mtime = preserve_tar_mtimes
     if default_mtime is None:
       self.default_mtime = 0
@@ -267,6 +268,7 @@ class TarFileWriter(object):
       mtime: modification time to put in the archive.
       mode: unix permission mode of the file, default 0644 (0755).
     """
+    name = name.replace('\\', '/')
     if file_content and os.path.isdir(file_content):
       # Recurse into directory
       self.add_dir(name, file_content, uid, gid, uname, gname, mtime, mode)

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -272,7 +272,8 @@ class TarFileWriter(object):
       return
     if not (name == self.root_directory or name.startswith('/') or
             name.startswith(self.root_directory + '/')):
-      name = os.path.join(self.root_directory, name)
+      #XXX name = os.path.join(self.root_directory, name)
+      name = self.root_directory + '/' + name
     if kind == tarfile.DIRTYPE:
       name = name.rstrip('/')
       if name in self.directories:

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -73,7 +73,7 @@ class TarFile(object):
       ids = (0, 0)
     if names is None:
       names = ('', '')
-    dest = os.path.normpath(dest)
+    dest = os.path.normpath(dest).replace(os.path.sep, '/')
     self.tarfile.add_file(
         dest,
         file_content=f,
@@ -107,7 +107,7 @@ class TarFile(object):
       ids = (0, 0)
     if names is None:
       names = ('', '')
-    dest = os.path.normpath(dest)
+    dest = os.path.normpath(dest).replace(os.path.sep, '/')
     self.tarfile.add_file(
         dest,
         content='' if kind == tarfile.REGTYPE else None,
@@ -168,7 +168,7 @@ class TarFile(object):
       symlink: the name of the symbolic link to add.
       destination: where the symbolic link point to.
     """
-    symlink = os.path.normpath(symlink)
+    symlink = os.path.normpath(symlink).replace(os.path.sep, '/')
     self.tarfile.add_file(symlink, tarfile.SYMTYPE, link=destination)
 
   def add_deb(self, deb):

--- a/pkg/build_tar.py
+++ b/pkg/build_tar.py
@@ -73,6 +73,7 @@ class TarFile(object):
       ids = (0, 0)
     if names is None:
       names = ('', '')
+    # Note: normpath changes / to \ on windows, but we expect / style paths.
     dest = os.path.normpath(dest).replace(os.path.sep, '/')
     self.tarfile.add_file(
         dest,

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -40,8 +40,7 @@ py_test(
     python_version = "PY3",
     srcs_version = "PY3",
     tags = [
-        # TODO(laszlocsomor): fix on Windows or describe why it cannot pass.
-        "no_windows",
+        #XXXXX "no_windows",
     ],
     deps = [
         "//:archive",

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -39,9 +39,6 @@ py_test(
     data = [":archive_testdata"],
     python_version = "PY3",
     srcs_version = "PY3",
-    tags = [
-        #XXXXX "no_windows",
-    ],
     deps = [
         "//:archive",
         "@bazel_tools//tools/python/runfiles",

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -201,6 +201,7 @@ class TarFileWriterTest(unittest.TestCase):
     # structure it describes.
     for c in content:
       if "data" in c:
+        # Create files is happening locally, so use native path sep.
         path_parts = c["name"][2:].split('/')
         p = os.path.join(tempdir, *path_parts)
         os.makedirs(os.path.dirname(p))
@@ -389,15 +390,13 @@ class TarFileWriterTest(unittest.TestCase):
           "rules_pkg/tests/test_tar_package_dir.tar")
       package_dir_file = self.data_files.Rlocation(
           "rules_pkg/tests/test_tar_package_dir_file.tar")
-
       expected_content = [
           {'name': '.'},
           {'name': './package'},
           {'name': './package/nsswitch.conf'},
       ]
-
-      self.assertTarFileContent(package_dir, expected_content)
       self.assertTarFileContent(package_dir_file, expected_content)
+      self.assertTarFileContent(package_dir, expected_content)
 
 if __name__ == "__main__":
   unittest.main()

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -201,7 +201,8 @@ class TarFileWriterTest(unittest.TestCase):
     # structure it describes.
     for c in content:
       if "data" in c:
-        p = os.path.join(tempdir, c["name"][2:])
+        path_parts = c["name"][2:].split('/')
+        p = os.path.join(tempdir, *path_parts)
         os.makedirs(os.path.dirname(p))
         with open(p, "wb") as f:
           f.write(c["data"])

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -121,8 +121,8 @@ class TarFileWriterTest(unittest.TestCase):
         for k, v in content[i].items():
           if k == "data":
             value = f.extractfile(current).read()
-          #XXXelif k == "name" and os.name == "nt":
-          #  value = getattr(current, k).replace("/", "\\")
+          elif k == "name" and os.name == "nt":
+            value = getattr(current, k).replace("\\", "/")
           else:
             value = getattr(current, k)
           error_msg = " ".join([

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -395,8 +395,8 @@ class TarFileWriterTest(unittest.TestCase):
           {'name': './package'},
           {'name': './package/nsswitch.conf'},
       ]
-      self.assertTarFileContent(package_dir_file, expected_content)
       self.assertTarFileContent(package_dir, expected_content)
+      self.assertTarFileContent(package_dir_file, expected_content)
 
 if __name__ == "__main__":
   unittest.main()

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -64,13 +64,12 @@ class SimpleArFileTest(unittest.TestCase):
 
   def testEmptyArFile(self):
     self.assertArFileContent(
-        self.data_files.Rlocation(
-            os.path.join("rules_pkg", "tests", "testdata", "empty.ar")),
+        self.data_files.Rlocation("rules_pkg/tests/testdata/empty.ar"),
         [])
 
   def assertSimpleFileContent(self, names):
     datafile = self.data_files.Rlocation(
-        os.path.join("rules_pkg", "tests", "testdata", "_".join(names) + ".ar"))
+        "rules_pkg/tests/testdata/" + "_".join(names) + ".ar")
     content = [{"filename": n,
                 "size": len(n.encode("utf-8")),
                 "data": n.encode("utf-8")}
@@ -210,7 +209,7 @@ class TarFileWriterTest(unittest.TestCase):
     for ext in ["", ".gz", ".bz2", ".xz"]:
       with archive.TarFileWriter(self.tempfile) as f:
         datafile = self.data_files.Rlocation(
-            os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar" + ext))
+            "rules_pkg/tests/testdata/tar_test.tar" + ext)
         f.add_tar(datafile, name_filter=lambda n: n != "./b")
       self.assertTarFileContent(self.tempfile, content)
 
@@ -223,7 +222,7 @@ class TarFileWriterTest(unittest.TestCase):
         ]
     with archive.TarFileWriter(self.tempfile) as f:
       datafile = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+          "rules_pkg/tests/testdata/tar_test.tar")
       f.add_tar(datafile, name_filter=lambda n: n != "./b", root="/foo")
     self.assertTarFileContent(self.tempfile, content)
 
@@ -242,7 +241,7 @@ class TarFileWriterTest(unittest.TestCase):
   def testPreserveTarMtimesTrueByDefault(self):
     with archive.TarFileWriter(self.tempfile) as f:
       input_tar_path = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+          "rules_pkg/tests/testdata/tar_test.tar")
       f.add_tar(input_tar_path)
       input_tar = tarfile.open(input_tar_path, "r")
       for file_name in f.members:
@@ -253,7 +252,7 @@ class TarFileWriterTest(unittest.TestCase):
   def testPreserveTarMtimesFalse(self):
     with archive.TarFileWriter(self.tempfile, preserve_tar_mtimes=False) as f:
       input_tar_path = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "testdata", "tar_test.tar"))
+          "rules_pkg/tests/testdata/tar_test.tar")
       f.add_tar(input_tar_path)
       for output_file in f.tar:
         self.assertEqual(output_file.mtime, 0)
@@ -378,9 +377,9 @@ class TarFileWriterTest(unittest.TestCase):
       to pkg_tar yields identical results
       """
       package_dir = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir.tar"))
+          "rules_pkg/tests/test_tar_package_dir.tar")
       package_dir_file = self.data_files.Rlocation(
-          os.path.join("rules_pkg", "tests", "test_tar_package_dir_file.tar"))
+          "rules_pkg/tests/test_tar_package_dir_file.tar")
 
       expected_content = [
           {'name': '.'},

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -110,7 +110,12 @@ class TarFileWriterTest(unittest.TestCase):
             be `{"name": "x"}`, the missing field will be ignored. To match
             the content of a file entry, use the key "data".
     """
-    with tarfile.open(tar, "r:") as f:
+    got_names = []
+    with tarfile.open(tar, "r:*") as f:
+      for current in f:
+        got_names.append(getattr(current, "name"))
+
+    with tarfile.open(tar, "r:*") as f:
       i = 0
       for current in f:
         error_msg = "Extraneous file at end of archive %s: %s" % (
@@ -130,6 +135,7 @@ class TarFileWriterTest(unittest.TestCase):
               "%s in archive %s does" % (current.name, tar),
               "not match expected value `%s`" % v
               ])
+          error_msg += str(got_names)
           self.assertEqual(value, v, error_msg)
         i += 1
       if i < len(content):

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -121,6 +121,8 @@ class TarFileWriterTest(unittest.TestCase):
         for k, v in content[i].items():
           if k == "data":
             value = f.extractfile(current).read()
+          elif k == "name" and os.name == "nt":
+            value = getattr(current, k).replace("/", "\\")
           else:
             value = getattr(current, k)
           error_msg = " ".join([

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -184,7 +184,7 @@ class TarFileWriterTest(unittest.TestCase):
     content = [
         {"name": "."}, {"name": "./a"}, {"name": "/b"}, {"name": "./c"},
         {"name": "./.d"}, {"name": "./..e"}, {"name": "./.f"}
-    ])
+    ]
     self.assertTarFileContent(self.tempfile, content)
 
   def testAddDir(self):

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -181,11 +181,8 @@ class TarFileWriterTest(unittest.TestCase):
       f.add_file("./.d")
       f.add_file("..e")
       f.add_file(".f")
-    content = []
-    if os.name != "nt":
-      content = [{"name": "."}]
-    content.extend([
-        {"name": "./a"}, {"name": "/b"}, {"name": "./c"},
+    content = [
+        {"name": "."}, {"name": "./a"}, {"name": "/b"}, {"name": "./c"},
         {"name": "./.d"}, {"name": "./..e"}, {"name": "./.f"}
     ])
     self.assertTarFileContent(self.tempfile, content)

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -121,8 +121,8 @@ class TarFileWriterTest(unittest.TestCase):
         for k, v in content[i].items():
           if k == "data":
             value = f.extractfile(current).read()
-          elif k == "name" and os.name == "nt":
-            value = getattr(current, k).replace("/", "\\")
+          #XXXelif k == "name" and os.name == "nt":
+          #  value = getattr(current, k).replace("/", "\\")
           else:
             value = getattr(current, k)
           error_msg = " ".join([
@@ -175,10 +175,13 @@ class TarFileWriterTest(unittest.TestCase):
       f.add_file("./.d")
       f.add_file("..e")
       f.add_file(".f")
-    content = [
-        {"name": "."}, {"name": "./a"}, {"name": "/b"}, {"name": "./c"},
+    content = []
+    if os.name != "nt":
+      content = [{"name": "."}]
+    content.extend([
+        {"name": "./a"}, {"name": "/b"}, {"name": "./c"},
         {"name": "./.d"}, {"name": "./..e"}, {"name": "./.f"}
-    ]
+    ])
     self.assertTarFileContent(self.tempfile, content)
 
   def testAddDir(self):

--- a/pkg/tests/pkg_deb_test.py
+++ b/pkg/tests/pkg_deb_test.py
@@ -90,11 +90,6 @@ class PktDebTest(unittest.TestCase):
             the content of a file entry, use the key 'data'.
         match_order: True if files must match in order as well as properties.
     """
-    # TODO(https://github.com/bazelbuild/rules_pkg/issues/213): On Windows,
-    # tarfile seems to not report the directory information. So we filter out
-    # items that are supposed to be directories.
-    if sys.platform == 'win32':
-      expected = [e for e in expected if not e.get('isdir')]
     expected_by_name = {}
     for e in expected:
       expected_by_name[e['name']] = e

--- a/pkg/tests/pkg_deb_test.py
+++ b/pkg/tests/pkg_deb_test.py
@@ -115,6 +115,8 @@ class PktDebTest(unittest.TestCase):
             value = name_in_tar_file.replace(os.path.sep, '/')
           elif k == 'isdir':
             value = info.isdir()
+          elif k == "name" and sys.platform == 'win32':
+            value = getattr(current, k).replace("\\", "/")
           else:
             value = getattr(info, k)
           error_msg = ' '.join([


### PR DESCRIPTION
Fixes to the tests:
- Counterintuitively, use '/' as a path separator instead of os.path.join(), because runfiles.Rlocation() requires that. So change those call sites
- account for the fact that tarinfo on windows does (correctly) return paths with \ in them.
- remove windows specific hackery in pkg_deb_test because the behavior is now correct

Fixes to the code:
- clean up the contract that tar names are '/' delimited and paths are os.path.sep delimited
- be more forgiving of users using the wrong delimiter
- fix a bug with using normpath (it changes / to \) thus breaking the name contract.   Fixes #213 