### PR TITLE
Replace broken link in pkg_deb doc

### DIFF
--- a/pkg/docs/reference.md
+++ b/pkg/docs/reference.md
@@ -435,7 +435,7 @@ for more details on this.
           where the deb is installed.
         </p>
         <p>
-          See <a href="https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html#s-conffile">https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html#s-conffile</a>.
+          See <a href="https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files">https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files</a>.
         </p>
       </td>
     </tr>


### PR DESCRIPTION
## What problem is being resolved
The link for further information for the `conffiles` and `conffiles_file` attribute of the `pkg_deb` rules yields "Page not found".
See https://github.com/bazelbuild/rules_pkg/blob/main/pkg/docs/reference.md

## Proposed solution
Replace the broken link with a working one.