### PR TITLE
Provide pkg_mklink, pkg_filegroup

### DIFF
--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -480,7 +480,7 @@ pkg_mklink = rule(
             mandatory = True,
         ),
         "attributes": attr.string(
-            doc = """Attributes to set on packaged directories.
+            doc = """Attributes to set on packaged symbolic links.
 
             Always use `pkg_attributes()` to set this rule attribute.
 

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -509,7 +509,7 @@ def _pkg_filegroup_impl(ctx):
                     },
                     attributes = s[PackageFilesInfo].attributes,
                 )
-                files.append(new_pfi)
+                files.append((new_pfi, s.label))
 
                 # dict.values() returns a list, not an iterator like in python3
                 mapped_files_depsets.append(s[DefaultInfo].files)
@@ -519,7 +519,7 @@ def _pkg_filegroup_impl(ctx):
                     dirs = [paths.join(ctx.attr.prefix, d) for d in s[PackageDirsInfo].dirs],
                     attributes = s[PackageDirsInfo].attributes,
                 )
-                dirs.append(new_pdi)
+                dirs.append((new_pdi, s.label))
 
             if PackageSymlinkInfo in s:
                 new_psi = PackageSymlinkInfo(
@@ -527,19 +527,19 @@ def _pkg_filegroup_impl(ctx):
                     destination = paths.join(ctx.attr.prefix, s[PackageSymlinkInfo].destination),
                     attributes = s[PackageSymlinkInfo].attributes,
                 )
-                links.append(new_psi)
+                links.append((new_psi, s.label))
     else:
         # Otherwise, everything is pretty much direct copies
         for s in ctx.attr.srcs:
             if PackageFilesInfo in s:
-                files.append(s[PackageFilesInfo])
+                files.append((s[PackageFilesInfo], s.label))
 
                 # dict.values() returns a list, not an iterator like in python3
                 mapped_files_depsets.append(s[DefaultInfo].files)
             if PackageDirsInfo in s:
-                dirs.append(s[PackageDirsInfo])
+                dirs.append((s[PackageDirsInfo], s.label))
             if PackageSymlinkInfo in s:
