### PR TITLE
Provide pkg_filegroup-using pkg_rpm contents/analysis tests

### DIFF
--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -480,7 +480,7 @@ pkg_mklink = rule(
             mandatory = True,
         ),
         "attributes": attr.string(
-            doc = """Attributes to set on packaged directories.
+            doc = """Attributes to set on packaged symbolic links.
 
             Always use `pkg_attributes()` to set this rule attribute.
 

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -509,7 +509,7 @@ def _pkg_filegroup_impl(ctx):
                     },
                     attributes = s[PackageFilesInfo].attributes,
                 )
-                files.append(new_pfi)
+                files.append((new_pfi, s.label))
 
                 # dict.values() returns a list, not an iterator like in python3
                 mapped_files_depsets.append(s[DefaultInfo].files)
@@ -519,7 +519,7 @@ def _pkg_filegroup_impl(ctx):
                     dirs = [paths.join(ctx.attr.prefix, d) for d in s[PackageDirsInfo].dirs],
                     attributes = s[PackageDirsInfo].attributes,
                 )
-                dirs.append(new_pdi)
+                dirs.append((new_pdi, s.label))
 
             if PackageSymlinkInfo in s:
                 new_psi = PackageSymlinkInfo(
@@ -527,19 +527,19 @@ def _pkg_filegroup_impl(ctx):
                     destination = paths.join(ctx.attr.prefix, s[PackageSymlinkInfo].destination),
                     attributes = s[PackageSymlinkInfo].attributes,
                 )
-                links.append(new_psi)
+                links.append((new_psi, s.label))
     else:
         # Otherwise, everything is pretty much direct copies
         for s in ctx.attr.srcs:
             if PackageFilesInfo in s:
-                files.append(s[PackageFilesInfo])
+                files.append((s[PackageFilesInfo], s.label))
 
                 # dict.values() returns a list, not an iterator like in python3
                 mapped_files_depsets.append(s[DefaultInfo].files)
             if PackageDirsInfo in s:
-                dirs.append(s[PackageDirsInfo])
+                dirs.append((s[PackageDirsInfo], s.label))
             if PackageSymlinkInfo in s:
-                links.append(s[PackageSymlinkInfo])
+                links.append((s[PackageSymlinkInfo], s.label))
 
     return [
         PackageFilegroupInfo(

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -20,13 +20,15 @@ the following:
 
 - `pkg_files` describes destinations for rule outputs
 - `pkg_mkdirs` describes directory structures
+- `pkg_mklink` describes symbolic links
+- `pkg_filegroup` creates groupings of above to add to packages
 
 Rules that actually make use of the outputs of the above rules are not specified
 here.  TODO(nacl): implement one.
 """
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//:providers.bzl", "PackageDirsInfo", "PackageFilesInfo")
+load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 
 _PKGFILEGROUP_STRIP_ALL = "."
 
@@ -425,4 +427,159 @@ pkg_mkdirs = rule(
         ),
     },
     provides = [PackageDirsInfo],
+)
+
+def _pkg_mklink_impl(ctx):
+    return [
+        PackageSymlinkInfo(
+            destination = ctx.attr.dest,
+            source = ctx.attr.src,
+            attributes = json.decode(ctx.attr.attributes),
+        ),
+    ]
+
+pkg_mklink = rule(
+    doc = """Define a symlink  within packages
+
+    This rule results in the creation of a single link within a package.
+
+    Symbolic links specified by this rule may point at files/directories outside of the
+    package, or otherwise left dangling.
+
+    """,
+    implementation = _pkg_mklink_impl,
+    attrs = {
+        "dest": attr.string(
+            doc = """Link "target", a path within the package.
+
+            This is the actual created symbolic link.
+
+            If the directory structure provided by this attribute is not
+            otherwise created when exist within the package when it is built, it
+            will be created implicitly, much like with `pkg_files`.
+
+            This path may be prefixed or rooted by grouping or packaging rules.
+
+            """,
+            mandatory = True,
+        ),
+        "src": attr.string(
+            doc = """Link "source", a path on the filesystem.
+
+            This is what the link "points" to, and may point to an arbitrary
+            filesystem path, even relative paths.
+
+            """,
+            mandatory = True,
+        ),
+        "attributes": attr.string(
+            doc = """Attributes to set on packaged directories.
+
+            Always use `pkg_attributes()` to set this rule attribute.
+
+            The default value for this is UNIX "0777", or the target
+            platform's equivalent.  All other values are left unspecified.
+
+            Symlink permissions may have different meanings depending on your
+            host operating system; consult its documentation for more details.
+
+            Consult the "Mapping Attributes" documentation in the rules_pkg
+            reference for more details.
+            """,
+            default = pkg_attributes(mode = "0777"),
+        ),
+    },
+    provides = [PackageSymlinkInfo],
+)
+
+def _pkg_filegroup_impl(ctx):
+    files = []
+    dirs = []
+    links = []
+    mapped_files_depsets = []
+
+    if ctx.attr.prefix:
+        # If "prefix" is provided, we need to manipulate the incoming providers.
+        for s in ctx.attr.srcs:
+            if PackageFilesInfo in s:
+                new_pfi = PackageFilesInfo(
+                    dest_src_map = {
+                        paths.join(ctx.attr.prefix, dest): src
+                        for dest, src in s[PackageFilesInfo].dest_src_map.items()
+                    },
+                    attributes = s[PackageFilesInfo].attributes,
+                )
+                files.append(new_pfi)
+
+                # dict.values() returns a list, not an iterator like in python3
+                mapped_files_depsets.append(s[DefaultInfo].files)
+
+            if PackageDirsInfo in s:
+                new_pdi = PackageDirsInfo(
+                    dirs = [paths.join(ctx.attr.prefix, d) for d in s[PackageDirsInfo].dirs],
+                    attributes = s[PackageDirsInfo].attributes,
+                )
+                dirs.append(new_pdi)
+
+            if PackageSymlinkInfo in s:
+                new_psi = PackageSymlinkInfo(
+                    source = s[PackageSymlinkInfo].source,
+                    destination = paths.join(ctx.attr.prefix, s[PackageSymlinkInfo].destination),
+                    attributes = s[PackageSymlinkInfo].attributes,
+                )
+                links.append(new_psi)
+    else:
+        # Otherwise, everything is pretty much direct copies
+        for s in ctx.attr.srcs:
+            if PackageFilesInfo in s:
+                files.append(s[PackageFilesInfo])
+
+                # dict.values() returns a list, not an iterator like in python3
+                mapped_files_depsets.append(s[DefaultInfo].files)
+            if PackageDirsInfo in s:
+                dirs.append(s[PackageDirsInfo])
+            if PackageSymlinkInfo in s:
+                links.append(s[PackageSymlinkInfo])
+
+    return [
+        PackageFilegroupInfo(
+            pkg_files = files,
+            pkg_dirs = dirs,
+            pkg_symlinks = links,
+        ),
+        # Necessary to ensure that dependent rules have access to files being
+        # mapped in.
+        DefaultInfo(
+            files = depset(transitive = mapped_files_depsets),
+        ),
+    ]
+
+pkg_filegroup = rule(
+    doc = """Package contents grouping rule.
+
+    This rule represents a collection of packaging specifications (e.g. those
+    created by `pkg_files`, `pkg_mklink`, etc.) that have something in common,
+    such as a prefix or a human-readable category.
+    """,
+    implementation = _pkg_filegroup_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = """A list of packaging specifications to be grouped together.""",
+            mandatory = True,
+            providers = [
+                [PackageFilesInfo, DefaultInfo],
+                [PackageDirsInfo],
+                [PackageSymlinkInfo],
+            ],
+        ),
+        "prefix": attr.string(
+            doc = """A prefix to prepend to provided paths, applied like so:
+
+            - For files and directories, this is simply prepended to the destination
+            - For symbolic links, this is prepended to the "destination" part.
+
+            """,
+        ),
+    },
+    provides = [PackageFilegroupInfo],
 )

--- a/pkg/new/BUILD
+++ b/pkg/new/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+exports_files(
+    glob([
+        "*.bzl",
+        "template.spec.in",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "standard_package",
+    srcs = glob([
+        "*.bzl",
+    ]) + [
+        "BUILD",
+        "template.spec.in",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/pkg/new/BUILD
+++ b/pkg/new/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2020 The Bazel Authors. All rights reserved.
+# Copyright 2021 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])
+load("//:mappings.bzl", "pkg_filegroup", "pkg_files")
+load(":rpm.bzl", "pkg_rpm")
+
+# TODO(nacl): this needs to be exported to the package.  Will look into this
+# once we know how we're going to be laying everything out.
 
 exports_files(
     glob([
         "*.bzl",
+    ]) + [
         "template.spec.in",
-    ]),
+    ],
     visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "standard_package",
-    srcs = glob([
-        "*.bzl",
-    ]) + [
-        "BUILD",
-        "template.spec.in",
-    ],
-    visibility = ["//:__pkg__"],
+pkg_files(
+    name = "artifacts",
+    srcs = [":template.spec.in"],
+)
+
+pkg_filegroup(
+    name = "usr_share_artifacts",
+    srcs = [":artifacts"],
+)
+
+pkg_rpm(
+    name = "example",
+    srcs = [":usr_share_artifacts"],
+    description = "Other example!",
+    license = "N/A",
+    release = "1",
+    summary = "Example!",
+    version = "1.0",
 )

--- a/pkg/new/rpm.bzl
+++ b/pkg/new/rpm.bzl
@@ -1,0 +1,754 @@
+# Copyright 2019-2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This is different from make_rpm.py in pkg/, and is specific to the
+# `pkg_rpm` rule in this directory.
+
+"""Provides rules for creating RPM packages via pkg_filegroup and friends."""
+
+load("//experimental:pkg_filegroup.bzl", "PackageDirInfo", "PackageFileInfo", "PackageSymlinkInfo")
+
+rpm_filetype = [".rpm"]
+
+spec_filetype = [".spec", ".spec.in"]
+
+def _pkg_rpm_impl(ctx):
+    """Implements the pkg_rpm rule."""
+
+    files = []
+    args = ["--name=" + ctx.label.name]
+
+    if ctx.attr.debug:
+        args.append("--debug")
+
+    if ctx.attr.rpmbuild_path:
+        args.append("--rpmbuild=" + ctx.attr.rpmbuild_path)
+
+    #### rpm spec "preamble"
+    preamble_pieces = []
+
+    # rpm_name takes precedence over name if provided
+    if ctx.attr.rpm_name:
+        rpm_name = ctx.attr.rpm_name
+    else:
+        rpm_name = ctx.attr.name
+    preamble_pieces.append("Name: " + rpm_name)
+
+    # Version can be specified by a file or inlined.
+    if ctx.attr.version_file:
+        if ctx.attr.version:
+            fail("Both version and version_file attributes were specified")
+
+        preamble_pieces.append("Version: ${VERSION_FROM_FILE}")
+        args.append("--version=@" + ctx.file.version_file.path)
+        files.append(ctx.file.version_file)
+    elif ctx.attr.version:
+        preamble_pieces.append("Version: " + ctx.attr.version)
+    else:
+        fail("None of the version or version_file attributes were specified")
+
+    # Release can be specified by a file or inlined.
+    if ctx.attr.release_file:
+        if ctx.attr.release:
+            fail("Both release and release_file attributes were specified")
+
+        preamble_pieces.append("Release: ${RELEASE_FROM_FILE}")
+        args.append("--release=@" + ctx.file.release_file.path)
+        files.append(ctx.file.release_file)
+    elif ctx.attr.release:
+        preamble_pieces.append("Release: " + ctx.attr.release)
+    else:
+        fail("None of the release or release_file attributes were specified")
+
+    if ctx.attr.summary:
+        preamble_pieces.append("Summary: " + ctx.attr.summary)
+    if ctx.attr.url:
+        preamble_pieces.append("URL: " + ctx.attr.url)
+    if ctx.attr.license:
+        preamble_pieces.append("License: " + ctx.attr.license)
+    if ctx.attr.group:
+        preamble_pieces.append("Group: " + ctx.attr.group)
+    if ctx.attr.provides:
+        preamble_pieces.extend(["Provides: " + p for p in ctx.attr.provides])
+    if ctx.attr.conflicts:
+        preamble_pieces.extend(["Conflicts: " + c for c in ctx.attr.conflicts])
+    if ctx.attr.requires:
+        preamble_pieces.extend(["Requires: " + r for r in ctx.attr.requires])
+    if ctx.attr.requires_contextual:
+        preamble_pieces.extend(
+            [
+                "Requires({}): {}".format(scriptlet, capability)
+                for scriptlet in ctx.attr.requires_contextual.keys()
+                for capability in ctx.attr.requires_contextual[scriptlet]
+            ],
+        )
+
+    # TODO: BuildArch is usually not hardcoded in spec files, unless the package
+    # is indeed restricted to a particular CPU architecture, or is actually
+    # "noarch".  This will become more of a concern when we start providing
+    # source RPMs.
+    #
+    # In the meantime, this will allow the "architecture" attribute to take
+    # effect.
+    if ctx.attr.architecture:
+        preamble_pieces.append("BuildArch: " + ctx.attr.architecture)
+
+    preamble_file = ctx.actions.declare_file(
+        "{}.spec.preamble".format(rpm_name),
+    )
+    ctx.actions.write(
+        output = preamble_file,
+        content = "\n".join(preamble_pieces),
+    )
+    files.append(preamble_file)
+    args.append("--preamble=" + preamble_file.path)
+
+    #### %description
+
+    if ctx.attr.description_file:
+        if ctx.attr.description:
+            fail("Both description and description_file attributes were specified")
+        description_file = ctx.file.description_file
+    elif ctx.attr.description:
+        description_file = ctx.actions.declare_file(
+            "{}.spec.description".format(rpm_name),
+        )
+        ctx.actions.write(
+            output = description_file,
+            content = ctx.attr.description,
+        )
+    else:
+        fail("None of the description or description_file attributes were specified")
+
+    files.append(description_file)
+    args.append("--description=" + description_file.path)
+
+    #### Non-procedurally-generated scriptlets
+
+    substitutions = {}
+    if ctx.attr.pre_scriptlet_file:
+        if ctx.attr.pre_scriptlet:
+            fail("Both pre_scriptlet and pre_scriptlet_file attributes were specified")
+        pre_scriptlet_file = ctx.file.pre_scriptlet_file
+        files.append(pre_scriptlet_file)
+        args.append("--pre_scriptlet=" + pre_scriptlet_file.path)
+    elif ctx.attr.pre_scriptlet:
+        scriptlet_file = ctx.actions.declare_file(ctx.label.name + ".pre_scriptlet")
+        files.append(scriptlet_file)
+        ctx.actions.write(scriptlet_file, ctx.attr.pre_scriptlet)
+        args.append("--pre_scriptlet=" + scriptlet_file.path)
+
+    if ctx.attr.post_scriptlet_file:
+        if ctx.attr.post_scriptlet:
+            fail("Both post_scriptlet and post_scriptlet_file attributes were specified")
+        post_scriptlet_file = ctx.file.post_scriptlet_file
+        files.append(post_scriptlet_file)
+        args.append("--post_scriptlet=" + post_scriptlet_file.path)
+    elif ctx.attr.post_scriptlet:
+        scriptlet_file = ctx.actions.declare_file(ctx.label.name + ".post_scriptlet")
+        files.append(scriptlet_file)
+        ctx.actions.write(scriptlet_file, ctx.attr.post_scriptlet)
+        args.append("--post_scriptlet=" + scriptlet_file.path)
+
+    if ctx.attr.preun_scriptlet_file:
+        if ctx.attr.preun_scriptlet:
+            fail("Both preun_scriptlet and preun_scriptlet_file attributes were specified")
+        preun_scriptlet_file = ctx.file.preun_scriptlet_file
+        files.append(preun_scriptlet_file)
+        args.append("--preun_scriptlet=" + preun_scriptlet_file.path)
+    elif ctx.attr.preun_scriptlet:
+        scriptlet_file = ctx.actions.declare_file(ctx.label.name + ".preun_scriptlet")
+        files.append(scriptlet_file)
+        ctx.actions.write(scriptlet_file, ctx.attr.preun_scriptlet)
+        args.append("--preun_scriptlet=" + scriptlet_file.path)
+
+    if ctx.attr.postun_scriptlet_file:
+        if ctx.attr.postun_scriptlet:
+            fail("Both postun_scriptlet and postun_scriptlet_file attributes were specified")
+        postun_scriptlet_file = ctx.file.postun_scriptlet_file
+        files.append(postun_scriptlet_file)
+        args.append("--postun_scriptlet=" + postun_scriptlet_file.path)
+    elif ctx.attr.postun_scriptlet:
+        scriptlet_file = ctx.actions.declare_file(ctx.label.name + ".postun_scriptlet")
+        files.append(scriptlet_file)
+        ctx.actions.write(scriptlet_file, ctx.attr.postun_scriptlet)
+        args.append("--postun_scriptlet=" + scriptlet_file.path)
+
+    #### Expand the spec file template; prepare data files
+
+    spec_file = ctx.actions.declare_file("%s.spec" % rpm_name)
+    ctx.actions.expand_template(
+        template = ctx.file.spec_template,
+        output = spec_file,
+        substitutions = substitutions,
+    )
+    args.append("--spec_file=" + spec_file.path)
+    files.append(spec_file)
+
+    args.append("--out_file=" + ctx.outputs.rpm.path)
+
+    # Add data files.
+    if ctx.file.changelog:
+        files.append(ctx.file.changelog)
+        args.append(ctx.file.changelog.path)
+
+    files += ctx.files.data
+
+    #### Sanity checking
+
+    # Ensure that no destinations collide.  RPMs that fail this check may be
+    # sane, but the output may also create hard-to-debug issues.  Better to err
+    # on the side of correctness here.
+    dest_check_map = {}
+    for d in ctx.attr.data:
+        # TODO(nacl, #191): This loop should be consolidated with the install
+        # script-generating loop below, as they're iterating on the same data.
+
+        # d is a Target
+
+        # FIXME: if/when we start to consider other providers here, we may want
+        # to create a subroutine to consolidate these loops.
+
+        # NOTE: This does not detect cases where directories are not named
+        # consistently.  For example, all of these may collide in reality, but
+        # won't be detected by the below:
+        #
+        # 1) usr/lib/libfoo.a
+        # 2) /usr/lib/libfoo.a
+        # 3) %{_libdir}/libfoo.a
+        #
+        # The rule of thumb, regardless of how these checks below are done, is
+        # to be consistent with path naming conventions.
+        #
+        # There is also an unsolved question of determining how to handle
+        # subdirectories of "PackageFileInfo" targets that are actually
+        # directories.
+        if PackageFileInfo in d:
+            pfi = d[PackageFileInfo]
+            for dest in pfi.dests:
+                if dest in dest_check_map:
+                    fail(
+                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
+                            dest,
+                            dest_check_map[dest],
+                            d.label,
+                        ),
+                        "data",
+                    )
+                else:
+                    dest_check_map[dest] = d.label
+
+        if PackageDirInfo in d:
+            pdi = d[PackageDirInfo]
+            for dest in pdi.dirs:
+                if dest in dest_check_map:
+                    fail(
+                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
+                            dest,
+                            dest_check_map[dest],
+                            d.label,
+                        ),
+                        "data",
+                    )
+                else:
+                    dest_check_map[dest] = d.label
+
+        if PackageSymlinkInfo in d:
+            psi = d[PackageSymlinkInfo]
+            for dest in psi.link_map.keys():
+                if dest in dest_check_map:
+                    fail(
+                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
+                            dest,
+                            dest_check_map[dest],
+                            d.label,
+                        ),
+                        "data",
+                    )
+                else:
+                    dest_check_map[dest] = d.label
+
+    #### Procedurally-generated scripts/lists (%install, %files)
+
+    # Build up the install script
+    install_script_pieces = []
+    if ctx.attr.debug:
+        install_script_pieces.append("set -x")
+
+    # TODO(nacl): __install, __cp
+    # {0} is the source, {1} is the dest
+    install_file_stanza_fmt = """
+install -d %{{buildroot}}/$(dirname {1})
+cp -r {0} %{{buildroot}}/{1}
+    """
+
+    # TODO(nacl): __install
+    # {0} is the directory name
+    #
+    # This may not be strictly necessary, given that they'll be created in the
+    # CPIO when rpmbuild processes the `%files` list.
+    install_dir_stanza_fmt = """
+install -d %{{buildroot}}/{0}
+    """
+
+    # {0} is the name of the link, {1} is the target
+    install_symlink_stanza_fmt = """
+%{{__install}} -d %{{buildroot}}/$(dirname {0})
+%{{__ln_s}} {1} %{{buildroot}}/{0}
+"""
+
+    # Build up the RPM files list (%files -f)
+    rpm_files_list = []
+
+    # Iterate over all incoming data, creating datasets as we go from the
+    # actual contents of the RPM.
+    #
+    # This is a naive approach to script creation is almost guaranteed to
+    # produce an installation script that is longer than necessary.  A better
+    # implementation would track directories that are created and ensure that
+    # they aren't unnecessarily recreated.
+    for elem in ctx.attr.data:
+        if PackageFileInfo in elem:
+            pfi = elem[PackageFileInfo]
+            file_base = "%attr({}) {}".format(
+                ", ".join(pfi.attrs["unix"]),
+                "%" + pfi.section if pfi.section else "",
+            )
+            for (source, dest) in zip(pfi.srcs, pfi.dests):
+                rpm_files_list.append(file_base + " /" + dest)
+
+                install_script_pieces.append(install_file_stanza_fmt.format(
+                    source.path,
+                    dest,
+                ))
+        if PackageDirInfo in elem:
+            pdi = elem[PackageDirInfo]
+            file_base = "%attr({}) {}".format(
+                ", ".join(pdi.attrs["unix"]),
+                "%" + pdi.section if pdi.section else "",
+            )
+            for d in pdi.dirs:
+                rpm_files_list.append(file_base + " /" + d)
+
+                install_script_pieces.append(install_dir_stanza_fmt.format(
+                    d,
+                ))
+        if PackageSymlinkInfo in elem:
+            psi = elem[PackageSymlinkInfo]
+            file_base = "%attr({}) {}".format(
+                ", ".join(psi.attrs["unix"]),
+                "%" + psi.section if psi.section else "",
+            )
+            for link_name, target in psi.link_map.items():
+                rpm_files_list.append(file_base + " /" + link_name)
+
+                install_script_pieces.append(install_symlink_stanza_fmt.format(
+                    link_name,
+                    target,
+                ))
+
+    install_script = ctx.actions.declare_file("{}.spec.install".format(rpm_name))
+    ctx.actions.write(
+        install_script,
+        "\n".join(install_script_pieces),
+    )
+    files.append(install_script)
+    args.append("--install_script=" + install_script.path)
+
+    rpm_files_file = ctx.actions.declare_file(
+        "{}.spec.files".format(rpm_name),
+    )
+    ctx.actions.write(
+        rpm_files_file,
+        "\n".join(rpm_files_list),
+    )
+    files.append(rpm_files_file)
+    args.append("--file_list=" + rpm_files_file.path)
+
+    additional_rpmbuild_args = []
+    if ctx.attr.binary_payload_compression:
+        additional_rpmbuild_args.extend([
+            "--define",
+            "_binary_payload {}".format(ctx.attr.binary_payload_compression),
+        ])
+
+    args.extend(["--rpmbuild_arg=" + a for a in additional_rpmbuild_args])
+
+    for f in ctx.files.data:
+        args.append(f.path)
+
+    #### Call the generator script.
+
+    ctx.actions.run(
+        mnemonic = "MakeRpm",
+        executable = ctx.executable._make_rpm,
+        use_default_shell_env = True,
+        arguments = args,
+        inputs = files,
+        outputs = [ctx.outputs.rpm],
+        env = {
+            "LANG": "en_US.UTF-8",
+            "LC_CTYPE": "UTF-8",
+            "PYTHONIOENCODING": "UTF-8",
+            "PYTHONUTF8": "1",
+        },
+    )
+
+    #### Output construction
+
+    # Link the RPM to the expected output name.
+    ctx.actions.symlink(
+        output = ctx.outputs.out,
+        target_file = ctx.outputs.rpm,
+    )
+
+    # Link the RPM to the RPM-recommended output name if possible.
+    if "rpm_nvra" in dir(ctx.outputs):
+        ctx.actions.symlink(
+            output = ctx.outputs.rpm_nvra,
+            target_file = ctx.outputs.rpm,
+        )
+
+# TODO(nacl): this relies on deprecated behavior (should use Providers
+# instead), it should be removed at some point.
+def _pkg_rpm_outputs(name, rpm_name, version, release):
+    actual_rpm_name = rpm_name or name
+    outputs = {
+        "out": actual_rpm_name + ".rpm",
+        "rpm": actual_rpm_name + "-%{architecture}.rpm",
+    }
+
+    # The "rpm_nvra" output follows the recommended package naming convention of
+    # Name-Version-Release.Arch.rpm
+    # See http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+    if version and release:
+        outputs["rpm_nvra"] = actual_rpm_name + "-%{version}-%{release}.%{architecture}.rpm"
+
+    return outputs
+
+# Define the rule.
+pkg_rpm = rule(
+    doc = """Creates an RPM format package via `pkg_filegroup` and friends.
+
+    The uses the outputs of the rules in `pkg_filegroup.bzl` to construct arbitrary RPM
+    packages.  Attributes of this rule provide preamble information and
+    scriptlets, which are then used to compose a valid RPM spec file.
+
+    The meat is in the `data` attribute, which is handled like so:
+
+    - `pkg_filegroup`s provide mappings of targets to output files:
+
+      - They are copied to their destination after their destination directory
+        is created.
+
+      - No directory ownership is implied; they will typically be owned by
+        `root.root` and given permissions associated with `root`'s `umask`,
+        typically 0755, unless otherwise overidden.
+
+      - File permissions are set in the `%files` manifest.  `%config` or other
+        `%files` properties are propagated from the `section` attribute.
+
+    - `pkg_mkdirs` provide directories and directory ownership. They are
+      created in the package tree directly.  They are owned as specified by the
+      `section` attribute, which typically is the same as `%dir`.
+
+    This rule will fail at analysis time if:
+
+    - Any `data` input may create the same destination, regardless of other
+      attributes.
+
+    Currently, two outputs are guaranteed to be produced: "%{name}.rpm", and
+    "%{name}-%{architecture}.rpm". If the "version" and "release" arguments are
+    non-empty, a third output will be produced, following the RPM-recommended
+    N-V-R.A format (Name-Version-Release.Architecture.rpm). Note that due to
+    the fact that rule implementations cannot access the contents of files,
+    the "version_file" and "release_file" arguments will not create an output
+    using N-V-R.A format.
+
+    This rule only functions on UNIXy platforms. The following tools must be
+    available on your system for this to function properly:
+
+    - `rpmbuild` (as specified in `rpmbuild_path`, or available in `$PATH`)
+
+    - GNU coreutils.  BSD coreutils may work, but are not tested.
+
+    """,
+    # @unsorted-dict-items
+    attrs = {
+        "rpm_name": attr.string(
+            doc = """Optional; RPM name override.
+
+            If not provided, the `name` attribute of this rule will be used
+            instead.
+
+            This influences values like the spec file name, and the name of the
+            output RPM.
+
+            """,
+        ),
+        "version": attr.string(
+            doc = """RPM "Version" tag.
+
+            Exactly one of `version` or `version_file` must be provided.
+            """,
+        ),
+        "version_file": attr.label(
+            doc = """File containing RPM "Version" tag.""",
+            allow_single_file = True,
+        ),
+        "release": attr.string(
+            doc = """RPM "Release" tag
+
+            Exactly one of `release` or `release_file` must be provided.
+            """,
+        ),
+        "release_file": attr.label(
+            doc = """File containing RPM "Release" tag.""",
+            allow_single_file = True,
+        ),
+        "group": attr.string(
+            doc = """Optional; RPM "Group" tag.
+
+            NOTE: some distributions (as of writing, Fedora > 17 and CentOS/RHEL
+            > 5) have deprecated this tag.  Other distributions may require it,
+            but it is harmless in any case.
+
+            """,
+        ),
+        # TODO(nacl): this should be augmented to use bazel platforms, and
+        # should not really set BuildArch.
+        "architecture": attr.string(
+            doc = """Package architecture.
+
+            This currently sets the `BuildArch` tag, which influences the output
+            architecture of the package.
+
+            Typically, `BuildArch` only needs to be set when the package is
+            known to be cross-platform (e.g. written in an interpreted
+            language), or, less common, when it is known that the application is
+            only valid for specific architectures.
+
+            When no attribute is provided, this will default to your host's
+            architecture.  This is usually what you want.
+
+            """,
+        ),
+        "license": attr.string(
+            doc = """RPM "License" tag.
+
+            The software license for the code distributed in this package.
+
+            The underlying RPM builder requires you to put something here; if
+            your package is not going to be distributed, feel free to set this
+            to something like "Internal".
+
+            """,
+            mandatory = True,
+        ),
+        "summary": attr.string(
+            doc = """RPM "Summary" tag.
+
+            One-line summary of this package.  Must not contain newlines.
+
+            """,
+            mandatory = True,
+        ),
+        "url": attr.string(
+            doc = """RPM "URL" tag; this project/vendor's home on the Internet.""",
+        ),
+        "description": attr.string(
+            doc = """Multi-line description of this package, corresponds to RPM %description.
+
+            Exactly one of `description` or `description_file` must be provided.
+            """,
+        ),
+        "description_file": attr.label(
+            doc = """File containing a multi-line description of this package, corresponds to RPM
+            %description.""",
+            allow_single_file = True,
+        ),
+        # TODO: this isn't consumed yet
+        "changelog": attr.label(
+            allow_single_file = True,
+        ),
+        "data": attr.label_list(
+            doc = """Mappings to include in this RPM.
+
+            These are typically brought into life as `pkg_filegroup`s.
+            """,
+            mandatory = True,
+            providers = [
+                [PackageFileInfo],
+                [PackageDirInfo],
+                [PackageSymlinkInfo],
+            ],
+        ),
+        "debug": attr.bool(
+            doc = """Debug the RPM helper script and RPM generation""",
+            default = False,
+        ),
+        "pre_scriptlet": attr.string(
+            doc = """RPM `%pre` scriptlet.  Currently only allowed to be a shell script.
+
+            `pre_scriptlet` and `pre_scriptlet_file` are mutually exclusive.
+            """,
+        ),
+        "pre_scriptlet_file": attr.label(
+            doc = """File containing the RPM `%pre` scriptlet""",
+            allow_single_file = True,
+        ),
+        "post_scriptlet": attr.string(
+            doc = """RPM `%post` scriptlet.  Currently only allowed to be a shell script.
+
+            `post_scriptlet` and `post_scriptlet_file` are mutually exclusive.
+            """,
+        ),
+        "post_scriptlet_file": attr.label(
+            doc = """File containing the RPM `%post` scriptlet""",
+            allow_single_file = True,
+        ),
+        "preun_scriptlet": attr.string(
+            doc = """RPM `%preun` scriptlet.  Currently only allowed to be a shell script.
+
+            `preun_scriptlet` and `preun_scriptlet_file` are mutually exclusive.
+            """,
+        ),
+        "preun_scriptlet_file": attr.label(
+            doc = """File containing the RPM `%preun` scriptlet""",
+            allow_single_file = True,
+        ),
+        "postun_scriptlet": attr.string(
+            doc = """RPM `%postun` scriptlet.  Currently only allowed to be a shell script.
+
+            `postun_scriptlet` and `postun_scriptlet_file` are mutually exclusive.
+            """,
+        ),
+        "postun_scriptlet_file": attr.label(
+            doc = """File containing the RPM `%postun` scriptlet""",
+            allow_single_file = True,
+        ),
+        "conflicts": attr.string_list(
+            doc = """List of capabilities that conflict with this package when it is installed.
+
+            Cooresponds to the "Conflicts" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "provides": attr.string_list(
+            doc = """List of rpm capabilities that this package provides.
+
+            Cooresponds to the "Provides" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "requires": attr.string_list(
+            doc = """List of rpm capability expressions that this package requires.
+
+            Corresponds to the "Requires" preamble tag.
+
+            See also: https://rpm.org/user_doc/dependencies.html
+            """,
+        ),
+        "requires_contextual": attr.string_list_dict(
+            doc = """Contextualized requirement specifications
+
+            This is a map of various properties (often scriptlet types) to
+            capability name specifications, e.g.:
+
+            ```python
+            {"pre": ["GConf2"],"post": ["GConf2"], "postun": ["GConf2"]}
+            ```
+
+            Which causes the below to be added to the spec file's preamble:
+
+            ```
+            Requires(pre): GConf2
+            Requires(post): GConf2
+            Requires(postun): GConf2
+            ```
+
+            This is most useful for ensuring that required tools exist when
+            scriptlets are run, although other properties are known.  Valid keys
+            for this attribute may include, but are not limited to:
+
+            - `pre`
+            - `post`
+            - `preun`
+            - `postun`
+            - `pretrans`
+            - `posttrans`
+
+            For capabilities that are always required by packages at runtime,
+            use the `requires` attribute instead.
+
+            See also: https://rpm.org/user_doc/more_dependencies.html
+
+            NOTE: `pkg_rpm` does not check if the keys of this dictionary are
+            acceptable to `rpm(8)`.
+            """,
+        ),
+
+        # TODO(nacl): this should be a toolchain
+        "rpmbuild_path": attr.string(
+            doc = """Path to a `rpmbuild` binary.""",
+        ),
+        "spec_template": attr.label(
+            doc = """Spec file template.
+
+            Use this if you need to add additional logic to your spec files that
+            is not available by default.
+
+            In most cases, you should not need to override this attribute.
+            """,
+            allow_single_file = spec_filetype,
+            default = "//experimental:template.spec.in",
+        ),
+        "binary_payload_compression": attr.string(
+            doc = """Compression mode used for this RPM
+
+            Must be a form that `rpmbuild(8)` knows how to process, which will
+            depend on the version of `rpmbuild` in use.  The value corresponds
+            to the `%_binary_payload` macro and is set on the `rpmbuild(8)`
+            command line if this attribute is provided.
+
+            Some examples of valid values (which may not be supported on your
+            system) can be found [here](https://git.io/JU9Wg).  On CentOS
+            systems (also likely Red Hat and Fedora), you can find some
+            supported values by looking for `%_binary_payload` in
+            `/usr/lib/rpm/macros`.  Other systems have similar files and
+            configurations.
+
+            If not provided, the compression mode will be computed using normal
+            RPM spec file processing.  Defaults may vary per distribution:
+            consult your distribution's documentation for more details.
+
+            WARNING: Bazel is currently not aware of action threading requirements
+            for non-test actions.  Using threaded compression may result in
+            overcommitting your system.
+            """,
+        ),
+        # Implicit dependencies.
+        "_make_rpm": attr.label(
+            default = Label("//:make_rpm"),
+            cfg = "exec",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    executable = False,
+    outputs = _pkg_rpm_outputs,
+    implementation = _pkg_rpm_impl,
+)

--- a/pkg/new/rpm.bzl
+++ b/pkg/new/rpm.bzl
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,81 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NOTE: This is different from make_rpm.py in pkg/, and is specific to the
-# `pkg_rpm` rule in this directory.
-
 """Provides rules for creating RPM packages via pkg_filegroup and friends."""
 
-load("//experimental:pkg_filegroup.bzl", "PackageDirInfo", "PackageFileInfo", "PackageSymlinkInfo")
+load("//:providers.bzl", "PackageFilegroupInfo")
 
 rpm_filetype = [".rpm"]
 
 spec_filetype = [".spec", ".spec.in"]
+
+# TODO(nacl): __install, __cp
+# {0} is the source, {1} is the dest
+#
+# TODO(nacl, #292): cp -r does not do the right thing with TreeArtifacts
+_INSTALL_FILE_STANZA_FMT = """
+install -d %{{buildroot}}/$(dirname {1})
+cp -r {0} %{{buildroot}}/{1}
+"""
+
+# TODO(nacl): __install
+# {0} is the directory name
+#
+# This may not be strictly necessary, given that they'll be created in the
+# CPIO when rpmbuild processes the `%files` list.
+_INSTALL_DIR_STANZA_FMT = """
+install -d %{{buildroot}}/{0}
+"""
+
+# {0} is the name of the link, {1} is the target
+_INSTALL_SYMLINK_STANZA_FMT = """
+%{{__install}} -d %{{buildroot}}/$(dirname {0})
+%{{__ln_s}} {1} %{{buildroot}}/{0}
+"""
+
+def _package_contents_metadata(origin_label, grouping_label):
+    """Named construct for helping to identify conflicting packaged contents"""
+    return struct(
+        origin = origin_label if origin_label else "<UNKNOWN>",
+        group = grouping_label
+    )
+
+def _conflicting_contents_error(destination, from1, from2, attr_name = "srcs"):
+    message = """Destination {destination} is provided by both (1) {from1_origin} and (2) {from2_origin}; please sensure that each destination is provided by exactly one input.
+
+    (1) {from1_origin} is provided from group {from1_group}
+    (2) {from2_origin} is provided from group {from2_group}
+    """.format(
+        destination = destination,
+        from1_origin = from1.origin,
+        from1_group = from1.group,
+        from2_origin = from2.origin,
+        from2_group = from2.group,
+    )
+
+    fail(message, attr_name)
+
+def _make_filetags(attributes, default_filetag = None):
+    """Helper function for rendering RPM spec file tags, like
+
+    ```
+    %attr(0755, root, root) %dir
+    ```
+    """
+    template = "%attr({mode}, {user}, {group}) {supplied_filetag}"
+
+    mode = attributes.get("mode", "-")
+    user = attributes.get("user", "-")
+    group = attributes.get("group", "-")
+
+    supplied_filetag = attributes.get("rpm_filetag", default_filetag)
+
+    return template.format(
+        mode = mode,
+        user = user,
+        group = group,
+        supplied_filetag = supplied_filetag or ""
+    )
 
 def _pkg_rpm_impl(ctx):
     """Implements the pkg_rpm rule."""
@@ -203,7 +268,7 @@ def _pkg_rpm_impl(ctx):
         files.append(ctx.file.changelog)
         args.append(ctx.file.changelog.path)
 
-    files += ctx.files.data
+    files += ctx.files.srcs
 
     #### Sanity checking
 
@@ -211,14 +276,9 @@ def _pkg_rpm_impl(ctx):
     # sane, but the output may also create hard-to-debug issues.  Better to err
     # on the side of correctness here.
     dest_check_map = {}
-    for d in ctx.attr.data:
+    for dep in ctx.attr.srcs:
         # TODO(nacl, #191): This loop should be consolidated with the install
         # script-generating loop below, as they're iterating on the same data.
-
-        # d is a Target
-
-        # FIXME: if/when we start to consider other providers here, we may want
-        # to create a subroutine to consolidate these loops.
 
         # NOTE: This does not detect cases where directories are not named
         # consistently.  For example, all of these may collide in reality, but
@@ -232,52 +292,33 @@ def _pkg_rpm_impl(ctx):
         # to be consistent with path naming conventions.
         #
         # There is also an unsolved question of determining how to handle
-        # subdirectories of "PackageFileInfo" targets that are actually
+        # subdirectories of "PackageFilesInfo" targets that are actually
         # directories.
-        if PackageFileInfo in d:
-            pfi = d[PackageFileInfo]
-            for dest in pfi.dests:
-                if dest in dest_check_map:
-                    fail(
-                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
-                            dest,
-                            dest_check_map[dest],
-                            d.label,
-                        ),
-                        "data",
-                    )
-                else:
-                    dest_check_map[dest] = d.label
 
-        if PackageDirInfo in d:
-            pdi = d[PackageDirInfo]
-            for dest in pdi.dirs:
+        # d is a Target
+        pfg_info = dep[PackageFilegroupInfo]
+        for entry, origin in pfg_info.pkg_files:
+            for dest, src in entry.dest_src_map.items():
+                metadata = _package_contents_metadata(origin, dep.label)
                 if dest in dest_check_map:
-                    fail(
-                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
-                            dest,
-                            dest_check_map[dest],
-                            d.label,
-                        ),
-                        "data",
-                    )
+                    _conflicting_contents_error(dest, metadata, dest_check_map[dest])
                 else:
-                    dest_check_map[dest] = d.label
+                    dest_check_map[dest] = metadata
 
-        if PackageSymlinkInfo in d:
-            psi = d[PackageSymlinkInfo]
-            for dest in psi.link_map.keys():
+        for entry, origin in pfg_info.pkg_dirs:
+            for dest in entry.dirs:
+                metadata = _package_contents_metadata(origin, dep.label)
                 if dest in dest_check_map:
-                    fail(
-                        "Destination '{0}' is provided by both {1} and {2}; please ensure each destination is provided by exactly one incoming rule".format(
-                            dest,
-                            dest_check_map[dest],
-                            d.label,
-                        ),
-                        "data",
-                    )
+                    _conflicting_contents_error(dest, metadata, dest_check_map[dest])
                 else:
-                    dest_check_map[dest] = d.label
+                    dest_check_map[dest] = metadata
+
+        for entry, origin in pfg_info.pkg_symlinks:
+            metadata = _package_contents_metadata(origin, dep.label)
+            if entry.destination in dest_check_map:
+                _conflicting_contents_error(entry.destination, metadata, dest_check_map[entry.destination])
+            else:
+                dest_check_map[entry.destination] = metadata
 
     #### Procedurally-generated scripts/lists (%install, %files)
 
@@ -285,28 +326,6 @@ def _pkg_rpm_impl(ctx):
     install_script_pieces = []
     if ctx.attr.debug:
         install_script_pieces.append("set -x")
