### PR TITLE
Correct readme.md for rpm toolchain

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -32,7 +32,6 @@ http_archive(
 )
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
-
 ```
 
 If you want to use `pkg_rpm()` you must instantiate a toolchain to provide the

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -24,11 +24,15 @@ and debian package.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
-    sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.4.0/rules_pkg-0.4.0.tar.gz",
+    ],
+    sha256 = "038f1caa773a7e35b3663865ffb003169c6a71dc995e39bf4815792f385d837d",
 )
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
+
 ```
 
 If you want to use `pkg_rpm()` you must instantiate a toolchain to provide the
@@ -37,7 +41,7 @@ If you want to use `pkg_rpm()` you must instantiate a toolchain to provide the
 ```
 # Find rpmbuild provided on your system.
 load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
-find_system_rpmbuild(name="rules_pkg_rpmbuild")
+find_system_rpmbuild(name = "rules_pkg_rpmbuild")
 ```
 
 <a name="basic-example"></a>

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -36,7 +36,7 @@ If you want to use `pkg_rpm()` you must instantiate a toolchain to provide the
 
 ```
 # Find rpmbuild provided on your system.
-load("//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
+load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
 find_system_rpmbuild(name="rules_pkg_rpmbuild")
 ```
 


### PR DESCRIPTION
The readme instructions for the rpm toolchain is incorrect, this should fix it.