-                links.append(s[PackageSymlinkInfo])
+                links.append((s[PackageSymlinkInfo], s.label))
 
     return [
         PackageFilegroupInfo(

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -20,13 +20,15 @@ the following:
 
 - `pkg_files` describes destinations for rule outputs
 - `pkg_mkdirs` describes directory structures
+- `pkg_mklink` describes symbolic links
+- `pkg_filegroup` creates groupings of above to add to packages
 
 Rules that actually make use of the outputs of the above rules are not specified
 here.  TODO(nacl): implement one.
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//:providers.bzl", "PackageDirsInfo", "PackageFilesInfo")
+load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 
 _PKGFILEGROUP_STRIP_ALL = "."
 
@@ -425,4 +427,159 @@ pkg_mkdirs = rule(
         ),
     },
     provides = [PackageDirsInfo],
+)
+
+def _pkg_mklink_impl(ctx):
+    return [
+        PackageSymlinkInfo(
+            destination = ctx.attr.dest,
+            source = ctx.attr.src,
+            attributes = json.decode(ctx.attr.attributes),
+        ),
+    ]
+
+pkg_mklink = rule(
+    doc = """Define a symlink  within packages
+
+    This rule results in the creation of a single link within a package.
+
+    Symbolic links specified by this rule may point at files/directories outside of the
+    package, or otherwise left dangling.
+
+    """,
+    implementation = _pkg_mklink_impl,
+    attrs = {
+        "dest": attr.string(
+            doc = """Link "target", a path within the package.
+
+            This is the actual created symbolic link.
+
+            If the directory structure provided by this attribute is not
+            otherwise created when exist within the package when it is built, it
+            will be created implicitly, much like with `pkg_files`.
+
+            This path may be prefixed or rooted by grouping or packaging rules.
+
+            """,
+            mandatory = True,
+        ),
+        "src": attr.string(
+            doc = """Link "source", a path on the filesystem.
+
+            This is what the link "points" to, and may point to an arbitrary
+            filesystem path, even relative paths.
+
+            """,
+            mandatory = True,
+        ),
+        "attributes": attr.string(
+            doc = """Attributes to set on packaged directories.
+
+            Always use `pkg_attributes()` to set this rule attribute.
+
+            The default value for this is UNIX "0777", or the target
+            platform's equivalent.  All other values are left unspecified.
+
+            Symlink permissions may have different meanings depending on your
+            host operating system; consult its documentation for more details.
+
+            Consult the "Mapping Attributes" documentation in the rules_pkg
+            reference for more details.
+            """,
+            default = pkg_attributes(mode = "0777"),
+        ),
+    },
+    provides = [PackageSymlinkInfo],
+)
+
+def _pkg_filegroup_impl(ctx):
+    files = []
+    dirs = []
+    links = []
+    mapped_files_depsets = []
+
+    if ctx.attr.prefix:
+        # If "prefix" is provided, we need to manipulate the incoming providers.
+        for s in ctx.attr.srcs:
+            if PackageFilesInfo in s:
+                new_pfi = PackageFilesInfo(
+                    dest_src_map = {
+                        paths.join(ctx.attr.prefix, dest): src
+                        for dest, src in s[PackageFilesInfo].dest_src_map.items()
+                    },
+                    attributes = s[PackageFilesInfo].attributes,
+                )
+                files.append(new_pfi)
+
+                # dict.values() returns a list, not an iterator like in python3
+                mapped_files_depsets.append(s[DefaultInfo].files)
+
+            if PackageDirsInfo in s:
+                new_pdi = PackageDirsInfo(
+                    dirs = [paths.join(ctx.attr.prefix, d) for d in s[PackageDirsInfo].dirs],
+                    attributes = s[PackageDirsInfo].attributes,
+                )
+                dirs.append(new_pdi)
+
+            if PackageSymlinkInfo in s:
+                new_psi = PackageSymlinkInfo(
+                    source = s[PackageSymlinkInfo].source,
+                    destination = paths.join(ctx.attr.prefix, s[PackageSymlinkInfo].destination),
+                    attributes = s[PackageSymlinkInfo].attributes,
+                )
+                links.append(new_psi)
+    else:
+        # Otherwise, everything is pretty much direct copies
+        for s in ctx.attr.srcs:
+            if PackageFilesInfo in s:
+                files.append(s[PackageFilesInfo])
+
+                # dict.values() returns a list, not an iterator like in python3
+                mapped_files_depsets.append(s[DefaultInfo].files)
+            if PackageDirsInfo in s:
+                dirs.append(s[PackageDirsInfo])
+            if PackageSymlinkInfo in s:
+                links.append(s[PackageSymlinkInfo])
+
+    return [
+        PackageFilegroupInfo(
+            pkg_files = files,
+            pkg_dirs = dirs,
+            pkg_symlinks = links,
+        ),
+        # Necessary to ensure that dependent rules have access to files being
+        # mapped in.
+        DefaultInfo(
+            files = depset(transitive = mapped_files_depsets),
+        ),
+    ]
+
+pkg_filegroup = rule(
+    doc = """Package contents grouping rule.
+
+    This rule represents a collection of packaging specifications (e.g. those
+    created by `pkg_files`, `pkg_mklink`, etc.) that have something in common,
+    such as a prefix or a human-readable category.
+    """,
+    implementation = _pkg_filegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = """A list of packaging specifications to be grouped together.""",
+            mandatory = True,
+            providers = [
+                [PackageFilesInfo, DefaultInfo],
+                [PackageDirsInfo],
+                [PackageSymlinkInfo],
+            ],
+        ),
+        "prefix": attr.string(
+            doc = """A prefix to prepend to provided paths, applied like so:
+
+            - For files and directories, this is simply prepended to the destination
+            - For symbolic links, this is prepended to the "destination" part.
+
+            """,
+        ),
+    },
+    provides = [PackageFilegroupInfo],
 )

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -64,7 +64,10 @@ PackageSymlinkInfo = provider(
     fields = {
         "attributes": """See `attributes` in PackageFilesInfo.""",
         "destination": """string: Filesystem link 'name'""",
-        "source": """string or Label: Filesystem link 'target'""",
+        "source": """string or Label: Filesystem link 'target'.
+        
+        TODO(nacl): Label sources not yet supported.
+        """,
     },
 )
 