-
-    # TODO(nacl): __install, __cp
-    # {0} is the source, {1} is the dest
-    install_file_stanza_fmt = """
-install -d %{{buildroot}}/$(dirname {1})
-cp -r {0} %{{buildroot}}/{1}
-    """
-
-    # TODO(nacl): __install
-    # {0} is the directory name
-    #
-    # This may not be strictly necessary, given that they'll be created in the
-    # CPIO when rpmbuild processes the `%files` list.
-    install_dir_stanza_fmt = """
-install -d %{{buildroot}}/{0}
-    """
-
-    # {0} is the name of the link, {1} is the target
-    install_symlink_stanza_fmt = """
-%{{__install}} -d %{{buildroot}}/$(dirname {0})
-%{{__ln_s}} {1} %{{buildroot}}/{0}
-"""
 
     # Build up the RPM files list (%files -f)
     rpm_files_list = []
@@ -318,45 +337,33 @@ install -d %{{buildroot}}/{0}
     # produce an installation script that is longer than necessary.  A better
     # implementation would track directories that are created and ensure that
     # they aren't unnecessarily recreated.
-    for elem in ctx.attr.data:
-        if PackageFileInfo in elem:
-            pfi = elem[PackageFileInfo]
-            file_base = "%attr({}) {}".format(
-                ", ".join(pfi.attrs["unix"]),
-                "%" + pfi.section if pfi.section else "",
-            )
-            for (source, dest) in zip(pfi.srcs, pfi.dests):
+    for dep in ctx.attr.srcs:
+        pfg_info = dep[PackageFilegroupInfo]
+        for entry, _ in pfg_info.pkg_files:
+            file_base = _make_filetags(entry.attributes)
+
+            for dest, src in entry.dest_src_map.items():
                 rpm_files_list.append(file_base + " /" + dest)
 
