### PR TITLE
Improve pkg_filegroup-using pkg_rpm TreeArtifact installation

### DIFF
--- a/pkg/experimental/BUILD
+++ b/pkg/experimental/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_binary")
+
 exports_files(
     glob([
         "*.bzl",
@@ -25,9 +27,18 @@ filegroup(
     name = "standard_package",
     srcs = glob([
         "*.bzl",
+        "*.py",
     ]) + [
         "BUILD",
         "template.spec.in",
     ],
     visibility = ["//:__pkg__"],
+)
+
+# Helper script used to augment the %install scriptlet and %files list with
+# those found in TreeArtifacts (directory outputs) See also #292.
+py_binary(
+    name = "augment_rpm_files_install",
+    srcs = ["augment_rpm_files_install.py"],
+    visibility = ["//visibility:public"],
 )

--- a/pkg/experimental/augment_rpm_files_install.py
+++ b/pkg/experimental/augment_rpm_files_install.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script takes a pair of Bazel-generated RPM %install scriptlet and %files
+# list, and combined with JSON description of TreeArtifacts, emits copies
+# augmented with the files detected in the materialized TreeArtifacts.
+
+import os
+import sys
+import json
+
+# XXX: Keep this in sync with the same variable in rpm.bzl
+_INSTALL_FILE_STANZA_FMT = """
+install -d %{{buildroot}}/$(dirname {1})
+cp {0} %{{buildroot}}/{1}
+""".strip()
+
+# Cheapo arg parsing.  Currently this script is single-purpose.
+
+# JSON file containing the TreeArtifact manifest info.
+#
+# This is expected to be an array of objects with the following fields:
+#
+# - src: Source file/directory location.
+# - dest: Install prefix
+# - tags: Tags for the %files manifest
+dir_data_path = sys.argv[1]
+
+# Existing files
+existing_install_script_path = sys.argv[2]
+existing_files_path = sys.argv[3]
+
+# Output files
+new_install_script_path = sys.argv[4]
+new_files_path = sys.argv[5]
+
+# Computed outputs to be combined with the originals
+dir_install_script_segments = []
+dir_files_segments = []
+
+with open(dir_data_path, 'r') as fh:
+    dir_data = json.load(fh)
+
+    for d in dir_data:
+        # d is a dict, d["src"] is the TreeArtifact directory to walk.
+        print(d["src"])
+        for root, dirs, files in os.walk(d["src"]):
+            # "root" is the current directory we're walking through.  This
+            # computes the path the source location (the TreeArtifact root) --
+            # the desired install location relative to the user-provided install
+            # destination.
+            path_relative_to_install_dest = os.path.relpath(root, start=d["src"])
+            print(path_relative_to_install_dest)
+
+            for f in files:
+                print(" ", d["dest"], path_relative_to_install_dest, f)
+                full_dest = os.path.join(d["dest"], path_relative_to_install_dest, f)
+                dir_install_script_segments.append(_INSTALL_FILE_STANZA_FMT.format(
+                    os.path.join(root, f),
+                    full_dest
+                ))
+                dir_files_segments.append(
+                    d["tags"] + " " + full_dest
+                )
+
+with open(existing_install_script_path, 'r') as fh:
+    existing_install_script = fh.read()
+
+with open(existing_files_path, 'r') as fh:
+    existing_files = fh.read()
+
+# Write the outputs
+with open(new_install_script_path, 'w') as fh:
+    fh.write(existing_install_script)
+    fh.write("\n")
+    fh.write("\n".join(dir_install_script_segments))
+
+with open(new_files_path, 'w') as fh:
+    fh.write(existing_files)
+    fh.write("\n")
+    fh.write("\n".join(dir_files_segments))

--- a/pkg/experimental/augment_rpm_files_install.py
+++ b/pkg/experimental/augment_rpm_files_install.py
@@ -22,7 +22,7 @@ import os
 import sys
 import json
 
-# XXX: Keep this in sync with the same variable in rpm.bzl
+# NOTE: Keep this in sync with the same variable in rpm.bzl
 _INSTALL_FILE_STANZA_FMT = """
 install -d %{{buildroot}}/$(dirname {1})
 cp {0} %{{buildroot}}/{1}

--- a/pkg/experimental/tests/rpm/BUILD
+++ b/pkg/experimental/tests/rpm/BUILD
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "pkg_mklink")
+load(
+    "@rules_pkg//:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+    "pkg_mkdirs",
+    "pkg_mklink",
+)
 load("@rules_pkg//experimental:rpm.bzl", "pkg_rpm")
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load(":analysis_tests.bzl", "analysis_tests")
+
+exports_files(
+    ["template-test.spec.in"],
+    visibility = [":__subpackages__"],
+)
 
 ############################################################################
 # analysis tests
@@ -265,6 +277,13 @@ sh_library(
 # Actual tests
 ############################################################################
 
+py_library(
+    name = "rpm_util",
+    srcs = ["rpm_util.py"],
+    imports = ["."],
+    visibility = [":__subpackages__"],
+)
+
 # RPM content verification tests
 py_test(
     name = "pkg_rpm_basic_test",
@@ -272,9 +291,12 @@ py_test(
     data = [":pkg_rpm_basic_test_data"],
     python_version = "PY3",
     tags = [
-        "no_windows",  # Windows doesn't have rpmbuild(8)
+        "no_windows",  # Windows doesn't have rpm(8) or rpmbuild(8)
     ],
-    deps = ["@rules_python//python/runfiles"],
+    deps = [
+        ":rpm_util",
+        "@rules_python//python/runfiles",
+    ],
 )
 
 # Smoke test for defaults

--- a/pkg/experimental/tests/rpm/rpm_util.py
+++ b/pkg/experimental/tests/rpm/rpm_util.py
@@ -1,0 +1,75 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import csv
+import subprocess
+
+def read_rpm_filedata(rpm_path, rpm_bin_path="rpm"):
+    """Read rpm metadata into a dictionary
+
+    Keys are the file names (absolute paths), values are the metadata as another dictionary.
+
+    The metadata fields are those defined in an RPM query.  To summarize, the fields are:
+
+    - path: file absolute path
+    - digest: hash of the file at "path".  All RPMs in this test suite use MD5 to
+              maintain compatibility.
+    - user: UNIX owning user
+    - group: UNIX owning group
+    - mode: UNIX octal mode
+    - fflags: RPM file flags (see upstream documentation for what these mean)
+    - symlink: Symlink target, or a "falsy" value if not provideds
+
+    Check out the implementation for more details, and consult the RPM
+    documentation for more details.
+
+    """
+    # It is not necessary to check for file sizes, as the hashes are
+    # sufficient for determining whether or not files are the same.
+    #
+    # This also simplifies behavior where RPM's size calculations have
+    # sometimes changed, e.g.:
+    #
+    # https://github.com/rpm-software-management/rpm/commit/2cf7096ba534b065feb038306c792784458ac9c7
+
+    rpm_queryformat = (
+        "[%{FILENAMES}"
+        ",%{FILEDIGESTS}"
+        ",%{FILEUSERNAME}"
+        ",%{FILEGROUPNAME}"
+        ",%{FILEMODES:octal}"
+        ",%{FILEFLAGS:fflags}"
+        ",%{FILELINKTOS}"
+        "\n]"
+    )
+
+    rpm_queryformat_fieldnames = [
+        "path",
+        "digest",
+        "user",
+        "group",
+        "mode",
+        "fflags",
+        "symlink",
+    ]
+
+    rpm_output = subprocess.check_output(
+        [rpm_bin_path, "-qp", "--queryformat", rpm_queryformat, rpm_path])
+
+    sio = io.StringIO(rpm_output.decode('utf-8'))
+    rpm_output_reader = csv.DictReader(
+        sio, fieldnames = rpm_queryformat_fieldnames)
+
+    return {r['path'] : r for r in rpm_output_reader}

--- a/pkg/experimental/tests/rpm/testdata
+++ b/pkg/experimental/tests/rpm/testdata
@@ -1,1 +1,0 @@
-../../../tests/testdata

--- a/pkg/experimental/tests/rpm/tree_artifacts/BUILD
+++ b/pkg/experimental/tests/rpm/tree_artifacts/BUILD
@@ -1,0 +1,192 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@rules_pkg//:mappings.bzl",
+    "pkg_filegroup",
+    "pkg_files",
+    "strip_prefix",
+)
+load("@rules_pkg//experimental:rpm.bzl", "pkg_rpm")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load(":rules.bzl", "directory")
+
+############################################################################
+# Test handling of directory outputs
+############################################################################
+
+# This package defines tests related to the installation of directory outputs
+# (TreeArtifacts) in RPM packages.  The rules in common are:
+#
+# - The order of incoming pkg_filegroups (and their contents) does not matter
+#
+# - Each file in a TreeArtifact is installed relative to its position in the
+#   TreeArtifact, which itself is relative to the desired install prefix.
+
+# The actual test.  It tests whether the contents match a particular desired
+# "manifest", most notably with regards to file structure.
+py_test(
+    name = "layer_with_files",
+    srcs = ["rpm_contents_vs_manifest_test.py"],
+    data = [":layer_with_files_test_data"],
+    main = "rpm_contents_vs_manifest_test.py",
+    tags = [
+        "no_windows",  # Windows doesn't have rpm(8) or rpmbuild(8)
+    ],
+    deps = [
+        "//experimental/tests/rpm:rpm_util",
+        "@rules_python//python/runfiles",
+    ],
+)
+
+# One cannot simply pass the output of pkg_rpm as runfiles content (#161).  This
+# seems to be the easiest way around this problem.
+sh_library(
+    name = "layer_with_files_test_data",
+    testonly = True,
+    srcs = [":test_dirs_rpm"],
+)
+
+# The RPM (target under test)
+pkg_rpm(
+    name = "test_dirs_rpm",
+    srcs = [
+        ":dirs_test_pfg",
+    ],
+    architecture = "noarch",
+    description = """pkg_rpm test rpm description""",
+    license = "Apache 2.0",
+    release = "2222",
+    spec_template = "//experimental/tests/rpm:template-test.spec.in",
+    summary = "pkg_rpm test rpm summary",
+    version = "1.1.1",
+)
+
+############################################################################
+# Test RPM Contents
+############################################################################
+
+# Establish a directory structure.  This will end up looking like:
+
+# test_dir/a        (created by a "directory" rule)
+# test_dir/b        (created by a "directory" rule)
+# test_dir/subdir/c (created by a "directory" rule)
+# test_dir/subdir/d (created by a "directory" rule)
+# test_dir/e        (created by a genrule)
+# test_dir/f        (created by a genrule)
+
+pkg_filegroup(
+    name = "dirs_test_pfg",
+    srcs = [
+        # do not sort
+        ":test_dir1_pf",
+        ":test_files_from_rules",
+    ],
+)
+
+pkg_files(
+    name = "test_dir1_pf",
+    srcs = [":test_dir1"],
+    strip_prefix = strip_prefix.from_pkg(""),
+)
+
+directory(
+    name = "test_dir1",
+    contents = "test_dir1",
+    filenames = [
+        "a",
+        "b",
+        "subdir/c",
+        "subdir/d",
+    ],
+    outdir = "test_dir",
+)
+
+pkg_files(
+    name = "test_files_from_rules",
+    srcs = [":my_files"],
+    prefix = "test_dir",
+)
+
+genrule(
+    name = "my_files",
+    outs = [
+        "e",
+        "f",
+    ],
+    cmd = "touch $(OUTS)",
+)
+
+############################################################################
+# Regression: Ensure that TreeArtifact installation WRT files is independent of install order
+############################################################################
+
+# The actual test, just like before, except the pkg_filegroup input is slightly
+# different.
+py_test(
+    name = "layer_with_files_reversed",
+    srcs = ["rpm_contents_vs_manifest_test.py"],
+    data = [":layer_with_files_reversed_test_data"],
+    env = {"TEST_RPM": "test_dirs_rpm_reversed.rpm"},
+    main = "rpm_contents_vs_manifest_test.py",
+    tags = [
+        "no_windows",  # Windows doesn't have rpm(8) or rpmbuild(8)
+    ],
+    deps = [
+        "//experimental/tests/rpm:rpm_util",
+        "@rules_python//python/runfiles",
+    ],
+)
+
+# One cannot simply pass the output of pkg_rpm as runfiles content (#161).  This
+# seems to be the easiest way around this problem.
+sh_library(
+    name = "layer_with_files_reversed_test_data",
+    testonly = True,
+    srcs = [":test_dirs_rpm_reversed"],
+)
+
+pkg_rpm(
+    name = "test_dirs_rpm_reversed",
+    srcs = [
+        ":dirs_test_pfg_reversed",
+    ],
+    architecture = "noarch",
+    description = """pkg_rpm test rpm description""",
+    license = "Apache 2.0",
+    release = "2222",
+    spec_template = "//experimental/tests/rpm:template-test.spec.in",
+    summary = "pkg_rpm test rpm summary",
+    version = "1.1.1",
+)
+
+# Like dirs_test_pfg, but the contents are reversed.  One of the major issues
+# with #292 was inconsistency due to install order.
+pkg_filegroup(
+    name = "dirs_test_pfg_reversed",
+    srcs = [
+        # do not sort
+        ":test_files_from_rules",
+        ":test_dir1_pf",
+    ],
+)
+
+############################################################################
+# Utility (used by the "directory" rule)
+############################################################################
+
+py_binary(
+    name = "create_directory_with_contents",
+    srcs = ["create_directory_with_contents.py"],
+)

--- a/pkg/experimental/tests/rpm/tree_artifacts/create_directory_with_contents.py
+++ b/pkg/experimental/tests/rpm/tree_artifacts/create_directory_with_contents.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+
+"""
+Creates a directory containing some files with determined contents
+
+Usage: ./this.py output_dir_name file1 contents1 ... fileN contentsN
+"""
+
+dirname = sys.argv[1]
+
+files_contents_map = {}
+
+# Simple way of grouping over pairs.  There other ones, like
+# https://stackoverflow.com/a/16789836, but they either requiring copying a
+# bunch of code around or having something that's a smidge unreadable.
+rest_args_iter = iter(sys.argv[2:])
+for a in rest_args_iter:
+    files_contents_map[a] = next(rest_args_iter)
+
+os.makedirs(dirname, exist_ok=True)
+
+for fname, contents in files_contents_map.items():
+    os.makedirs(
+        os.path.join(dirname, os.path.dirname(fname)),
+        exist_ok=True
+    )
+    with open(os.path.join(dirname, fname), 'w') as fh:
+        fh.write(contents)

--- a/pkg/experimental/tests/rpm/tree_artifacts/rpm_contents_vs_manifest_test.py
+++ b/pkg/experimental/tests/rpm/tree_artifacts/rpm_contents_vs_manifest_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import csv
+import io
+import os
+import rpm_util
+from rules_python.python.runfiles import runfiles
+
+EXPECTED_RPM_MANIFEST_CSV = """
+path,digest,user,group,mode,fflags,symlink
+/test_dir/a,dc35e5df50b75e25610e1aaaa29edaa4,root,root,100644,,
+/test_dir/b,dc35e5df50b75e25610e1aaaa29edaa4,root,root,100644,,
+/test_dir/subdir/c,dc35e5df50b75e25610e1aaaa29edaa4,root,root,100644,,
+/test_dir/subdir/d,dc35e5df50b75e25610e1aaaa29edaa4,root,root,100644,,
+/test_dir/e,d41d8cd98f00b204e9800998ecf8427e,root,root,100644,,
+/test_dir/f,d41d8cd98f00b204e9800998ecf8427e,root,root,100644,,
+""".strip()
+
+
+class PkgRpmCompManifest(unittest.TestCase):
+    def setUp(self):
+        self.runfiles = runfiles.Create()
+        self.maxDiff = None
+        # Allow for parameterization of this test based on the desired RPM to test.
+        self.rpm_path = self.runfiles.Rlocation(os.path.join(
+            os.environ["TEST_WORKSPACE"],
+            "experimental", "tests", "rpm", "tree_artifacts",
+            # The object behind os.environ is not a dict, and thus doesn't have
+            # the "getdefault()" we'd otherwise use here.
+            os.environ["TEST_RPM"] if "TEST_RPM" in os.environ else "test_dirs_rpm.rpm",
+        )) 
+
+    def test_contents_match(self):
+        sio = io.StringIO(EXPECTED_RPM_MANIFEST_CSV)
+        manifest_reader = csv.DictReader(sio)
+        manifest_specs = {r['path']: r for r in manifest_reader}
+
+        rpm_specs = rpm_util.read_rpm_filedata(self.rpm_path)
+
+        self.assertDictEqual(manifest_specs, rpm_specs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/experimental/tests/rpm/tree_artifacts/rules.bzl
+++ b/pkg/experimental/tests/rpm/tree_artifacts/rules.bzl
@@ -1,0 +1,56 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules to aid TreeArtifact testing"""
+
+def _directory_impl(ctx):
+    out_dir_file = ctx.actions.declare_directory(ctx.attr.outdir or ctx.attr.name)
+
+    args = ctx.actions.args()
+    args.add(out_dir_file.path)
+
+    for fn in ctx.attr.filenames:
+        args.add(fn)
+        args.add(ctx.attr.contents)
+
+    ctx.actions.run(
+        outputs = [out_dir_file],
+        inputs = [],
+        executable = ctx.executable._dir_creator,
+        arguments = [args],
+    )
+    return DefaultInfo(files = depset([out_dir_file]))
+
+directory = rule(
+    doc = """Helper rule to create simple TreeArtifact structures
+
+We would normally just use genrules for this, but their directory output
+creation capabilities are "unsound".
+    """,
+    implementation = _directory_impl,
+    attrs = {
+        "filenames": attr.string_list(
+            doc = """Paths to create in the directory.
+
+Paths containing directories will also have the intermediate directories created too.""",
+        ),
+        "contents": attr.string(),
+        "outdir": attr.string(),
+        "_dir_creator": attr.label(
+            default = ":create_directory_with_contents",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -34,12 +34,12 @@ PackageFilesInfo = provider(
     fields = {
         "attributes": """Attribute information, represented as a `dict`.
 
-        Keys are strings representing attribute identifiers, values are
-        arbitrary data structures that represent the associated data.  These are
-        most often strings, but are not explicity defined.
+Keys are strings representing attribute identifiers, values are
+arbitrary data structures that represent the associated data.  These are
+most often strings, but are not explicity defined.
 
-        For known attributes and data type expectations, see the Common
-        Attributes documentation in the `rules_pkg` reference.
+For known attributes and data type expectations, see the Common
+Attributes documentation in the `rules_pkg` reference.
         """,
 
         # This is a mapping of destinations to sources to allow for the same


### PR DESCRIPTION
`pkg_rpm` with `pkg_filegroup` never properly consumed TreeArtifacts (directory
outputs).  This is due to two factors:

- In RPM packages, adding a directory as a file results in the directory being
  owned and every file under it having consistent permissions.  In our
  experience, this has led to confusing behavior and can make RPM
  package content listings harder to understand.

- The command for copying files into place does the wrong thing when the
  target directory already exists for any reason.

This change remedies the above by enumerating TreeArtifact directory structures
during the execution phase (as they are not knowable at analysis time), and
passing the outputs to a command that creates additions to the install scripts
and `%files` manifests.  Files in TreeArtifacts are now installed and owned by
the RPM individually.  Attributes are applied identically to all files in the
TreeArtifact, and TreeArtifact processing is only performed if any are detected.

It is currently not possible to any additional processing to TreeArtifacts,
including excluding files and stripping prefixes (#269).  Until such
time, workarounds such as using `genrule`s or other custom rules should be used.

Regression tests are also provided.

Additional changes include:

- Fixed some uninclusive language.

- The "RPM contents manifest" code for the `pkg_rpm` tests has been factored
  into a library.

- `buildifier` opportunistically applied.

- Removing an unused test symlink

NOTE 1: Another possible alternative implementations involve changing the existing
`PackageFilesInfo` provider and/or creating a new one that represents
TreeArtifacts.  This was not explored, but many of the implementation details
used here can be re-purposed should that be considered.

NOTE 2: The change does not attempt to do conflict checks between TreeArtifact
installations and other TreeArtifact installations, or
files/directories/symlinks already identified at analysis time.  To reduce the
complexity of this otherwise large change, this feature currently deferred.  My
current (untested) understanding is that if this happens, duplicates in `%files`
will be detected, and cause most versions of `rpmbuild` to fail.

Fixes #292.