@@ -74,7 +77,7 @@ PackageFilegroupInfo = provider(
     doc = """Provider representing a collection of related packaging providers""",
     fields = {
         "pkg_files": "list of child PackageFilesInfo providers",
-        "pkg_dirs": "list of child PackageDirInfo providers",
+        "pkg_dirs": "list of child PackageDirsInfo providers",
         "pkg_symlinks": "list of child PackageSymlinkInfo providers",
     },
 )

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -65,7 +65,7 @@ PackageSymlinkInfo = provider(
         "attributes": """See `attributes` in PackageFilesInfo.""",
         "destination": """string: Filesystem link 'name'""",
         "source": """string or Label: Filesystem link 'target'.
-        
+
         TODO(nacl): Label sources not yet supported.
         """,
     },
@@ -74,10 +74,17 @@ PackageSymlinkInfo = provider(
 # Grouping provider: the only one that needs to be consumed by packaging (or
 # other) rules that materialize paths.
 PackageFilegroupInfo = provider(
-    doc = """Provider representing a collection of related packaging providers""",
+    doc = """Provider representing a collection of related packaging providers,
+
+    In the "fields" documentation, "origin" refers to the label identifying the
+    where the provider was originally defined.  This can be used by packaging
+    rules to provide better diagnostics related to where packaging rules were
+    created.
+
+    """,
     fields = {
-        "pkg_files": "list of child PackageFilesInfo providers",
-        "pkg_dirs": "list of child PackageDirsInfo providers",
-        "pkg_symlinks": "list of child PackageSymlinkInfo providers",
+        "pkg_files": "list of tuples of (PackageFilesInfo, origin)",
+        "pkg_dirs": "list of tuples of (PackageDirsInfo, origin)",
+        "pkg_symlinks": "list of tuples of (PackageSymlinkInfo, origin)",
     },
 )

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -655,6 +655,7 @@ def _test_pkg_mklink():
         dest = "foo",
         src = "bar",
         tags = ["manual"],
+        attributes = pkg_attributes(mode = "0111"),
     )
 
     pkg_mklink_contents_test(
@@ -662,7 +663,31 @@ def _test_pkg_mklink():
         target_under_test = ":pkg_mklink_base_g",
         expected_dest = "foo",
         expected_src = "bar",
-        expected_attributes = pkg_attributes(mode = "0777"),
+        expected_attributes = pkg_attributes(mode = "0111"),
+    )
+
+    # Test that the default mode (0755) is always set regardless of the other
+    # values in "attributes".
+    pkg_mklink(
+        name = "pkg_mklink_mode_overlay_if_not_provided_g",
+        dest = "foo",
+        src = "bar",
+        attributes = pkg_attributes(
+            user = "root",
+            group = "sudo",
+        ),
+        tags = ["manual"],
+    )
+    pkg_mklink_contents_test(
+        name = "pkg_mklink_mode_overlay_if_not_provided",
+        target_under_test = ":pkg_mklink_mode_overlay_if_not_provided_g",
+        expected_dest = "foo",
+        expected_src = "bar",
+        expected_attributes = pkg_attributes(
+            mode = "0777",
+            user = "root",
+            group = "sudo",
+        ),
     )
 
 ##########
@@ -919,6 +944,7 @@ def mappings_analysis_tests():
             ":pkg_mkdirs_mode_overlay_if_not_provided",
             # Tests involving pkg_mklink
             ":pkg_mklink_base",
+            ":pkg_mklink_mode_overlay_if_not_provided",
             # Tests involving pkg_filegroup
             ":pfg_tests",
         ],

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -853,7 +853,7 @@ def _test_pkg_filegroup(name):
         expected_pkg_files = ["{}_pkg_files_prefixed".format(name)],
         expected_pkg_dirs = ["{}_pkg_dirs_prefixed".format(name)],
         expected_pkg_symlinks = ["{}_pkg_symlink_prefixed".format(name)],
-        # The origins for everythin will be wrong here, since they're derived
+        # The origins for everything will be wrong here, since they're derived
         # from the labels of the inputs to pkg_filegroup.
         #
         # The first test here should be adequate for this purpose.

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -16,14 +16,28 @@
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 load(
     "//:mappings.bzl",
     "pkg_attributes",
+    "pkg_filegroup",
     "pkg_files",
     "pkg_mkdirs",
+    "pkg_mklink",
     "strip_prefix",
 )
-load("//:providers.bzl", "PackageDirsInfo", "PackageFilesInfo")
+
+##########
+# Helpers
+##########
+
+def _flatten(list_of_lists):
+    """Transform a list of lists into a single list, preserving relative order."""
+    return [item for sublist in list_of_lists for item in sublist]
+
+##########
+# pkg_files tests
+##########
 
 def _pkg_files_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -42,6 +56,8 @@ def _pkg_files_contents_test_impl(ctx):
             target_under_test[PackageFilesInfo].attributes,
             "pkg_files attributes do not match expectations",
         )