-                install_script_pieces.append(install_file_stanza_fmt.format(
-                    source.path,
+                install_script_pieces.append(_INSTALL_FILE_STANZA_FMT.format(
+                    src.path,
                     dest,
                 ))
-        if PackageDirInfo in elem:
-            pdi = elem[PackageDirInfo]
-            file_base = "%attr({}) {}".format(
-                ", ".join(pdi.attrs["unix"]),
-                "%" + pdi.section if pdi.section else "",
-            )
-            for d in pdi.dirs:
+        for entry, _ in pfg_info.pkg_dirs:
+            file_base = _make_filetags(entry.attributes, "%dir")
+            for d in entry.dirs:
                 rpm_files_list.append(file_base + " /" + d)
 
-                install_script_pieces.append(install_dir_stanza_fmt.format(
+                install_script_pieces.append(_INSTALL_DIR_STANZA_FMT.format(
                     d,
-                ))
-        if PackageSymlinkInfo in elem:
-            psi = elem[PackageSymlinkInfo]
-            file_base = "%attr({}) {}".format(
-                ", ".join(psi.attrs["unix"]),
-                "%" + psi.section if psi.section else "",
-            )
-            for link_name, target in psi.link_map.items():
-                rpm_files_list.append(file_base + " /" + link_name)
-
-                install_script_pieces.append(install_symlink_stanza_fmt.format(
-                    link_name,
-                    target,
-                ))
+            ))
+        for entry, _ in pfg_info.pkg_symlinks:
+            file_base = _make_filetags(entry.attributes)
+            rpm_files_list.append(file_base + " /" + entry.destination)
+            install_script_pieces.append(_INSTALL_SYMLINK_STANZA_FMT.format(
+                entry.destination,
+                entry.source
+            ))
 
     install_script = ctx.actions.declare_file("{}.spec.install".format(rpm_name))
     ctx.actions.write(
@@ -385,7 +392,7 @@ install -d %{{buildroot}}/{0}
 
     args.extend(["--rpmbuild_arg=" + a for a in additional_rpmbuild_args])
 
-    for f in ctx.files.data:
+    for f in ctx.files.srcs:
         args.append(f.path)
 
     #### Call the generator script.
@@ -441,27 +448,9 @@ def _pkg_rpm_outputs(name, rpm_name, version, release):
 pkg_rpm = rule(
     doc = """Creates an RPM format package via `pkg_filegroup` and friends.
 
-    The uses the outputs of the rules in `pkg_filegroup.bzl` to construct arbitrary RPM
-    packages.  Attributes of this rule provide preamble information and
+    The uses the outputs of the rules in `mappings.bzl` to construct arbitrary
+    RPM packages.  Attributes of this rule provide preamble information and
     scriptlets, which are then used to compose a valid RPM spec file.
-
-    The meat is in the `data` attribute, which is handled like so:
-
-    - `pkg_filegroup`s provide mappings of targets to output files:
-
-      - They are copied to their destination after their destination directory
-        is created.
-
-      - No directory ownership is implied; they will typically be owned by
-        `root.root` and given permissions associated with `root`'s `umask`,
-        typically 0755, unless otherwise overidden.
-
-      - File permissions are set in the `%files` manifest.  `%config` or other
-        `%files` properties are propagated from the `section` attribute.
-
-    - `pkg_mkdirs` provide directories and directory ownership. They are
-      created in the package tree directly.  They are owned as specified by the
-      `section` attribute, which typically is the same as `%dir`.
 
     This rule will fail at analysis time if:
 
@@ -482,6 +471,16 @@ pkg_rpm = rule(
     - `rpmbuild` (as specified in `rpmbuild_path`, or available in `$PATH`)
 
     - GNU coreutils.  BSD coreutils may work, but are not tested.
+
+    To set RPM file attributes (like `%config` and friends), set the
+    `rpm_filetag` in corresponding packaging rule (`pkg_files`, etc).  The value
+    is prepended with "%" and added to the `%files` list, for example:
+
+    ```
+    attrs = {"rpm_filetag": ("config(missingok, noreplace)",)},
+    ```
+
+    Is the equivalent to `%config(missingok, noreplace)` in the `%files` list.
 
     """,
     # @unsorted-dict-items
@@ -582,17 +581,13 @@ pkg_rpm = rule(
         "changelog": attr.label(
             allow_single_file = True,
         ),
-        "data": attr.label_list(
-            doc = """Mappings to include in this RPM.
+        "srcs": attr.label_list(
+            doc = """Mapping groups to include in this RPM.
 
             These are typically brought into life as `pkg_filegroup`s.
             """,
             mandatory = True,
-            providers = [
-                [PackageFileInfo],
-                [PackageDirInfo],
-                [PackageSymlinkInfo],
-            ],
+            providers = [PackageFilegroupInfo],
         ),
         "debug": attr.bool(
             doc = """Debug the RPM helper script and RPM generation""",
@@ -714,7 +709,7 @@ pkg_rpm = rule(
             In most cases, you should not need to override this attribute.
             """,
             allow_single_file = spec_filetype,
-            default = "//experimental:template.spec.in",
+            default = "//new:template.spec.in",
         ),
         "binary_payload_compression": attr.string(
             doc = """Compression mode used for this RPM
@@ -733,7 +728,7 @@ pkg_rpm = rule(
 
             If not provided, the compression mode will be computed using normal
             RPM spec file processing.  Defaults may vary per distribution:
-            consult your distribution's documentation for more details.
+            consult its documentation for more details.
 
             WARNING: Bazel is currently not aware of action threading requirements
             for non-test actions.  Using threaded compression may result in

--- a/pkg/new/template.spec.in
+++ b/pkg/new/template.spec.in
@@ -1,0 +1,20 @@
+# -*- rpm-spec -*-
+
+# This comprises the entirety of the preamble
+%include %build_rpm_options
+
+%description
+%include %build_rpm_description
+
+%install
+%include %build_rpm_install
+
+%files -f %build_rpm_files
+
+${PRE_SCRIPTLET}
+
+${POST_SCRIPTLET}
+
+${PREUN_SCRIPTLET}
+
+${POSTUN_SCRIPTLET}

--- a/pkg/new/tests/rpm/BUILD
+++ b/pkg/new/tests/rpm/BUILD
@@ -1,0 +1,249 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_pkg//experimental:pkg_filegroup.bzl", "pkg_filegroup", "pkg_mkdirs", "pkg_mklinks")
+load("@rules_pkg//experimental:rpm.bzl", "pkg_rpm")
+load("@rules_python//python:defs.bzl", "py_test")
+
+licenses(["notice"])
+
+filegroup(
+    name = "ars",
+    srcs = glob(["testdata/*.ar"]),
+)
+
+############################################################################
+# pkg_filegroups for testing
+############################################################################
+
+pkg_filegroup(
+    name = "ars_pfg",
+    srcs = [
+        ":ars",
+    ],
+    attrs = {"unix": [
+        "0755",
+        "root",
+        "root",
+    ]},
+    prefix = "/test",
+)
+
+pkg_mkdirs(
+    name = "var_log_foo",
+    attrs = {"unix": [
+        "0755",
+        "root",
+        "root",
+    ]},
+    dirs = ["/var/log/foo"],
+)
+
+pkg_mklinks(
+    name = "test_links",
+    attrs = {"unix": [
+        "0777",
+        "root",
+        "root",
+    ]},
+    links = {"/usr/bin/link-name": "/usr/bin/link-target"},
+)
+
+############################################################################
+# Test RPMs
+############################################################################
+
+pkg_rpm(
+    name = "test_rpm",
+    architecture = "noarch",
+    conflicts = ["not-a-test"],
+    data = [
+        ":ars_pfg",
+        ":test_links",
+        ":var_log_foo",
+    ],
+    description = """pkg_rpm test rpm description""",
+    license = "Apache 2.0",
+    post_scriptlet = """echo post""",
+    postun_scriptlet = """echo postun""",
+    pre_scriptlet = """echo pre""",
+    preun_scriptlet = """echo preun""",
+    provides = ["test"],
+    release = "2222",
+    requires = ["test-lib > 1.0"],
+    requires_contextual = {"preun": ["bash"]},
+    spec_template = "template-test.spec.in",
+    summary = "pkg_rpm test rpm summary",
+    version = "1.1.1",
+)
+
+# Just like the above one, except the compression is changed.
+pkg_rpm(
+    name = "test_rpm-bzip2",
+    architecture = "noarch",
+    binary_payload_compression = "w2.bzdio",
+    conflicts = ["not-a-test"],
+    data = [
+        ":ars_pfg",
+        ":test_links",
+        ":var_log_foo",
+    ],
+    description = """pkg_rpm test rpm description""",
+    license = "Apache 2.0",
+    post_scriptlet = """echo post""",
+    postun_scriptlet = """echo postun""",
+    pre_scriptlet = """echo pre""",
+    preun_scriptlet = """echo preun""",
+    provides = ["test"],
+    release = "2222",
+    requires = ["test-lib > 1.0"],
+    requires_contextual = {"preun": ["bash"]},
+    spec_template = "template-test.spec.in",
+    summary = "pkg_rpm test rpm summary",
+    version = "1.1.1",
+)
+
+############################################################################
+# Test RPM metadata -- used to verify RPM contents in tests
+############################################################################
+
+# Emit a CSV file providing a manifest providing the expected RPM contents
+genrule(
+    name = "test_rpm_manifest",
+    srcs = [":ars"],
+    outs = ["manifest.csv"],
+    # Keep the header (the first line echo'd below) in sync with
+    # rpm_queryformat_fieldnames in pkg_rpm_basic_test.py
+    cmd = """
+    echo 'path,digest,user,group,mode,fflags,symlink' > $@
+    for f in $(locations :ars); do
+        # Destination path
+        (
+            echo -n /test/$$(basename $$f),
+            # Hash
+            md5sum $$f | cut -d' ' -f1 | tr '\\n' ,
+            # User,Group,Mode,Fflags (fflags not provided)
+            echo -n 'root,root,100755,'
+            # Symlink destination (not provided)
+            echo ,
+        ) >> $@
+
+    done
+    # Directory (has no hash)
+    (
+        echo -n /var/log/foo,
+        # No hash (beginning), fflags (end), or symlink destination (end)
+        echo ,root,root,40755,,
+    ) >> $@
+
+    # Symlink (has no hash)
+    (
+        echo -n /usr/bin/link-name,
+        # No hash (beginning), or fflags (second-to-last)
+        echo ,root,root,120777,,/usr/bin/link-target
+    ) >> $@
+    """,
+)
+
+genrule(
+    name = "test_rpm_metadata",
+    srcs = [],
+    outs = [
+        "conflicts.csv",
+        "provides.csv",
+        "requires.csv",
+    ],
+    # In the below, we don't use the "," separator for everything, because the
+    # query tags used to get the associated dependency types
+    # (e.g. %{REQUIREFLAGS:deptype}) itself uses commas.  This makes it so the test
+    # doesn't have to rely on knowing the number of fields in each CSV file.
+    cmd = """
+    (
+        echo 'capability:sense'
+        echo 'not-a-test:manual'
+    ) > $(RULEDIR)/conflicts.csv
+    (
+        # NOTE: excludes the "self-require" (we did nothing special to make it
+        # appear)
+
+        echo 'capability:sense'
+        echo 'test:manual'
+    ) > $(RULEDIR)/provides.csv
+    (
+        # NOTE: excludes 'rpmlib' requires that may be version-dependent
+        echo 'capability:sense'
+        # Common, automatically generated
+        echo '/bin/sh:pre,interp'
+        echo '/bin/sh:post,interp'
+        echo '/bin/sh:preun,interp'
+        echo '/bin/sh:postun,interp'
+        # Hand-specified, specific dependencies
+        echo 'bash:preun'
+        # Hand-specified
+        echo 'test-lib > 1.0:manual'
+    ) > $(RULEDIR)/requires.csv
+    """,
+)
+
+# One cannot simply pass the output of pkg_rpm as runfiles content (#161).  This
+# seems to be the easiest way around this problem.
+sh_library(
+    name = "pkg_rpm_basic_test_data",
+    testonly = True,
+    data = [
+        ":test_rpm",
+        ":test_rpm-bzip2",
+        ":test_rpm_manifest",
+        ":test_rpm_metadata",
+    ],
+)
+
+############################################################################
+# Actual tests
+############################################################################
+
+# RPM content verification tests
+py_test(
+    name = "pkg_rpm_basic_test",
+    srcs = ["pkg_rpm_basic_test.py"],
+    data = [":pkg_rpm_basic_test_data"],
+    python_version = "PY3",
+    tags = [
+        "no_windows",  # Windows doesn't have rpmbuild(8)
+    ],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+# Smoke test for defaults
+pkg_rpm(
+    name = "test_rpm_default_template",
+    testonly = True,
+    architecture = "noarch",
+    data = [
+        ":ars_pfg",
+        ":test_links",
+        ":var_log_foo",
+    ],
+    description = """pkg_rpm test rpm description""",
+    license = "Apache 2.0",
+    release = "2222",
+    summary = "pkg_rpm test rpm summary",
+    version = "1.1.1",
+)
+
+build_test(
+    name = "pkg_rpm_smoke",
+    targets = [":test_rpm_default_template"],
+)

--- a/pkg/new/tests/rpm/BUILD
+++ b/pkg/new/tests/rpm/BUILD
@@ -13,52 +13,94 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_pkg//experimental:pkg_filegroup.bzl", "pkg_filegroup", "pkg_mkdirs", "pkg_mklinks")
-load("@rules_pkg//experimental:rpm.bzl", "pkg_rpm")
+load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "pkg_mklink")
+load("@rules_pkg//new:rpm.bzl", "pkg_rpm")
 load("@rules_python//python:defs.bzl", "py_test")
+load(":analysis_tests.bzl", "analysis_tests")
 
-licenses(["notice"])
 
-filegroup(
-    name = "ars",
-    srcs = glob(["testdata/*.ar"]),
-)
+############################################################################
+# analysis tests
+############################################################################
+analysis_tests(name = "analysis_tests")
 
 ############################################################################
 # pkg_filegroups for testing
 ############################################################################
 
-pkg_filegroup(
-    name = "ars_pfg",
+filegroup(
+    name = "ars",
+    srcs = [
+        "//tests:testdata/a.ar",
+        "//tests:testdata/a_ab.ar",
+        "//tests:testdata/a_b.ar",
+        "//tests:testdata/a_b_ab.ar",
+        "//tests:testdata/ab.ar",
+        "//tests:testdata/b.ar",
+        "//tests:testdata/empty.ar",
+    ],
+)
+
+
+pkg_files(
+    name = "ars_pf",
     srcs = [
         ":ars",
     ],
-    attrs = {"unix": [
-        "0755",
-        "root",
-        "root",
-    ]},
+    attributes = pkg_attributes(
+        mode = "0755",
+        user = "root",
+        group = "root",
+    ),
     prefix = "/test",
+)
+
+genrule(
+    name = "config_empty",
+    outs = ["config.txt"],
+    cmd = "touch $@",
+)
+
+pkg_files(
+    name = "config_file",
+    srcs = [":config_empty"],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0644",
+        rpm_filetag = "%config(missingok, noreplace)",
+        user = "root",
+    ),
 )
 
 pkg_mkdirs(
     name = "var_log_foo",
-    attrs = {"unix": [
-        "0755",
-        "root",
-        "root",
-    ]},
+    attributes = pkg_attributes(
+        mode = "0755",
+        user = "root",
+        group = "root",
+    ),
     dirs = ["/var/log/foo"],
 )
 
-pkg_mklinks(
+pkg_mklink(
     name = "test_links",
-    attrs = {"unix": [
-        "0777",
-        "root",
-        "root",
-    ]},
-    links = {"/usr/bin/link-name": "/usr/bin/link-target"},
+    attributes = pkg_attributes(
+        mode = "0777",
+        user = "root",
+        group = "root",
+    ),
+    dest = "/usr/bin/link-name",
+    src = "/usr/bin/link-target",
+)
+
+pkg_filegroup(
+    name = "test_pfg",
+    srcs = [
+        ":ars_pf",
+        ":config_file",
+        ":test_links",
+        ":var_log_foo",
+    ],
 )
 
 ############################################################################
@@ -69,10 +111,8 @@ pkg_rpm(
     name = "test_rpm",
     architecture = "noarch",
     conflicts = ["not-a-test"],
-    data = [
-        ":ars_pfg",
-        ":test_links",
-        ":var_log_foo",
+    srcs = [
+        ":test_pfg",
     ],
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
@@ -95,10 +135,8 @@ pkg_rpm(
     architecture = "noarch",
     binary_payload_compression = "w2.bzdio",
     conflicts = ["not-a-test"],
-    data = [
-        ":ars_pfg",
-        ":test_links",
-        ":var_log_foo",
+    srcs = [
+        ":test_pfg",
     ],
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
@@ -122,7 +160,10 @@ pkg_rpm(
 # Emit a CSV file providing a manifest providing the expected RPM contents
 genrule(
     name = "test_rpm_manifest",
-    srcs = [":ars"],
+    srcs = [
+        ":ars",
+        ":config_file",
+    ],
     outs = ["manifest.csv"],
     # Keep the header (the first line echo'd below) in sync with
     # rpm_queryformat_fieldnames in pkg_rpm_basic_test.py
@@ -139,7 +180,17 @@ genrule(
             # Symlink destination (not provided)
             echo ,
         ) >> $@
-
+    done
+    # Config file
+    for f in $(location :config_file); do
+        (
+            echo -n /$$(basename $$f),
+            md5sum $$f | cut -d' ' -f1 | tr '\\n' ,
+            # User,Group,Mode,Fflags (fflags "cmn" = config + missingok + noreplace)
+            echo -n 'root,root,100644,cmn'
+            # Symlink destination (not provided)
+            echo ,
+        ) >> $@
     done
     # Directory (has no hash)
     (
@@ -180,6 +231,7 @@ genrule(
 
         echo 'capability:sense'
         echo 'test:manual'
+        echo 'config(test_rpm) = 1.1.1-2222:config'
     ) > $(RULEDIR)/provides.csv
     (
         # NOTE: excludes 'rpmlib' requires that may be version-dependent
@@ -193,6 +245,7 @@ genrule(
         echo 'bash:preun'
         # Hand-specified
         echo 'test-lib > 1.0:manual'
+        echo 'config(test_rpm) = 1.1.1-2222:config'
     ) > $(RULEDIR)/requires.csv
     """,
 )
@@ -202,7 +255,7 @@ genrule(
 sh_library(
     name = "pkg_rpm_basic_test_data",
     testonly = True,
-    data = [
+    srcs = [
         ":test_rpm",
         ":test_rpm-bzip2",
         ":test_rpm_manifest",
@@ -231,10 +284,8 @@ pkg_rpm(
     name = "test_rpm_default_template",
     testonly = True,
     architecture = "noarch",
-    data = [
-        ":ars_pfg",
-        ":test_links",
-        ":var_log_foo",
+    srcs = [
+        ":test_pfg",
     ],
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",

--- a/pkg/new/tests/rpm/analysis_tests.bzl
+++ b/pkg/new/tests/rpm/analysis_tests.bzl
@@ -1,0 +1,201 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for RPM generation analysis"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//new:rpm.bzl", "pkg_rpm")
+load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
+load(
+    "//:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+    "pkg_mkdirs",
+    "pkg_mklink",
+    "strip_prefix",
+)
+
+# Generic negative test boilerplate
+#
+# TODO: create an internal test library containing this function, and maybe the second one too
+def _generic_neg_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    asserts.expect_failure(env, ctx.attr.reason)
+
+    return analysistest.end(env)
+
+generic_neg_test = analysistest.make(
+    _generic_neg_test_impl,
+    attrs = {
+        "reason": attr.string(
+            default = "",
+        ),
+    },
+    expect_failure = True,
+)
+
+def _generic_base_case_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # Nothing here intentionally, this is simply an attempt to verify successful
+    # analysis.
+
+    return analysistest.end(env)
+
+generic_base_case_test = analysistest.make(
+    _generic_base_case_test_impl,
+    attrs = {},
+)
+
+def _declare_pkg_rpm(name, srcs_ungrouped, tags = None, **kwargs):
+    pfg_name = "{}_pfg".format(name)
+    _tags = tags or ["manual"]
+
+    pkg_filegroup(
+        name = pfg_name,
+        srcs = srcs_ungrouped,
+        tags = _tags,
+    )
+
+    pkg_rpm(
+        name = name,
+        srcs = [":" + pfg_name],
+        version = "1.0",
+        release = "1",
+        license = "N/A",
+        summary = "A test",
+        description = "very much a test",
+        tags = _tags,
+        **kwargs
+    )
+
+def _declare_conflicts_test(name, srcs, **kwargs):
+    rpm_name = name + "_rpm"
+    _declare_pkg_rpm(
+        name = rpm_name,
+        srcs_ungrouped = srcs,
+        tags = ["manual"],
+    )
+
+    generic_neg_test(
+        name = name,
+        target_under_test = ":" + rpm_name,
+    )
+
+def _test_conflicting_inputs(name):
+    # The test here is to confirm if pkg_rpm rejects conflicting inputs
+    #
+    # The structure of the code is such that it's only necessary to test any one
+    # packaged item conflicts with all others; order is irrelevant.
+    #
+    # So, we test how everything would conflict with a "file" entry
+    pkg_files(
+        name = "{}_file_base".format(name),
+        srcs = ["foo"],
+        tags = ["manual"],
+    )
+
+    _declare_pkg_rpm(
+        name = name + "_base",
+        srcs_ungrouped = [":{}_file_base".format(name)],
+    )
+
+    generic_base_case_test(
+        name = name + "_base_case_passes_analysis",
+        target_under_test = ":" + name + "_base",
+    )
+
+    ##################################################
+    # file vs conflicting file
+    ##################################################
+
+    pkg_files(
+        name = "{}_file_conflict".format(name),
+        srcs = ["foo"],
+        tags = ["manual"],
+    )
+
+    _declare_conflicts_test(
+        name = name + "_conflict_with_file",
+        srcs = [
+            ":{}_file_base".format(name),
+            ":{}_file_conflict".format(name),
+        ],
+    )
+
+    ##################################################
+    # file vs conflicting dir
+    ##################################################
+
+    pkg_mkdirs(
+        name = "{}_dir_conflict".format(name),
+        dirs = ["foo"],
+        tags = ["manual"],
+    )
+
+    _declare_conflicts_test(
+        name = name + "_conflict_with_dir",
+        srcs = [
+            ":{}_file_base".format(name),
+            ":{}_dir_conflict".format(name),
+        ],
+    )
+
+    ##################################################
+    # file vs conflicting symbolic link
+    ##################################################
+
+    pkg_mklink(
+        name = "{}_symlink_conflict".format(name),
+        dest = "foo",
+        src = "bar",
+        tags = ["manual"],
+    )
+
+    _declare_conflicts_test(
+        name = name + "_conflict_with_symlink",
+        srcs = [
+            ":{}_file_base".format(name),
+            ":{}_symlink_conflict".format(name),
+        ],
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [":{}_{}".format(name, test_name)
+                 for test_name in
+                 [
+                     "base_case_passes_analysis",
+                     "conflict_with_file",
+                     "conflict_with_dir",
+                     "conflict_with_symlink",
+                 ]
+        ],
+    )
+
+
+def analysis_tests(name, **kwargs):
+    # Need to test:
+    #
+    # - Mutual exclusivity of certain options (low)
+    #
+    _test_conflicting_inputs(name = name + "_conflicting_inputs")
+    native.test_suite(
+        name = name,
+        tests = [
+            name + "_conflicting_inputs"
+        ],
+    )

--- a/pkg/new/tests/rpm/pkg_rpm_basic_test.py
+++ b/pkg/new/tests/rpm/pkg_rpm_basic_test.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import subprocess
+import csv
+import io
+import os
+from rules_python.python.runfiles import runfiles
+
+# This provides some tests for built RPMs, mostly by taking the built RPM and
+# running rpm queries on it.
+#
+# Useful reading:
+#
+# - RPM queryformat documentation (shortish):
+#   https://rpm.org/user_doc/query_format.html
+#
+# - In-depth RPM query documentation:
+#   http://ftp.rpm.org/max-rpm/s1-rpm-query-parts.html
+#
+# - Specifically, about the --qf/--queryformat syntax:
+#   http://ftp.rpm.org/max-rpm/s1-rpm-query-parts.html#S3-RPM-QUERY-QUERYFORMAT-OPTION
+#
+# - --queryformat tags list: http://ftp.rpm.org/max-rpm/ch-queryformat-tags.html
+#
+class PkgRpmBasicTest(unittest.TestCase):
+    def setUp(self):
+        self.runfiles = runfiles.Create()
+        self.test_rpm_path = self.runfiles.Rlocation(
+            "rules_pkg/experimental/tests/rpm/test_rpm.rpm")
+        self.test_rpm_bzip2_path = self.runfiles.Rlocation(
+            "rules_pkg/experimental/tests/rpm/test_rpm-bzip2.rpm")
+        self.maxDiff = None
+
+    def test_scriptlet_content(self):
+        expected = b"""\
+preinstall scriptlet (using /bin/sh):
+echo pre
+postinstall scriptlet (using /bin/sh):
+echo post
+preuninstall scriptlet (using /bin/sh):
+echo preun
+postuninstall scriptlet (using /bin/sh):
+echo postun
+"""
+
+        output = subprocess.check_output(
+            ["rpm", "-qp", "--scripts", self.test_rpm_path])
+
+        self.assertEqual(output, expected)
+
+    def test_basic_headers(self):
+        fields = {
+            "NAME": b"test_rpm",
+            "VERSION": b"1.1.1",
+            "RELEASE": b"2222",
+            "ARCH": b"noarch",
+            "GROUP": b"Unspecified",
+            "SUMMARY": b"pkg_rpm test rpm summary",
+        }
+        for fieldname, expected in fields.items():
+            output = subprocess.check_output([
+                "rpm", "-qp", "--queryformat", "%{" + fieldname + "}",
+                self.test_rpm_path
+            ])
+
+            self.assertEqual(
+                output, expected,
+                "RPM Tag {} does not match expected value".format(fieldname))
+
+    def test_contents(self):
+        manifest_file = self.runfiles.Rlocation(
+            "rules_pkg/experimental/tests/rpm/manifest.csv")
+        manifest_specs = {}
+        with open(manifest_file, "r", newline='', encoding="utf-8") as fh:
+            manifest_reader = csv.DictReader(fh)
+            manifest_specs = {r['path']: r for r in manifest_reader}
+
+        # It is not necessary to check for file sizes, as the hashes are
+        # sufficient for determining whether or not files are the same.
+        #
+        # This also simplifies behavior where RPM's size calculations have
+        # sometimes changed, e.g.:
+        #
+        # https://github.com/rpm-software-management/rpm/commit/2cf7096ba534b065feb038306c792784458ac9c7
+
+        rpm_queryformat = (
+            "[%{FILENAMES}"
+            ",%{FILEDIGESTS}"
+            ",%{FILEUSERNAME}"
+            ",%{FILEGROUPNAME}"
+            ",%{FILEMODES:octal}"
+            ",%{FILEFLAGS:fflags}"
+            ",%{FILELINKTOS}"
+            "\n]"
+        )
+
+        rpm_queryformat_fieldnames = [
+            "path",
+            "digest",
+            "user",
+            "group",
+            "mode",
+            "fflags",
+            "symlink",
+        ]
+
+        rpm_output = subprocess.check_output(
+            ["rpm", "-qp", "--queryformat", rpm_queryformat, self.test_rpm_path])
+
+        sio = io.StringIO(rpm_output.decode('utf-8'))
+        rpm_output_reader = csv.DictReader(
+            sio, fieldnames = rpm_queryformat_fieldnames)
+        for rpm_file_info in rpm_output_reader:
+            my_path = rpm_file_info['path']
+            self.assertIn(my_path, manifest_specs)
+            self.assertDictEqual(manifest_specs[my_path], rpm_file_info)
+
+    def test_preamble_metadata(self):
+        metadata_prefix = "rules_pkg/experimental/tests/rpm"
+
+        rpm_filename = os.path.basename(self.test_rpm_path)
+        rpm_basename = os.path.splitext(rpm_filename)[0]
+
+        # Tuples of:
+        # Metadata name, RPM Tag prefix, exclusion list (currently only support "startswith")
+        #
+        # The exclusions should probably be regexps at some point, but right
+        # now, our job is relatively easy.  They only operate on the
+        # "capability" portion of the tag.
+        test_md = [
+            ("conflicts", "CONFLICT", []),
+            # rpm packages implicitly provide themselves, something like:
+            # "test_rpm = 1.1.1-2222".  We don't bother testing this, since we
+            # don't take direct action to specify it.
+            ("provides",  "PROVIDE",  [rpm_basename]),
+            # Skip rpmlib-related requirements; they are often dependent on the
+            # version of `rpm` we are using.
+            ("requires",  "REQUIRE",  ["rpmlib"]),
+        ]
+        for (mdtype, tag, exclusions) in test_md:
+            md_file = self.runfiles.Rlocation(
+                os.path.join(metadata_prefix, mdtype + ".csv"))
+
+            with open(md_file, "r", newline='', encoding="utf-8") as fh:
+                md_reader = csv.DictReader(fh, delimiter=':')
+                # I heard you like functional programming ;)
+                #
+                # This produces a list of outputs whenever the "capability"
+                # attribute starts with any of the values in the "exclusions"
+                # list.
+                md_specs_unsorted = [line for line in md_reader
+                                     if not any(line['capability'].startswith(e)
+                                                for e in exclusions)]
+                # And this sorts it, ordering by the sorted "association list"
+                # form of the dictionary.
+                #
+                # The sorting of the key values is not necessary with versions
+                # of python3 (3.5+, I believe) that have dicts maintain
+                # insertion order.
+                md_specs = sorted(md_specs_unsorted,
+                                  key = lambda x: sorted(x.items()))
+
+
+            # This typically becomes the equivalent of:
+            #
+            #   '[%{PROVIDENEVRS};%{PROVIDEFLAGS:deptype}\n]'
+            #
+            # as passed to `rpm --queryformat`
+            rpm_queryformat = (
+                # NEVRS = Name Epoch Version Release (plural), which look something like:
+                #   rpmlib(CompressedFileNames) <= 3.0.4-1
+                # or:
+                #   bash
+                "[%{{{tag}NEVRS}}"
+                # Flags associated with the dependency type.  This used to
+                # evaluate in what "sense" the dependency was added.
+                #
+                # Values often include things like:
+                #
+                # - "interp" for scriptlet interpreter dependencies
+                # - "postun" for dependencies of the "postun" scriptlet
+                # - "manual" for values that are explicitly specified
+                ":%{{{tag}FLAGS:deptype}}"
+                "\n]"
+            ).format(tag = tag)
+
+            rpm_queryformat_fieldnames = [
+                "capability",
+                "sense",
+            ]
+
+            rpm_output = subprocess.check_output(
+                ["rpm", "-qp", "--queryformat", rpm_queryformat, self.test_rpm_path])
+
+            sio = io.StringIO(rpm_output.decode('utf-8'))
+            rpm_output_reader = csv.DictReader(
+                sio, delimiter=':', fieldnames=rpm_queryformat_fieldnames)
+
+            # Get everything in the same order as the read-in metadata file
+            rpm_outputs_filtered_unsorted = [line for line in rpm_output_reader
+                                             if not any(line['capability'].startswith(e)
+                                                        for e in exclusions)]
+
+            rpm_outputs_filtered = sorted(rpm_outputs_filtered_unsorted, key = lambda x: sorted(x.items()))
+
+            for expected, actual in zip(md_specs, rpm_outputs_filtered):
+                self.assertDictEqual(expected, actual,
+                                     msg="{} metadata discrepancy".format(mdtype))
+
+    def test_compression_none_provided(self):
+        # Test when we don't provide "binary_payload_compression" to pkg_rpm
+        my_rpm = self.test_rpm_path
+        rpm_output = subprocess.check_output(
+            ["rpm", "-qp", "--queryformat", "%{PAYLOADCOMPRESSOR}", my_rpm])
+        sio = io.StringIO(rpm_output.decode('utf-8'))
+        actual_compressor = sio.read()
+        # `bzip2` compression was, AFAICT, never the default for rpmbuild(8),
+        # and never will be, so this should be fine.
+        self.assertNotEqual(actual_compressor, 'bzip2')
+
+    def test_compression_passthrough(self):
+        # Test when we provide "binary_payload_compression" to pkg_rpm
+        my_rpm = self.test_rpm_bzip2_path
+        rpm_output = subprocess.check_output(
+            ["rpm", "-qp", "--queryformat", "%{PAYLOADCOMPRESSOR}", my_rpm])
+        sio = io.StringIO(rpm_output.decode('utf-8'))
+        actual_compressor = sio.read()
+        self.assertEqual(actual_compressor, 'bzip2')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/new/tests/rpm/pkg_rpm_basic_test.py
+++ b/pkg/new/tests/rpm/pkg_rpm_basic_test.py
@@ -41,9 +41,9 @@ class PkgRpmBasicTest(unittest.TestCase):
     def setUp(self):
         self.runfiles = runfiles.Create()
         self.test_rpm_path = self.runfiles.Rlocation(
-            "rules_pkg/experimental/tests/rpm/test_rpm.rpm")
+            "rules_pkg/new/tests/rpm/test_rpm.rpm")
         self.test_rpm_bzip2_path = self.runfiles.Rlocation(
-            "rules_pkg/experimental/tests/rpm/test_rpm-bzip2.rpm")
+            "rules_pkg/new/tests/rpm/test_rpm-bzip2.rpm")
         self.maxDiff = None
 
     def test_scriptlet_content(self):
@@ -84,7 +84,7 @@ echo postun
 
     def test_contents(self):
         manifest_file = self.runfiles.Rlocation(
-            "rules_pkg/experimental/tests/rpm/manifest.csv")
+            "rules_pkg/new/tests/rpm/manifest.csv")
         manifest_specs = {}
         with open(manifest_file, "r", newline='', encoding="utf-8") as fh:
             manifest_reader = csv.DictReader(fh)
@@ -125,13 +125,12 @@ echo postun
         sio = io.StringIO(rpm_output.decode('utf-8'))
         rpm_output_reader = csv.DictReader(
             sio, fieldnames = rpm_queryformat_fieldnames)
-        for rpm_file_info in rpm_output_reader:
-            my_path = rpm_file_info['path']
-            self.assertIn(my_path, manifest_specs)
-            self.assertDictEqual(manifest_specs[my_path], rpm_file_info)
 
+        rpm_output_specs = {r['path'] : r for r in rpm_output_reader}
+
+        self.assertDictEqual(manifest_specs, rpm_output_specs)
     def test_preamble_metadata(self):
-        metadata_prefix = "rules_pkg/experimental/tests/rpm"
+        metadata_prefix = "rules_pkg/new/tests/rpm"
 
         rpm_filename = os.path.basename(self.test_rpm_path)
         rpm_basename = os.path.splitext(rpm_filename)[0]

--- a/pkg/new/tests/rpm/template-test.spec.in
+++ b/pkg/new/tests/rpm/template-test.spec.in
@@ -1,0 +1,45 @@
+# -*- rpm-spec -*-
+
+################################################################################
+# Test customizations
+
+# Force MD5 file digesting to preserve compatibility with (very old) versions of
+# rpm.
+#
+# For valid values to set here, see:
+# https://github.com/rpm-software-management/rpm/blob/8d628a138ee4c3d1b77b993a3c5b71345ce052e8/macros.in#L393-L405
+#
+# At some point, we might want to consider bumping this up to use SHA-1 (2), but
+# that would be best reserved for when we don't know of anyone using rpm < 4.6.
+%define _source_filedigest_algorithm 1
+%define _binary_filedigest_algorithm 1
+
+# Do not try to use magic to determine file types
+%define __spec_install_post %{nil}
+
+################################################################################
+
+# Hey!
+#
+# Keep the below in sync with pkg/experimental/template.spec.in!
+
+################################################################################
+
+# This comprises the entirety of the preamble
+%include %build_rpm_options
+
+%description
+%include %build_rpm_description
+
+%install
+%include %build_rpm_install
+
+%files -f %build_rpm_files
+
+${PRE_SCRIPTLET}
+
+${POST_SCRIPTLET}
+
+${PREUN_SCRIPTLET}
+
+${POSTUN_SCRIPTLET}

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -64,7 +64,10 @@ PackageSymlinkInfo = provider(
     fields = {
         "attributes": """See `attributes` in PackageFilesInfo.""",
         "destination": """string: Filesystem link 'name'""",
-        "source": """string or Label: Filesystem link 'target'""",
+        "source": """string or Label: Filesystem link 'target'.
+        
+        TODO(nacl): Label sources not yet supported.
+        """,
     },
 )
 
@@ -74,7 +77,7 @@ PackageFilegroupInfo = provider(
     doc = """Provider representing a collection of related packaging providers""",
     fields = {
         "pkg_files": "list of child PackageFilesInfo providers",
-        "pkg_dirs": "list of child PackageDirInfo providers",
+        "pkg_dirs": "list of child PackageDirsInfo providers",
         "pkg_symlinks": "list of child PackageSymlinkInfo providers",
     },
 )

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -65,7 +65,7 @@ PackageSymlinkInfo = provider(
         "attributes": """See `attributes` in PackageFilesInfo.""",
         "destination": """string: Filesystem link 'name'""",
         "source": """string or Label: Filesystem link 'target'.
-        
+
         TODO(nacl): Label sources not yet supported.
         """,
     },
@@ -74,10 +74,17 @@ PackageSymlinkInfo = provider(
 # Grouping provider: the only one that needs to be consumed by packaging (or
 # other) rules that materialize paths.
 PackageFilegroupInfo = provider(
-    doc = """Provider representing a collection of related packaging providers""",
+    doc = """Provider representing a collection of related packaging providers,
+
+    In the "fields" documentation, "origin" refers to the label identifying the
+    where the provider was originally defined.  This can be used by packaging
+    rules to provide better diagnostics related to where packaging rules were
+    created.
+
+    """,
     fields = {
-        "pkg_files": "list of child PackageFilesInfo providers",
-        "pkg_dirs": "list of child PackageDirsInfo providers",
-        "pkg_symlinks": "list of child PackageSymlinkInfo providers",
+        "pkg_files": "list of tuples of (PackageFilesInfo, origin)",
+        "pkg_dirs": "list of tuples of (PackageDirsInfo, origin)",
+        "pkg_symlinks": "list of tuples of (PackageSymlinkInfo, origin)",
     },
 )

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -655,6 +655,7 @@ def _test_pkg_mklink():
         dest = "foo",
         src = "bar",
         tags = ["manual"],
+        attributes = pkg_attributes(mode = "0111"),
     )
 
     pkg_mklink_contents_test(
@@ -662,7 +663,31 @@ def _test_pkg_mklink():
         target_under_test = ":pkg_mklink_base_g",
         expected_dest = "foo",
         expected_src = "bar",
-        expected_attributes = pkg_attributes(mode = "0777"),
+        expected_attributes = pkg_attributes(mode = "0111"),
+    )
+
+    # Test that the default mode (0755) is always set regardless of the other
+    # values in "attributes".
+    pkg_mklink(
+        name = "pkg_mklink_mode_overlay_if_not_provided_g",
+        dest = "foo",
+        src = "bar",
+        attributes = pkg_attributes(
+            user = "root",
+            group = "sudo",
+        ),
+        tags = ["manual"],
+    )
+    pkg_mklink_contents_test(
+        name = "pkg_mklink_mode_overlay_if_not_provided",
+        target_under_test = ":pkg_mklink_mode_overlay_if_not_provided_g",
+        expected_dest = "foo",
+        expected_src = "bar",
+        expected_attributes = pkg_attributes(
+            mode = "0777",
+            user = "root",
+            group = "sudo",
+        ),
     )
 
 ##########
@@ -919,6 +944,7 @@ def mappings_analysis_tests():
             ":pkg_mkdirs_mode_overlay_if_not_provided",
             # Tests involving pkg_mklink
             ":pkg_mklink_base",
+            ":pkg_mklink_mode_overlay_if_not_provided",
             # Tests involving pkg_filegroup
             ":pfg_tests",
         ],

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -16,14 +16,28 @@
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 load(
     "//:mappings.bzl",
     "pkg_attributes",
+    "pkg_filegroup",
     "pkg_files",
     "pkg_mkdirs",
+    "pkg_mklink",
     "strip_prefix",
 )
-load("//:providers.bzl", "PackageDirsInfo", "PackageFilesInfo")
+
+##########
+# Helpers
+##########
+
+def _flatten(list_of_lists):
+    """Transform a list of lists into a single list, preserving relative order."""
+    return [item for sublist in list_of_lists for item in sublist]
+
+##########
+# pkg_files tests
+##########
 
 def _pkg_files_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -42,6 +56,8 @@ def _pkg_files_contents_test_impl(ctx):
             target_under_test[PackageFilesInfo].attributes,
             "pkg_files attributes do not match expectations",
         )
+
+    # TODO(nacl): verify DefaultInfo propagation
 
     return analysistest.end(env)
 
@@ -593,6 +609,215 @@ def _test_pkg_mkdirs():
     )
 
 ##########
+# Test pkg_mklink
+##########
+def _pkg_mklink_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        ctx.attr.expected_src,
+        target_under_test[PackageSymlinkInfo].source,
+        "pkg_mklink source does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        ctx.attr.expected_dest,
+        target_under_test[PackageSymlinkInfo].destination,
+        "pkg_mklink destination does not match expectations",
+    )
+
+    # Simple equality checks for the others, if specified
+    if ctx.attr.expected_attributes:
+        asserts.equals(
+            env,
+            json.decode(ctx.attr.expected_attributes),
+            target_under_test[PackageSymlinkInfo].attributes,
+            "pkg_mklink attributes do not match expectations",
+        )
+
+    return analysistest.end(env)
+
+pkg_mklink_contents_test = analysistest.make(
+    _pkg_mklink_contents_test_impl,
+    attrs = {
+        "expected_src": attr.string(mandatory = True),
+        "expected_dest": attr.string(mandatory = True),
+        "expected_attributes": attr.string(),
+    },
+)
+
+def _test_pkg_mklink():
+    pkg_mklink(
+        name = "pkg_mklink_base_g",
+        dest = "foo",
+        src = "bar",
+        tags = ["manual"],
+    )
+
+    pkg_mklink_contents_test(
+        name = "pkg_mklink_base",
+        target_under_test = ":pkg_mklink_base_g",
+        expected_dest = "foo",
+        expected_src = "bar",
+        expected_attributes = pkg_attributes(mode = "0777"),
+    )
+
+##########
+# Test pkg_filegroup
+##########
+def _pkg_filegroup_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    asserts.equals(
+        env,
+        [t[PackageFilesInfo] for t in ctx.attr.expected_pkg_files],
+        target_under_test[PackageFilegroupInfo].pkg_files,
+        "pkg_filegroup file list does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        [t[PackageDirsInfo] for t in ctx.attr.expected_pkg_dirs],
+        target_under_test[PackageFilegroupInfo].pkg_dirs,
+        "pkg_filegroup directory list does not match expectations",
+    )
+
+    asserts.equals(
+        env,
+        [t[PackageSymlinkInfo] for t in ctx.attr.expected_pkg_symlinks],
+        target_under_test[PackageFilegroupInfo].pkg_symlinks,
+        "pkg_filegroup symlink map list does not match expectations",
+    )
+
+    # Verify that the DefaultInfo is propagated properly out of the input
+    # pkg_files's -- these are the files that need to be passed along to the
+    # packaging rules.
+    expected_packaged_files = sorted(_flatten([
+        t[DefaultInfo].files.to_list()
+        for t in ctx.attr.expected_pkg_files
+    ]))
+    packaged_files = sorted(target_under_test[DefaultInfo].files.to_list())
+
+    asserts.equals(
+        env,
+        expected_packaged_files,
+        packaged_files,
+        "pkg_filegroup does not propagate DefaultInfo from pkg_file inputs",
+    )
+
+    return analysistest.end(env)
+
+pkg_filegroup_contents_test = analysistest.make(
+    _pkg_filegroup_contents_test_impl,
+    attrs = {
+        "expected_pkg_files": attr.label_list(
+            providers = [PackageFilesInfo],
+            default = [],
+        ),
+        "expected_pkg_dirs": attr.label_list(
+            providers = [PackageDirsInfo],
+            default = [],
+        ),
+        "expected_pkg_symlinks": attr.label_list(
+            providers = [PackageSymlinkInfo],
+            default = [],
+        ),
+    },
+)
+
+def _test_pkg_filegroup(name):
+    pkg_files(
+        name = "{}_pkg_files".format(name),
+        srcs = ["foo", "bar"],
+        prefix = "bin",
+        tags = ["manual"],
+    )
+
+    pkg_mkdirs(
+        name = "{}_pkg_dirs".format(name),
+        dirs = ["etc"],
+        tags = ["manual"],
+    )
+
+    pkg_mklink(
+        name = "{}_pkg_symlink".format(name),
+        src = "src",
+        dest = "dest",
+        tags = ["manual"],
+    )
+
+    pkg_filegroup(
+        name = "{}_pfg".format(name),
+        srcs = [t.format(name) for t in ["{}_pkg_files", "{}_pkg_dirs", "{}_pkg_symlink"]],
+        tags = ["manual"],
+    )
+
+    # Base case: confirm that basic data translation is working
+    pkg_filegroup_contents_test(
+        name = "{}_contents_valid".format(name),
+        target_under_test = "{}_pfg".format(name),
+        expected_pkg_files = ["{}_pkg_files".format(name)],
+        expected_pkg_dirs = ["{}_pkg_dirs".format(name)],
+        expected_pkg_symlinks = ["{}_pkg_symlink".format(name)],
+    )
+
+    ##################################################
+
+    pkg_files(
+        name = "{}_pkg_files_prefixed".format(name),
+        srcs = ["foo", "bar"],
+        prefix = "prefix/bin",
+        tags = ["manual"],
+    )
+
+    pkg_mkdirs(
+        name = "{}_pkg_dirs_prefixed".format(name),
+        dirs = ["prefix/etc"],
+        tags = ["manual"],
+    )
+
+    pkg_mklink(
+        name = "{}_pkg_symlink_prefixed".format(name),
+        src = "src",
+        dest = "prefix/dest",
+        tags = ["manual"],
+    )
+
+    # Test that prefixing works by using the unprefixed mapping rules we
+    # initially created, and set a prefix.
+    pkg_filegroup(
+        name = "{}_prefixed_pfg".format(name),
+        srcs = [t.format(name) for t in ["{}_pkg_files", "{}_pkg_dirs", "{}_pkg_symlink"]],
+        prefix = "prefix",
+        tags = ["manual"],
+    )
+
+    # Then test that the results are equivalent to manually specifying the
+    # prefix everywhere.
+    pkg_filegroup_contents_test(
+        name = "{}_contents_prefix_translated".format(name),
+        target_under_test = "{}_prefixed_pfg".format(name),
+        expected_pkg_files = ["{}_pkg_files_prefixed".format(name)],
+        expected_pkg_dirs = ["{}_pkg_dirs_prefixed".format(name)],
+        expected_pkg_symlinks = ["{}_pkg_symlink_prefixed".format(name)],
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            t.format(name)
+            for t in [
+                "{}_contents_valid",
+                "{}_contents_prefix_translated",
+            ]
+        ],
+    )
+
+##########
 # Test strip_prefix pseudo-module
 ##########
 
@@ -614,6 +839,11 @@ def mappings_analysis_tests():
     _test_pkg_files_extrepo()
     _test_pkg_files_rename()
     _test_pkg_mkdirs()
+    _test_pkg_mklink()
+
+    # TODO(nacl) migrate the above to use a scheme the one used here.  At the very
+    # least, the test suites should be easy to find/name.
+    _test_pkg_filegroup(name = "pfg_tests")
 
     native.test_suite(
         name = "pkg_files_analysis_tests",
@@ -658,6 +888,10 @@ def mappings_analysis_tests():
             # Tests involving pkg_mkdirs
             ":pkg_mkdirs_base",
             ":pkg_mkdirs_mode_overlay_if_not_provided",
+            # Tests involving pkg_mklink
+            ":pkg_mklink_base",
+            # Tests involving pkg_filegroup
+            ":pfg_tests",
         ],
     )
 


### PR DESCRIPTION
This change is built on top of #293 and #303, which are not yet submitted.  The actual work involved with this change is in 146bc2a.

---

This change provides a number of unit tests for the pkg_filegroup-using
`pkg_rpm` rule, meant to ensure that packages are formed as expected and
conflict detection is properly implemented.

The main differences between these and the tests in experimental/tests are:

- Analysis tests for conflict detection
- Fixed bugs WRT contents detection
- Path changes

This is likely not the final destination for these test cases, and this commit may be
combined with the rules implementation, depending on the size of the diff.  See
#303 for more details.