### PR TITLE
experimental/rpm.bzl: use rpmbuild toolchain, re-enable RPM testing in CI

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -10,8 +10,9 @@ common: &common
 tasks:
   centos7:
     platform: centos7
+    working_directory: /workdir/pkg
     test_targets:
-    # This include the rpm tests, whihc are not (yet) supported in the below
+    # This include the rpm tests, which are not (yet) supported in the below
     # cases.
     - "..."
   ubuntu1604:

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -12,7 +12,7 @@ tasks:
     platform: centos7
     working_directory: /workdir/pkg
     test_targets:
-    # This include the rpm tests, which are not (yet) supported in the below
+    # This includes the rpm tests, which are not (yet) supported in the below
     # cases.
     - "..."
   ubuntu1604:

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -2,9 +2,6 @@ common: &common
   working_directory: /workdir/pkg
   test_targets:
   - "..."
-  # Cannot run until #183 is resolved; none of the CI images have rpmbuild(8)
-  - "-//tests/rpm/..."
-  - "-//experimental/tests/rpm/..."
 
 tasks:
   centos7:

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -2,11 +2,18 @@ common: &common
   working_directory: /workdir/pkg
   test_targets:
   - "..."
+  # Cannot run until #183 is resolved; none of the CI images have rpmbuild(8)
+  - "-//tests/rpm/..."
+  - "-//experimental/tests/rpm/..."
+
 
 tasks:
   centos7:
     platform: centos7
-    <<: *common
+    test_targets:
+    # This include the rpm tests, whihc are not (yet) supported in the below
+    # cases.
+    - "..."
   ubuntu1604:
     platform: ubuntu1604
     <<: *common

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -21,7 +21,7 @@ and debian package.
 <a name="workspace-setup"></a>
 ### WORKSPACE setup
 
-```
+```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",
@@ -35,10 +35,11 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 ```
 
-If you want to use `pkg_rpm()` you must instantiate a toolchain to provide the
-`rpmbuild` tool.  Add this to WORKSPACE to use the installed version.
+If you want to use `pkg_rpm()` (either from `rpm.bzl` or `experimental/rpm.bzl`)
+you must instantiate a toolchain to provide the `rpmbuild` tool.  Add this to
+WORKSPACE to use one installed on your system:
 
-```
+```python
 # Find rpmbuild provided on your system.
 load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
 find_system_rpmbuild(name = "rules_pkg_rpmbuild")

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -9,7 +9,8 @@
 <a name="notes"></a>
 ## Release Notes
 
-Version 0.3.0 or later requires Bazel 3.2.0 or later.
+Version 1.0.0 or later (including all currently in-development code) requires
+Bazel 4.0.0 or later.
 
 <a name="overview"></a>
 ## Overview

--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides rules for creating RPM packages via pkg_filegroup and friends."""
+"""Provides rules for creating RPM packages via pkg_filegroup and friends.
+
+pkg_rpm() depends on the existence of an rpmbuild toolchain. Many users will
+find to convenient to use the one provided with their system. To enable that
+toolchain add the following stanza to WORKSPACE:
+
+```
+# Find rpmbuild if it exists.
+load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
+find_system_rpmbuild(name="rules_pkg_rpmbuild")
+```
+"""
 
 load("//:providers.bzl", "PackageFilegroupInfo")
 
@@ -92,6 +103,7 @@ def _pkg_rpm_impl(ctx):
     """Implements the pkg_rpm rule."""
 
     files = []
+    tools = []
     args = ["--name=" + ctx.label.name]
 
     if ctx.attr.debug:
@@ -99,6 +111,22 @@ def _pkg_rpm_impl(ctx):
 
     if ctx.attr.rpmbuild_path:
         args.append("--rpmbuild=" + ctx.attr.rpmbuild_path)
+
+        # buildifier: disable=print
+        print("rpmbuild_path is deprecated. See the README for instructions on how" +
+              " to migrate to toolchains")
+    else:
+        toolchain = ctx.toolchains["@rules_pkg//toolchains:rpmbuild_toolchain_type"].rpmbuild
+        if not toolchain.valid:
+            fail("The rpmbuild_toolchain is not properly configured: " +
+                 toolchain.name)
+        if toolchain.path:
+            args.append("--rpmbuild=" + toolchain.path)
+        else:
+            executable = toolchain.label.files_to_run.executable
+            tools.append(executable)
+            tools += toolchain.label.default_runfiles.files.to_list()
+            args.append("--rpmbuild=%s" % executable.path)
 
     #### rpm spec "preamble"
     preamble_pieces = []
@@ -410,6 +438,7 @@ def _pkg_rpm_impl(ctx):
             "PYTHONIOENCODING": "UTF-8",
             "PYTHONUTF8": "1",
         },
+        tools = tools,
     )
 
     #### Output construction
@@ -695,11 +724,6 @@ pkg_rpm = rule(
             acceptable to `rpm(8)`.
             """,
         ),
-
-        # TODO(nacl): this should be a toolchain
-        "rpmbuild_path": attr.string(
-            doc = """Path to a `rpmbuild` binary.""",
-        ),
         "spec_template": attr.label(
             doc = """Spec file template.
 
@@ -735,6 +759,9 @@ pkg_rpm = rule(
             overcommitting your system.
             """,
         ),
+        "rpmbuild_path": attr.string(
+            doc = """Path to a `rpmbuild` binary.  Deprecated in favor of the rpmbuild toolchain""",
+        ),
         # Implicit dependencies.
         "_make_rpm": attr.label(
             default = Label("//:make_rpm"),
@@ -746,4 +773,5 @@ pkg_rpm = rule(
     executable = False,
     outputs = _pkg_rpm_outputs,
     implementation = _pkg_rpm_impl,
+    toolchains = ["@rules_pkg//toolchains:rpmbuild_toolchain_type"],
 )


### PR DESCRIPTION
This change modifies the pkg_rpm rule in `pkg/experimental/rpm.bzl` to use the
rpmbuild toolchain currently in use by the existing RPM packaging rule in
`pkg/rpm.bzl`.  Logic was largely copied from `pkg/rpm.bzl`.

Additionally, the RPM tests were removed from the disabled test set -- the
toolchain skipping system should be enough to take care of this on systems that
don't have rpmbuild (everything but CentOS in CI, right now).

Documentation was also updated to reflect bazel version compatibility.  Other
`pkg_filegroup`-related changes require 4.0.0.

Fixes #299, partially resolves #183.