### PR TITLE
Create alias for distro creation rule; add copyright in distro/BUILD

### DIFF
--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -1,3 +1,17 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("//:pkg.bzl", "pkg_tar")
 load("//:version.bzl", "version")
 load("//releasing:defs.bzl", "print_rel_notes")
@@ -9,6 +23,11 @@ licenses(["notice"])
 
 package(
     default_visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "distro",
+    actual = "rules_pkg-%s" % version,
 )
 
 # Build the artifact to put on the github release page.
@@ -54,7 +73,7 @@ py_test(
         ":release_version.py",
     ],
     data = [
-        ":rules_pkg-%s.tar.gz" % version,
+        ":distro",
         "testdata/BUILD.tmpl",
     ],
     local = True,


### PR DESCRIPTION
Building the distribution tarball for rules_pkg requires you to know the version
number, which isn't always known offhand.

This change creates an `alias` rule in `distro/BUILD` which makes building the
"distro" tarball as simple as naming `//distro` in a rule or `bazel`
command-line.

Additionally, a copyright statement for `distro/BUILD` was added, dated back to
the original creation of the file in this repository.