### PR TITLE
Allow for more structured package mapping rule attributes

### DIFF
--- a/pkg/docs/reference.md
+++ b/pkg/docs/reference.md
@@ -23,7 +23,7 @@ These attributes are used in several rules within this module.
 | out               | Name of the output file. This file will always be created and used to access the package content. If `package_file_name` is also specified, `out` will be a symlink.            | String                                                             | required        |                                           |
 | package_file_name | The name of the file which will contain the package. The name may contain variables in the form `{var}`. The values for substitution are specified through `package_variables`. | String                                                             | optional        | package type specific                     |
 | package_variables | A target that provides `PackageVariablesInfo` to substitute into `package_file_name`.                                                                                           | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional        | None                                      |
-| attributes        | Attributes to set on entities created within packages.  Not to be confused with bazel rule attributes.  See 'Mapping "Attributes"' below                                        | dict of String -> String List                                      | optional        | Varies.  See 'Mapping "Attributes"' below |
+| attributes        | Attributes to set on entities created within packages.  Not to be confused with bazel rule attributes.  See 'Mapping "Attributes"' below                                        | Undefined.                                                         | optional        | Varies.  Consult individual rule documentation for details. |
 
 See
 [examples/naming_package_files](https://github.com/bazelbuild/rules_pkg/tree/main/examples/naming_package_files)
@@ -38,31 +38,27 @@ rules such as `pkg_files`, and `pkg_mkdirs`.  These allow fine-grained control
 of the contents of your package.  For example:
 
 ```python
-attributes = {
-    "unix": ("0644", "myapp", "myapp"),
-    "my_custom_attribute": ("some custom value",),
-}
+attributes = pkg_attributes(
+    mode = "0644",
+    user = "root",
+    group = "wheel",
+    my_custom_attribute = "some custom value",
+)
 ```
 
-Known attributes include the following:
+`mode`, `user`, and `group` correspond to common UNIX-style filesystem
+permissions.  Attributes should always be specified using the `pkg_attributes`
+helper macro.
 
-#### `unix`
+When `mode` is not specified, it defaults to "0444" (read-only).  If `user` and
+`group` are not specified, then defaults will be chosen by the underlying
+package builder.  Any specific behavior from package builders should not be
+relied upon.
 
-Specifies basic UNIX-style filesystem permissions. For example:
+Any other attributes should be specified as additional arguments to the
+`pkg_attributes` rule.
 
-```python
-{"unix": ("0755", "root", "root")}
-```
-
-This is a three-element tuple, providing the filesystem mode (as an octal
-string, like above), user, and group.
-
-`"-"` may be provided in place of any of the values in the tuple.  Packaging
-rules will set these to a default, which will vary based on the underlying
-package builder and is otherwise unspecified.  Relying upon values set by it is
-not recommended.
-
-Package mapping rules typically set this to `("-", "-", "-")`.
+There are currently no other well-known attributes known at this time.
 
 ---
 

--- a/pkg/docs/reference.md
+++ b/pkg/docs/reference.md
@@ -50,15 +50,17 @@ attributes = pkg_attributes(
 permissions.  Attributes should always be specified using the `pkg_attributes`
 helper macro.
 
-When `mode` is not specified, it defaults to "0444" (read-only).  If `user` and
-`group` are not specified, then defaults will be chosen by the underlying
-package builder.  Any specific behavior from package builders should not be
-relied upon.
+Each mapping rule has some default mapping attributes.  At this time, the only
+default is "mode", which will be set if it is not otherwise overridden by the user.
 
-Any other attributes should be specified as additional arguments to the
-`pkg_attributes` rule.
+If `user` and `group` are not specified, then defaults for them will be chosen
+by the underlying package builder.  Any specific behavior from package builders
+should not be relied upon.
 
-There are currently no other well-known attributes known at this time.
+Any other attributes should be specified as additional arguments to
+`pkg_attributes`.
+
+There are currently no other well-known attributes.
 
 ---
 

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -209,7 +209,7 @@ def _pkg_files_impl(ctx):
 
     out_attributes = json.decode(ctx.attr.attributes)
 
-    # Default mode is the common, "sane" 0644
+    # The least surprising default mode is that of a normal file (0644)
     out_attributes.setdefault("mode", "0644")
 
     # Do file renaming
@@ -370,7 +370,7 @@ pkg_files = rule(
 def _pkg_mkdirs_impl(ctx):
     out_attributes = json.decode(ctx.attr.attributes)
 
-    # Default mode is the common, "sane" 0755
+    # The least surprising default mode is that of a normal directory (0755)
     out_attributes.setdefault("mode", "0755")
     return [
         PackageDirsInfo(

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -29,31 +29,32 @@ PackageVariablesInfo = provider(
     },
 )
 
-# For the below, attributes always look something like this:
-#
-# ```
-#   {"unix": ["0755", "root", "root"]}
-# ```
-#
-
 PackageFilesInfo = provider(
     doc = """Provider representing the installation of one or more files to destination with attributes""",
     fields = {
-        "attributes": """dict of string -> string list: Attributes to apply to installed file(s)""",
-        # TODO(nacl): determine what types actually should represent the sources
-        # here.  Files, or Labels?
+        "attributes": """Attribute information, represented as a `dict`.
+
+        Keys are strings representing attribute identifiers, values are
+        arbitrary data structures that represent the associated data.  These are
+        most often strings, but are not explicity defined.
+
+        For known attributes and data type expectations, see the Common
+        Attributes documentation in the `rules_pkg` reference.
+        """,
 
         # This is a mapping of destinations to sources to allow for the same
         # target to be installed to multiple locations within a package within a
         # single provider.
-        "dest_src_map": """Map of file destinations to sources""",
+        "dest_src_map": """Map of file destinations to sources.
+
+        Sources are represented by bazel `File` structures.""",
     },
 )
 
 PackageDirsInfo = provider(
     doc = """Provider representing the creation of one or more directories in a package""",
     fields = {
-        "attributes": """dict of string -> string list: Attributes to apply to created directories""",
+        "attributes": """See `attributes` in PackageFilesInfo.""",
         "dirs": """string list: installed directory names""",
     },
 )
@@ -61,7 +62,7 @@ PackageDirsInfo = provider(
 PackageSymlinkInfo = provider(
     doc = """Provider representing the creation of a single symbolic link in a package""",
     fields = {
-        "attributes": """dict of string -> string list: Attributes to apply to created symlink""",
+        "attributes": """See `attributes` in PackageFilesInfo.""",
         "destination": """string: Filesystem link 'name'""",
         "source": """string or Label: Filesystem link 'target'""",
     },

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -18,6 +18,7 @@ load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load(
     "//:mappings.bzl",
+    "pkg_attributes",
     "pkg_files",
     "pkg_mkdirs",
     "strip_prefix",
@@ -33,6 +34,15 @@ def _pkg_files_contents_test_impl(ctx):
 
     asserts.new_set_equals(env, expected_dests, actual_dests, "pkg_files dests do not match expectations")
 
+    # Simple equality checks for the others, if specified
+    if ctx.attr.expected_attributes:
+        asserts.equals(
+            env,
+            json.decode(ctx.attr.expected_attributes),
+            target_under_test[PackageFilesInfo].attributes,
+            "pkg_files attributes do not match expectations",
+        )
+
     return analysistest.end(env)
 
 pkg_files_contents_test = analysistest.make(
@@ -43,7 +53,7 @@ pkg_files_contents_test = analysistest.make(
         "expected_dests": attr.string_list(
             mandatory = True,
         ),
-        # attrs are always passed through unchanged (and maybe rejected)
+        "expected_attributes": attr.string(),
     },
 )
 
@@ -70,6 +80,13 @@ def _test_pkg_files_contents():
     pkg_files(
         name = "pf_no_strip_prefix_g",
         srcs = ["testdata/hello.txt"],
+        attributes = pkg_attributes(
+            mode = "0644",
+            user = "foo",
+            group = "bar",
+            # kwargs begins here
+            foo = "bar",
+        ),
         tags = ["manual"],
     )
 
@@ -77,6 +94,12 @@ def _test_pkg_files_contents():
         name = "pf_no_strip_prefix",
         target_under_test = ":pf_no_strip_prefix_g",
         expected_dests = ["hello.txt"],
+        expected_attributes = pkg_attributes(
+            mode = "0644",
+            user = "foo",
+            group = "bar",
+            foo = "bar",
+        ),
     )
 
     # And now, files_only = True
@@ -479,19 +502,20 @@ def _pkg_mkdirs_contents_test_impl(ctx):
     asserts.new_set_equals(env, expected_dirs, actual_dirs, "pkg_mkdirs dirs do not match expectations")
 
     # Simple equality checks for the others
-    asserts.equals(
-        env,
-        ctx.attr.expected_attributes,
-        target_under_test[PackageDirsInfo].attributes,
-        "pkg_mkdir attributes do not match expectations",
-    )
+    if ctx.attr.expected_attributes != None:
+        asserts.equals(
+            env,
+            json.decode(ctx.attr.expected_attributes),
+            target_under_test[PackageDirsInfo].attributes,
+            "pkg_mkdir attributes do not match expectations",
+        )
 
     return analysistest.end(env)
 
 pkg_mkdirs_contents_test = analysistest.make(
     _pkg_mkdirs_contents_test_impl,
     attrs = {
-        "expected_attributes": attr.string_list_dict(),
+        "expected_attributes": attr.string(),
         "expected_dirs": attr.string_list(
             mandatory = True,
         ),
@@ -503,14 +527,22 @@ def _test_pkg_mkdirs():
     pkg_mkdirs(
         name = "pkg_mkdirs_base_g",
         dirs = ["foo/bar", "baz"],
-        attributes = {"unix": ["0711", "root", "sudo"]},
+        attributes = pkg_attributes(
+            mode = "0711",
+            user = "root",
+            group = "sudo",
+        ),
         tags = ["manual"],
     )
     pkg_mkdirs_contents_test(
         name = "pkg_mkdirs_base",
         target_under_test = "pkg_mkdirs_base_g",
         expected_dirs = ["foo/bar", "baz"],
-        expected_attributes = {"unix": ["0711", "root", "sudo"]},
+        expected_attributes = pkg_attributes(
+            mode = "0711",
+            user = "root",
+            group = "sudo",
+        ),
     )
 
 ##########

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -81,7 +81,7 @@ def _test_pkg_files_contents():
         name = "pf_no_strip_prefix_g",
         srcs = ["testdata/hello.txt"],
         attributes = pkg_attributes(
-            mode = "0644",
+            mode = "0755",
             user = "foo",
             group = "bar",
             # kwargs begins here
@@ -95,7 +95,7 @@ def _test_pkg_files_contents():
         target_under_test = ":pf_no_strip_prefix_g",
         expected_dests = ["hello.txt"],
         expected_attributes = pkg_attributes(
-            mode = "0644",
+            mode = "0755",
             user = "foo",
             group = "bar",
             foo = "bar",
@@ -172,6 +172,31 @@ def _test_pkg_files_contents():
             # The generated target output, in this case, a symlink
             "testdata/test_script",
         ],
+    )
+
+    # Test that the default mode (0644) is always set regardless of the other
+    # values in "attributes".
+    pkg_files(
+        name = "pf_attributes_mode_overlay_if_not_provided_g",
+        srcs = ["foo"],
+        strip_prefix = strip_prefix.from_pkg(),
+        attributes = pkg_attributes(
+            user = "foo",
+            group = "bar",
+            foo = "bar",
+        ),
+        tags = ["manual"],
+    )
+    pkg_files_contents_test(
+        name = "pf_attributes_mode_overlay_if_not_provided",
+        target_under_test = ":pf_attributes_mode_overlay_if_not_provided_g",
+        expected_dests = ["foo"],
+        expected_attributes = pkg_attributes(
+            mode = "0644",
+            user = "foo",
+            group = "bar",
+            foo = "bar",
+        ),
     )
 
     # Test that pkg_files rejects cases where two sources resolve to the same
@@ -536,10 +561,32 @@ def _test_pkg_mkdirs():
     )
     pkg_mkdirs_contents_test(
         name = "pkg_mkdirs_base",
-        target_under_test = "pkg_mkdirs_base_g",
+        target_under_test = ":pkg_mkdirs_base_g",
         expected_dirs = ["foo/bar", "baz"],
         expected_attributes = pkg_attributes(
             mode = "0711",
+            user = "root",
+            group = "sudo",
+        ),
+    )
+
+    # Test that the default mode (0755) is always set regardless of the other
+    # values in "attributes".
+    pkg_mkdirs(
+        name = "pkg_mkdirs_mode_overlay_if_not_provided_g",
+        dirs = ["foo"],
+        attributes = pkg_attributes(
+            user = "root",
+            group = "sudo",
+        ),
+        tags = ["manual"],
+    )
+    pkg_mkdirs_contents_test(
+        name = "pkg_mkdirs_mode_overlay_if_not_provided",
+        target_under_test = ":pkg_mkdirs_mode_overlay_if_not_provided_g",
+        expected_dirs = ["foo"],
+        expected_attributes = pkg_attributes(
+            mode = "0755",
             user = "root",
             group = "sudo",
         ),
@@ -579,6 +626,7 @@ def mappings_analysis_tests():
             ":pf_files_only",
             ":pf_strip_testdata_from_pkg",
             ":pf_strip_prefix_from_root",
+            ":pf_attributes_mode_overlay_if_not_provided",
             # Tests involving excluded files
             ":pf_exclude_by_label_strip_all",
             ":pf_exclude_by_filename_strip_all",
@@ -609,6 +657,7 @@ def mappings_analysis_tests():
             ":pf_rename_single_excluded_value",
             # Tests involving pkg_mkdirs
             ":pkg_mkdirs_base",
+            ":pkg_mkdirs_mode_overlay_if_not_provided",
         ],
     )
 


### PR DESCRIPTION
This change modifies the `attributes` attribute of `pkg_files` and `pkg_mkdirs`
to allow for more structured inputs than a list of strings.

For the lack of a better option, the solution for this right now is to serialize
the data in terms of JSON strings, which will be assembled using the new
`pkg_attributes` macro.  Users should always use `pkg_attributes` for this
purpose.

The JSON is decoded within the mapping rules and passed out through their
providers.

A better option would be to pass Providers full of structured data directly into
rules, but, unfortunately Bazel does not support this at this time.