+
+    # TODO(nacl): verify DefaultInfo propagation
 
     return analysistest.end(env)
 
@@ -593,6 +609,215 @@ def _test_pkg_mkdirs():
     )
 
 ##########
+# Test pkg_mklink
+##########
+def _pkg_mklink_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        ctx.attr.expected_src,
+        target_under_test[PackageSymlinkInfo].source,
+        "pkg_mklink source does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        ctx.attr.expected_dest,
+        target_under_test[PackageSymlinkInfo].destination,
+        "pkg_mklink destination does not match expectations",
+    )
+
+    # Simple equality checks for the others, if specified
+    if ctx.attr.expected_attributes:
+        asserts.equals(
+            env,
+            json.decode(ctx.attr.expected_attributes),
+            target_under_test[PackageSymlinkInfo].attributes,
+            "pkg_mklink attributes do not match expectations",
+        )
+
+    return analysistest.end(env)
+
+pkg_mklink_contents_test = analysistest.make(
+    _pkg_mklink_contents_test_impl,
+    attrs = {
+        "expected_src": attr.string(mandatory = True),
+        "expected_dest": attr.string(mandatory = True),
+        "expected_attributes": attr.string(),
+    },
+)
+
+def _test_pkg_mklink():
+    pkg_mklink(
+        name = "pkg_mklink_base_g",
+        dest = "foo",
+        src = "bar",
+        tags = ["manual"],
+    )
+
+    pkg_mklink_contents_test(
+        name = "pkg_mklink_base",
+        target_under_test = ":pkg_mklink_base_g",
+        expected_dest = "foo",
+        expected_src = "bar",
+        expected_attributes = pkg_attributes(mode = "0777"),
+    )
+
+##########
+# Test pkg_filegroup
+##########
+def _pkg_filegroup_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        [t[PackageFilesInfo] for t in ctx.attr.expected_pkg_files],
+        target_under_test[PackageFilegroupInfo].pkg_files,
+        "pkg_filegroup file list does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        [t[PackageDirsInfo] for t in ctx.attr.expected_pkg_dirs],
+        target_under_test[PackageFilegroupInfo].pkg_dirs,
+        "pkg_filegroup directory list does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        [t[PackageSymlinkInfo] for t in ctx.attr.expected_pkg_symlinks],
+        target_under_test[PackageFilegroupInfo].pkg_symlinks,
+        "pkg_filegroup symlink map list does not match expectations",
+    )
+
+    # Verify that the DefaultInfo is propagated properly out of the input
+    # pkg_files's -- these are the files that need to be passed along to the
+    # packaging rules.
+    expected_packaged_files = sorted(_flatten([
+        t[DefaultInfo].files.to_list()
+        for t in ctx.attr.expected_pkg_files
+    ]))
+    packaged_files = sorted(target_under_test[DefaultInfo].files.to_list())
+
+    asserts.equals(
+        env,
+        expected_packaged_files,
+        packaged_files,
+        "pkg_filegroup does not propagate DefaultInfo from pkg_file inputs",
+    )
+
+    return analysistest.end(env)
+
+pkg_filegroup_contents_test = analysistest.make(
+    _pkg_filegroup_contents_test_impl,
+    attrs = {
+        "expected_pkg_files": attr.label_list(
+            providers = [PackageFilesInfo],
+            default = [],
+        ),
+        "expected_pkg_dirs": attr.label_list(
+            providers = [PackageDirsInfo],
+            default = [],
+        ),
+        "expected_pkg_symlinks": attr.label_list(
+            providers = [PackageSymlinkInfo],
+            default = [],
+        ),
+    },
+)
+
+def _test_pkg_filegroup(name):
+    pkg_files(
+        name = "{}_pkg_files".format(name),
+        srcs = ["foo", "bar"],
+        prefix = "bin",
+        tags = ["manual"],
+    )
+
+    pkg_mkdirs(
+        name = "{}_pkg_dirs".format(name),
+        dirs = ["etc"],
+        tags = ["manual"],
+    )
+
+    pkg_mklink(
+        name = "{}_pkg_symlink".format(name),
+        src = "src",
+        dest = "dest",
+        tags = ["manual"],
+    )
+
+    pkg_filegroup(
+        name = "{}_pfg".format(name),
+        srcs = [t.format(name) for t in ["{}_pkg_files", "{}_pkg_dirs", "{}_pkg_symlink"]],
+        tags = ["manual"],
+    )
+
+    # Base case: confirm that basic data translation is working
+    pkg_filegroup_contents_test(
+        name = "{}_contents_valid".format(name),
+        target_under_test = "{}_pfg".format(name),
+        expected_pkg_files = ["{}_pkg_files".format(name)],
+        expected_pkg_dirs = ["{}_pkg_dirs".format(name)],
+        expected_pkg_symlinks = ["{}_pkg_symlink".format(name)],
+    )
+
+    ##################################################
+
+    pkg_files(
+        name = "{}_pkg_files_prefixed".format(name),
+        srcs = ["foo", "bar"],
+        prefix = "prefix/bin",
+        tags = ["manual"],
+    )
+
+    pkg_mkdirs(
+        name = "{}_pkg_dirs_prefixed".format(name),
+        dirs = ["prefix/etc"],
+        tags = ["manual"],
+    )
+
+    pkg_mklink(
+        name = "{}_pkg_symlink_prefixed".format(name),
+        src = "src",
+        dest = "prefix/dest",
+        tags = ["manual"],
+    )
+
+    # Test that prefixing works by using the unprefixed mapping rules we
+    # initially created, and set a prefix.
+    pkg_filegroup(
+        name = "{}_prefixed_pfg".format(name),
+        srcs = [t.format(name) for t in ["{}_pkg_files", "{}_pkg_dirs", "{}_pkg_symlink"]],
+        prefix = "prefix",
+        tags = ["manual"],
+    )
+
+    # Then test that the results are equivalent to manually specifying the
+    # prefix everywhere.
+    pkg_filegroup_contents_test(
+        name = "{}_contents_prefix_translated".format(name),
+        target_under_test = "{}_prefixed_pfg".format(name),
+        expected_pkg_files = ["{}_pkg_files_prefixed".format(name)],
+        expected_pkg_dirs = ["{}_pkg_dirs_prefixed".format(name)],
+        expected_pkg_symlinks = ["{}_pkg_symlink_prefixed".format(name)],
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            t.format(name)
+            for t in [
+                "{}_contents_valid",
+                "{}_contents_prefix_translated",
+            ]
+        ],
+    )
+
+##########
 # Test strip_prefix pseudo-module
 ##########
 
