### PR TITLE
Add support for triggers file to pkg_deb rule

### DIFF
--- a/pkg/docs/reference.md
+++ b/pkg/docs/reference.md
@@ -426,6 +426,18 @@ for more details on this.
       </td>
     </tr>
     <tr>
+      <td><code>triggers</code></td>
+      <td>
+        <code>File, optional</code>
+        <p>
+          triggers file for configuring installation events exchanged by packages.
+        </p>
+        <p>
+          See <a href="https://wiki.debian.org/DpkgTriggers">https://wiki.debian.org/DpkgTriggers</a>.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>conffiles</code>, <code>conffiles_file</code></td>
       <td>
         <code>String list or File, optional</code>

--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -172,6 +172,7 @@ def CreateDeb(output,
               postrm=None,
               config=None,
               templates=None,
+              triggers=None,
               conffiles=None,
               **kwargs):
   """Create a full debian package."""
@@ -188,6 +189,8 @@ def CreateDeb(output,
     extrafiles['config'] = (config, 0o755)
   if templates:
     extrafiles['templates'] = (templates, 0o644)
+  if triggers:
+    extrafiles['triggers'] = (triggers, 0o644)
   if conffiles:
     extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
   control = CreateDebControl(extrafiles=extrafiles, **kwargs)
@@ -325,6 +328,9 @@ def main():
   parser.add_argument(
       '--templates',
       help='The templates file (prefix with @ to provide a path).')
+  parser.add_argument(
+      '--triggers',
+      help='The triggers file (prefix with @ to provide a path).')
   # see
   # https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html#s-conffile
   parser.add_argument(
@@ -342,6 +348,7 @@ def main():
       postrm=GetFlagValue(options.postrm, False),
       config=GetFlagValue(options.config, False),
       templates=GetFlagValue(options.templates, False),
+      triggers=GetFlagValue(options.triggers, False),
       conffiles=GetFlagValues(options.conffile),
       package=options.package,
       version=GetFlagValue(options.version),

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -214,6 +214,9 @@ def _pkg_deb_impl(ctx):
     if ctx.attr.templates:
         args += ["--templates=@" + ctx.file.templates.path]
         files += [ctx.file.templates]
+    if ctx.attr.triggers:
+        args += ["--triggers=@" + ctx.file.triggers.path]
+        files += [ctx.file.triggers]
 
     # Conffiles can be specified by a file or a string list
     if ctx.attr.conffiles_file:
@@ -393,6 +396,7 @@ pkg_deb_impl = rule(
         "postrm": attr.label(allow_single_file = True),
         "config": attr.label(allow_single_file = True),
         "templates": attr.label(allow_single_file = True),
+        "triggers": attr.label(allow_single_file = True),
         "conffiles_file": attr.label(allow_single_file = True),
         "conffiles": attr.string_list(default = []),
         "version_file": attr.label(allow_single_file = True),

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -294,6 +294,7 @@ pkg_deb(
     provides = ["hello"],
     replaces = ["oldpkg"],
     templates = ":testdata/templates",
+    triggers = ":testdata/deb_triggers",
     urgency = "low",
     version = "test",
 )

--- a/pkg/tests/pkg_deb_test.py
+++ b/pkg/tests/pkg_deb_test.py
@@ -178,6 +178,7 @@ class PkgDebTest(unittest.TestCase):
         {'name': './control', 'mode': 0o644},
         {'name': './preinst', 'mode': 0o755},
         {'name': './templates', 'mode': 0o644},
+        {'name': './triggers', 'mode': 0o644},
     ]
     self.assert_control_content(expected, match_order=False)
 
@@ -204,6 +205,13 @@ class PkgDebTest(unittest.TestCase):
     for field in ('Template: titi/test', 'Type: string'):
       if templates.find(field) < 0:
         self.fail('Missing template field: <%s> in <%s>' % (field, templates))
+
+  def test_triggers(self):
+    triggers = self.deb_file.get_deb_ctl_file('triggers')
+    self.assertEqual(
+        triggers,
+        '# tutu ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\n'
+        'some-trigger\n')
 
   def test_changes(self):
     changes_path = self.runfiles.Rlocation(

--- a/pkg/tests/testdata/deb_triggers
+++ b/pkg/tests/testdata/deb_triggers
@@ -1,0 +1,2 @@
+# tutu ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é
+some-trigger


### PR DESCRIPTION
Enables the [triggers Debian package feature](https://wiki.debian.org/DpkgTriggers).
For details see the associated issue.

Fixes https://github.com/bazelbuild/rules_pkg/issues/279