### PR TITLE
Updates for a 0.4.0 release

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -35,7 +35,7 @@ filegroup(
 
 exports_files(
     ["WORKSPACE"],
-    visibility = ["//distro:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/pkg/version.bzl
+++ b/pkg/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_pkg."""
 
-version = "0.3.0"
+version = "0.4.0"


### PR DESCRIPTION
- bump version
- Open visibility of WORKSPACE because Bazel's integration tests
  insist that it be visible to //src:test_repos.