### PR TITLE
Refactor usage of xz compression so tests are less fragile across platforms.

### DIFF
--- a/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
+++ b/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
@@ -15,5 +15,5 @@
 
 # buildifier: disable=unnamed-macro
 def register_my_rpmbuild_toolchain():
-    """Register a prebuilt rpmbuild.""".
+    """Register a prebuilt rpmbuild."""
     native.register_toolchains("//local:local_rpmbuild")

--- a/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
+++ b/examples/prebuilt_rpmbuild/local/rpmbuild.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Register a prebuilt rpmbuild.""".
+"""Register a prebuilt rpmbuild."""
 
 # buildifier: disable=unnamed-macro
 def register_my_rpmbuild_toolchain():

--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -20,6 +20,17 @@ import os
 import subprocess
 import tarfile
 
+try:
+  import lzma  # pylint: disable=g-import-not-at-top, unused-import
+  HAS_LZMA = True
+except ImportError:
+  HAS_LZMA = False
+
+# This is slightly a lie. We do support xz fallback through the xz tool, but
+# that is fragile. Users should stick to the expectations provided here.
+COMPRESSIONS = ('', 'gz', 'bz2', 'xz') if HAS_LZMA else ('', 'gz', 'bz2')
+
+
 # Use a deterministic mtime that doesn't confuse other programs.
 # See: https://github.com/bazelbuild/bazel/issues/1299
 PORTABLE_MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
@@ -54,7 +65,8 @@ class SimpleArFile(object):
     Attributes:
       filename: the filename of the entry, as described in the archive.
       timestamp: the timestamp of the file entry.
-      owner_id, group_id: numeric id of the user and group owning the file.
+      owner_id: numeric id of the user and group owning the file.
+      group_id: numeric id of the user and group owning the file.
       mode: unix permission mode of the file
       size: size of the file
       data: the content of the file.
@@ -128,8 +140,13 @@ class TarFileWriter(object):
     else:
       mode = 'w:'
     self.gz = compression in ['tgz', 'gz']
-    # Support xz compression through xz... until we can use Py3
-    self.xz = compression in ['xz', 'lzma']
+    # Fallback to xz compression through xz.
+    self.use_xz_tool = False
+    if compression in ['xz', 'lzma']:
+      if HAS_LZMA:
+        mode = 'w:xz'
+      else:
+        self.use_xz_tool = True
     self.name = name
     self.root_directory = root_directory.rstrip('/')
     self.preserve_mtime = preserve_tar_mtimes
@@ -402,7 +419,7 @@ class TarFileWriter(object):
     # Close the gzip file object if necessary.
     if self.fileobj:
       self.fileobj.close()
-    if self.xz:
+    if self.use_xz_tool:
       # Support xz compression through xz... until we can use Py3
       if subprocess.call('which xz', shell=True, stdout=subprocess.PIPE):
         raise self.Error('Cannot handle .xz and .lzma compression: '

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -16,11 +16,19 @@
 load(":path.bzl", "compute_data_path", "dest_path")
 load(":providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
 
+# TODO(aiuto): Figure  out how to get this from the python toolchain.
+# See check for lzma in archive.py for a hint at a method.
+HAS_XZ_SUPPORT = True
+
 # Filetype to restrict inputs
-tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.xz", ".tar.bz2"]
+tar_filetype = (
+    [".tar", ".tar.gz", ".tgz", ".tar.bz2", "tar.xz"] if HAS_XZ_SUPPORT else [".tar", ".tar.gz", ".tgz", ".tar.bz2"]
+)
+SUPPORTED_TAR_COMPRESSIONS = (
+    ["", "gz", "bz2", "xz"] if HAS_XZ_SUPPORT else ["", "gz", "bz2"]
+)
 deb_filetype = [".deb", ".udeb"]
 _DEFAULT_MTIME = -1
-
 
 def _remap(remap_paths, path):
     """If path starts with a key in remap_paths, rewrite it."""
@@ -32,7 +40,6 @@ def _remap(remap_paths, path):
 def _quote(filename, protect = "="):
     """Quote the filename, by escaping = by \\= and \\ by \\\\"""
     return filename.replace("\\", "\\\\").replace(protect, "\\" + protect)
-
 
 def _pkg_tar_impl(ctx):
     """Implementation of the pkg_tar rule."""
@@ -46,13 +53,13 @@ def _pkg_tar_impl(ctx):
         if ctx.attr.package_variables:
             package_variables = ctx.attr.package_variables[PackageVariablesInfo]
             output_name = output_name.format(**package_variables.values)
-        elif ctx.attr.package_file_name.find('{') >= 0:
+        elif ctx.attr.package_file_name.find("{") >= 0:
             fail("package_variables is required when using '{' in package_file_name")
         output_file = ctx.actions.declare_file(output_name)
         outputs.append(output_file)
         ctx.actions.symlink(
             output = ctx.outputs.out,
-            target_file = output_file
+            target_file = output_file,
         )
     else:
         output_file = ctx.outputs.out
@@ -60,7 +67,7 @@ def _pkg_tar_impl(ctx):
 
     # Compute the relative path
     data_path = compute_data_path(output_file, ctx.attr.strip_prefix)
-    data_path_without_prefix = compute_data_path(output_file, '.')
+    data_path_without_prefix = compute_data_path(output_file, ".")
 
     # Find a list of path remappings to apply.
     remap_paths = ctx.attr.remap_paths
@@ -106,7 +113,9 @@ def _pkg_tar_impl(ctx):
 
     args += [
         "--file=%s=%s" % (_quote(f.path), _remap(
-            remap_paths, dest_path(f, data_path, data_path_without_prefix)))
+            remap_paths,
+            dest_path(f, data_path, data_path_without_prefix),
+        ))
         for f in file_inputs
     ]
     for target, f_dest_path in ctx.attr.files.items():
@@ -173,7 +182,7 @@ def _pkg_tar_impl(ctx):
         PackageArtifactInfo(
             label = ctx.label.name,
             file_name = output_name,
-        )
+        ),
     ]
 
 def _pkg_deb_impl(ctx):
@@ -365,7 +374,7 @@ def pkg_tar(name, **kwargs):
     pkg_tar_impl(
         name = name,
         out = kwargs.pop("out", None) or (name + "." + extension),
-        **kwargs,
+        **kwargs
     )
 
 # A rule for creating a deb file, see README.md
@@ -421,7 +430,7 @@ pkg_deb_impl = rule(
     },
 )
 
-def pkg_deb(name, package, archive_name=None, **kwargs):
+def pkg_deb(name, package, archive_name = None, **kwargs):
     """Creates a deb file. See pkg_deb_impl."""
     archive_name = archive_name or name
     version = kwargs.get("version") or ""
@@ -449,7 +458,7 @@ def _pkg_zip_impl(ctx):
     for f in ctx.files.srcs:
         arg = "%s=%s" % (
             _quote(f.path),
-            dest_path(f, compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix))
+            dest_path(f, compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix)),
         )
         args.add(arg)
 

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -15,12 +15,10 @@
 
 licenses(["notice"])
 
-load("//:pkg.bzl", "pkg_deb", "pkg_tar", "pkg_zip")
+load("//:pkg.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_deb", "pkg_tar", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-
 load(":my_package_name.bzl", "my_package_naming")
-
 
 filegroup(
     name = "archive_testdata",
@@ -39,16 +37,11 @@ py_test(
     data = [":archive_testdata"],
     python_version = "PY3",
     srcs_version = "PY3",
-    tags = [
-        # TODO(laszlocsomor): fix on Windows or describe why it cannot pass.
-        "no_windows",
-    ],
     deps = [
         "//:archive",
         "@bazel_tools//tools/python/runfiles",
     ],
 )
-
 
 py_test(
     name = "path_test",
@@ -137,7 +130,6 @@ pkg_tar(
     ],
     package_dir_file = "testdata/test_tar_package_dir_file.txt",
 )
-
 
 pkg_tar(
     name = "test_tar_out",
@@ -229,10 +221,10 @@ pkg_zip(
 filegroup(
     name = "test_zip_strip_prefix",
     srcs = [
+        "test-zip-strip_prefix-dot",
         "test-zip-strip_prefix-empty",
         "test-zip-strip_prefix-none",
         "test-zip-strip_prefix-zipcontent",
-        "test-zip-strip_prefix-dot",
     ],
 )
 
@@ -299,21 +291,20 @@ pkg_deb(
     make_deb = "//:make_deb",
     package = "titi",
     preinst = "testdata/deb_preinst",
-    replaces = ["oldpkg"],
     provides = ["hello"],
+    replaces = ["oldpkg"],
     templates = ":testdata/templates",
     urgency = "low",
     version = "test",
 )
 
 [pkg_tar(
-    name = "test-tar-basic-%s" % ext[1:],
+    name = "test-tar-basic-%s" % ext,
     srcs = [
         ":etc/nsswitch.conf",
         ":usr/titi",
     ],
-    extension = "tar%s" % ext,
-    # extension = ext[1:],
+    extension = "tar.%s" % ext if ext else "tar",
     mode = "0644",
     modes = {"usr/titi": "0755"},
     owner = "42.24",
@@ -323,12 +314,7 @@ pkg_deb(
     package_dir = "/",
     strip_prefix = ".",
     symlinks = {"usr/bin/java": "/path/to/bin/java"},
-) for ext in [
-    "",
-    ".gz",
-    ".bz2",
-    ".xz",  # This will breaks if xzcat is not installed
-]]
+) for ext in SUPPORTED_TAR_COMPRESSIONS]
 
 [pkg_tar(
     name = "test-tar-inclusion-%s" % ext,
@@ -337,12 +323,7 @@ pkg_deb(
         ":test-tar-basic-%s" % ext,
         ":test_tar_naming",
     ],
-) for ext in [
-    "",
-    "gz",
-    "bz2",
-    "xz",
-]]
+) for ext in SUPPORTED_TAR_COMPRESSIONS]
 
 pkg_tar(
     name = "test-tar-strip_prefix-empty",
@@ -425,26 +406,25 @@ py_test(
         "pkg_tar_test.py",
     ],
     data = [
-        ":test-tar-basic-.tar",
-        ":test-tar-basic-bz2.tar.bz2",
-        ":test-tar-basic-gz.tar.gz",
-        ":test-tar-basic-xz.tar.xz",
         ":test-tar-empty_dirs.tar",
         ":test-tar-empty_files.tar",
         ":test-tar-files_dict.tar",
-        ":test-tar-inclusion-.tar",
-        ":test-tar-inclusion-bz2.tar",
-        ":test-tar-inclusion-gz.tar",
-        ":test-tar-inclusion-xz.tar",
         ":test-tar-mtime.tar",
         ":test-tar-strip_prefix-dot.tar",
         ":test-tar-strip_prefix-empty.tar",
         ":test-tar-strip_prefix-etc.tar",
         ":test-tar-strip_prefix-none.tar",
         ":test-tar-strip_prefix-substring.tar",
+    ] + [
+        ":test-tar-basic-%s" % compression
+        for compression in SUPPORTED_TAR_COMPRESSIONS
+    ] + [
+        ":test-tar-inclusion-%s" % compression
+        for compression in SUPPORTED_TAR_COMPRESSIONS
     ],
     python_version = "PY3",
     deps = [
+        "//:archive",
         "@bazel_tools//tools/python/runfiles",
     ],
 )
@@ -455,11 +435,11 @@ py_test(
     srcs = [
         "pkg_deb_test.py",
     ],
-    python_version = "PY3",
     data = [
-        ":titi_test_all.deb",
         ":titi_test_all.changes",
+        ":titi_test_all.deb",
     ],
+    python_version = "PY3",
     deps = [
         "//:archive",
         "@bazel_tools//tools/python/runfiles",
@@ -469,7 +449,6 @@ py_test(
 test_suite(
     name = "windows_tests",
     tags = [
-        "-no_windows",
         "-slow",
     ],
     visibility = ["//visibility:private"],

--- a/pkg/tests/archive_test.py
+++ b/pkg/tests/archive_test.py
@@ -211,7 +211,7 @@ class TarFileWriterTest(unittest.TestCase):
         {"name": "./a", "data": b"a"},
         {"name": "./ab", "data": b"ab"},
         ]
-    for ext in ["", ".gz", ".bz2", ".xz"]:
+    for ext in [("." + comp if comp else "") for comp in archive.COMPRESSIONS]:
       with archive.TarFileWriter(self.tempfile) as f:
         datafile = self.data_files.Rlocation(os.path.join(
             "rules_pkg", "tests", "testdata", "tar_test.tar" + ext))

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -17,6 +17,7 @@ import tarfile
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
+from rules_pkg import archive
 
 PORTABLE_MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
 
@@ -159,7 +160,7 @@ class PkgTarTest(unittest.TestCase):
         {'name': './usr/bin'},
         {'name': './usr/bin/java', 'linkname': '/path/to/bin/java'},
     ]
-    for ext in ('', '.gz', '.bz2', '.xz'):
+    for ext in [('.' + comp if comp else '') for comp in archive.COMPRESSIONS]:
       with self.subTest(ext=ext):
         self.assertTarFileContent('test-tar-basic-%s.tar%s' % (ext[1:], ext),
                                   content)
@@ -175,7 +176,7 @@ class PkgTarTest(unittest.TestCase):
         {'name': './usr/bin/java', 'linkname': '/path/to/bin/java'},
         {'name': './BUILD'},
     ]
-    for ext in ('', '.gz', '.bz2', '.xz'):
+    for ext in [('.' + comp if comp else '') for comp in archive.COMPRESSIONS]:
       with self.subTest(ext=ext):
         self.assertTarFileContent('test-tar-inclusion-%s.tar' % ext[1:],
                                   content)


### PR DESCRIPTION
Refactor usage of xz compression so that support for it is limited to one .bzl and one .py file.

Context: #275

Some Python implementations and/or build environments do not have support for xz compression.  In order to make it easier to developer and use the package on those platforms pkg.bzl now provides an indicator of support. That is used in the test cases to conditionally add tests for xz compressed tar files. The python code follows a similar pattern.

This allows someone importing the rules to change only one or two locations to change the test patterns to conform to the constriants of their environment.

Next step: Make the connection between the Starlark and Python code automatic.