@@ -614,6 +839,11 @@ def mappings_analysis_tests():
     _test_pkg_files_extrepo()
     _test_pkg_files_rename()
     _test_pkg_mkdirs()
+    _test_pkg_mklink()
+
+    # TODO(nacl) migrate the above to use a scheme the one used here.  At the very
+    # least, the test suites should be easy to find/name.
+    _test_pkg_filegroup(name = "pfg_tests")
 
     native.test_suite(
         name = "pkg_files_analysis_tests",
@@ -658,6 +888,10 @@ def mappings_analysis_tests():
             # Tests involving pkg_mkdirs
             ":pkg_mkdirs_base",
             ":pkg_mkdirs_mode_overlay_if_not_provided",
+            # Tests involving pkg_mklink
+            ":pkg_mklink_base",
+            # Tests involving pkg_filegroup
+            ":pfg_tests",
         ],
     )
 


### PR DESCRIPTION
This change provides the last two pieces of the basic package creation puzzle: a
symbolic link provisioning rule (`pkg_mklink`) and a simple package grouping
rule (`pkg_filegroup`).

As compared to the original rules in `pkg/experimental/pkg_filegroup.bzl`:

- `pkg_mklink` (formerly `pkg_mklinks`) now operates on a single
  source-destination pair.  This is to ease integration of a planned feature
  where you will be able to make symbolic links to targets named by a label.
  The mechanics of this particular feature are not fleshed out at this time, but
  the current feeling is that these will be resolved as a part of the
  `pkg_filegroup` rule.

  To create multiple links, you can use a list comprehension in a BUILD
  file with minimal loss of clarity.

- `pkg_filegroup` is now an example of a "Grouping Rule", which allows for common
  groups of packaged files to be associated under a common name and prefix.  These
  are intended to be inputs to packaging rules (`pkg_rpm`, `pkg_tar`, etc.).

Tests are included for all of the above.