### PR TITLE
experimental/rpm.bzl: support filename templating; remove "outputs" rule attribute

### DIFF
--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -25,7 +25,8 @@ find_system_rpmbuild(name="rules_pkg_rpmbuild")
 ```
 """
 
-load("//:providers.bzl", "PackageFilegroupInfo")
+load("//:private/util.bzl", "setup_output_files")
+load("//:providers.bzl", "PackageArtifactInfo", "PackageFilegroupInfo", "PackageVariablesInfo")
 
 rpm_filetype = [".rpm"]
 
@@ -128,14 +129,33 @@ def _pkg_rpm_impl(ctx):
             tools += toolchain.label.default_runfiles.files.to_list()
             args.append("--rpmbuild=%s" % executable.path)
 
+    #### Calculate output file name
+    # rpm_name takes precedence over name if provided
+    if ctx.attr.package_name:
+        rpm_name = ctx.attr.package_name
+    else:
+        rpm_name = ctx.attr.name
+
+    default_file = ctx.actions.declare_file("{}.rpm".format(rpm_name))
+
+    package_file_name = ctx.attr.package_file_name
+    if not package_file_name:
+        package_file_name = "%s-%s-%s.%s.rpm" % (
+            rpm_name,
+            ctx.attr.version,
+            ctx.attr.release,
+            ctx.attr.architecture,
+        )
+
+    outputs, output_file, output_name = setup_output_files(
+        ctx,
+        package_file_name = package_file_name,
+        default_output_file = default_file,
+    )
+
     #### rpm spec "preamble"
     preamble_pieces = []
 
-    # rpm_name takes precedence over name if provided
-    if ctx.attr.rpm_name:
-        rpm_name = ctx.attr.rpm_name
-    else:
-        rpm_name = ctx.attr.name
     preamble_pieces.append("Name: " + rpm_name)
 
     # Version can be specified by a file or inlined.
@@ -289,7 +309,7 @@ def _pkg_rpm_impl(ctx):
     args.append("--spec_file=" + spec_file.path)
     files.append(spec_file)
 
-    args.append("--out_file=" + ctx.outputs.rpm.path)
+    args.append("--out_file=" + output_file.path)
 
     # Add data files.
     if ctx.file.changelog:
@@ -431,7 +451,7 @@ def _pkg_rpm_impl(ctx):
         use_default_shell_env = True,
         arguments = args,
         inputs = files,
-        outputs = [ctx.outputs.rpm],
+        outputs = [output_file],
         env = {
             "LANG": "en_US.UTF-8",
             "LC_CTYPE": "UTF-8",
@@ -441,37 +461,15 @@ def _pkg_rpm_impl(ctx):
         tools = tools,
     )
 
-    #### Output construction
-
-    # Link the RPM to the expected output name.
-    ctx.actions.symlink(
-        output = ctx.outputs.out,
-        target_file = ctx.outputs.rpm,
-    )
-
-    # Link the RPM to the RPM-recommended output name if possible.
-    if "rpm_nvra" in dir(ctx.outputs):
-        ctx.actions.symlink(
-            output = ctx.outputs.rpm_nvra,
-            target_file = ctx.outputs.rpm,
-        )
-
-# TODO(nacl): this relies on deprecated behavior (should use Providers
-# instead), it should be removed at some point.
-def _pkg_rpm_outputs(name, rpm_name, version, release):
-    actual_rpm_name = rpm_name or name
-    outputs = {
-        "out": actual_rpm_name + ".rpm",
-        "rpm": actual_rpm_name + "-%{architecture}.rpm",
-    }
-
-    # The "rpm_nvra" output follows the recommended package naming convention of
-    # Name-Version-Release.Arch.rpm
-    # See http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
-    if version and release:
-        outputs["rpm_nvra"] = actual_rpm_name + "-%{version}-%{release}.%{architecture}.rpm"
-
-    return outputs
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+        ),
+        PackageArtifactInfo(
+            label = ctx.label.name,
+            file_name = output_name,
+        ),
+    ]
 
 # Define the rule.
 pkg_rpm = rule(
@@ -485,14 +483,6 @@ pkg_rpm = rule(
 
     - Any `data` input may create the same destination, regardless of other
       attributes.
-
-    Currently, two outputs are guaranteed to be produced: "%{name}.rpm", and
-    "%{name}-%{architecture}.rpm". If the "version" and "release" arguments are
-    non-empty, a third output will be produced, following the RPM-recommended
-    N-V-R.A format (Name-Version-Release.Architecture.rpm). Note that due to
-    the fact that rule implementations cannot access the contents of files,
-    the "version_file" and "release_file" arguments will not create an output
-    using N-V-R.A format.
 
     This rule only functions on UNIXy platforms. The following tools must be
     available on your system for this to function properly:
@@ -514,16 +504,26 @@ pkg_rpm = rule(
     """,
     # @unsorted-dict-items
     attrs = {
-        "rpm_name": attr.string(
+        "package_name": attr.string(
             doc = """Optional; RPM name override.
 
             If not provided, the `name` attribute of this rule will be used
             instead.
 
-            This influences values like the spec file name, and the name of the
-            output RPM.
-
+            This influences values like the spec file name.
             """,
+        ),
+        "package_file_name": attr.string(
+            doc = """See 'Common Attributes' in the rules_pkg reference.
+
+            If this is not provided, the package file given a NVRA-style
+            (name-version-release.arch) output, which is preferred by most RPM
+            repositories.
+            """,
+        ),
+        "package_variables": attr.label(
+            doc = "See 'Common Attributes' in the rules_pkg reference",
+            providers = [PackageVariablesInfo],
         ),
         "version": attr.string(
             doc = """RPM "Version" tag.
@@ -705,8 +705,8 @@ pkg_rpm = rule(
             ```
 
             This is most useful for ensuring that required tools exist when
-            scriptlets are run, although other properties are known.  Valid keys
-            for this attribute may include, but are not limited to:
+            scriptlets are run, although there may be other valid use cases.
+            Valid keys for this attribute may include, but are not limited to:
 
             - `pre`
             - `post`
@@ -741,7 +741,7 @@ pkg_rpm = rule(
             Must be a form that `rpmbuild(8)` knows how to process, which will
             depend on the version of `rpmbuild` in use.  The value corresponds
             to the `%_binary_payload` macro and is set on the `rpmbuild(8)`
-            command line if this attribute is provided.
+            command line if provided.
 
             Some examples of valid values (which may not be supported on your
             system) can be found [here](https://git.io/JU9Wg).  On CentOS
@@ -750,9 +750,9 @@ pkg_rpm = rule(
             `/usr/lib/rpm/macros`.  Other systems have similar files and
             configurations.
 
-            If not provided, the compression mode will be computed using normal
-            RPM spec file processing.  Defaults may vary per distribution:
-            consult its documentation for more details.
+            If not provided, the compression mode will be computed by `rpmbuild`
+            itself.  Defaults may vary per distribution or build of `rpm`;
+            consult the relevant documentation for more details.
 
             WARNING: Bazel is currently not aware of action threading requirements
             for non-test actions.  Using threaded compression may result in
@@ -771,7 +771,7 @@ pkg_rpm = rule(
         ),
     },
     executable = False,
-    outputs = _pkg_rpm_outputs,
     implementation = _pkg_rpm_impl,
+    provides = [PackageArtifactInfo],
     toolchains = ["@rules_pkg//toolchains:rpmbuild_toolchain_type"],
 )

--- a/pkg/experimental/tests/rpm/analysis_tests.bzl
+++ b/pkg/experimental/tests/rpm/analysis_tests.bzl
@@ -23,6 +23,7 @@ load(
     "pkg_mkdirs",
     "pkg_mklink",
 )
+load("//:providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
 
 # Generic negative test boilerplate
 #
@@ -72,6 +73,7 @@ def _declare_pkg_rpm(name, srcs_ungrouped, tags = None, **kwargs):
         srcs = [":" + pfg_name],
         version = "1.0",
         release = "1",
+        architecture = "noarch",
         license = "N/A",
         summary = "A test",
         description = "very much a test",
@@ -91,6 +93,10 @@ def _declare_conflicts_test(name, srcs, **kwargs):
         name = name,
         target_under_test = ":" + rpm_name,
     )
+
+############################################################
+# Begin tests.  Check that the conflict detection system works.
+############################################################
 
 def _test_conflicting_inputs(name):
     # The test here is to confirm if pkg_rpm rejects conflicting inputs
@@ -183,15 +189,148 @@ def _test_conflicting_inputs(name):
         ],
     )
 
+############################################################
+# Verify that rules produce expected named outputs
+############################################################
+
+#### Setup; helpers
+
+def _package_naming_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    pai = target_under_test[PackageArtifactInfo]
+
+    pai_name = pai.file_name
+    asserts.equals(
+        env,
+        pai_name,
+        ctx.attr.expected_name,
+        "PackageArtifactInfo file name does not match expected value.",
+    )
+
+    # Try to find the expected files in the DefaultInfo.  We have to look for
+    # them; PackageArtifactInfo only gives a file name, not a File structure.
+    packaged_file = None
+    default_name_found = False
+    for f in target_under_test[DefaultInfo].files.to_list():
+        if f.basename == pai_name:
+            packaged_file = f
+        elif f.basename == ctx.attr.expected_default_name and not default_name_found:
+            default_name_found = True
+
+    asserts.true(
+        env,
+        packaged_file != None,
+        "File mentioned in PackageArtifactInfo '{}' is not in DefaultInfo".format(pai_name),
+    )
+
+    asserts.true(
+        env,
+        default_name_found,
+        "Expected package file with default name '{}' is not in DefaultInfo".format(ctx.attr.expected_default_name),
+    )
+
+    return analysistest.end(env)
+
+package_naming_test = analysistest.make(
+    _package_naming_test_impl,
+    attrs = {
+        "expected_name": attr.string(),
+        "expected_default_name": attr.string(),
+    },
+)
+
+# Dummy substitution set, used in below test cases
+def _dummy_pkg_variables_impl(ctx):
+    return [
+        PackageVariablesInfo(
+            values = {
+                "FOO": "foo",
+                "BAR": "bar",
+            },
+        ),
+    ]
+
+dummy_pkg_variables = rule(
+    implementation = _dummy_pkg_variables_impl,
+    attrs = {},
+)
+
+#### Tests start here
+
+def _test_naming(name):
+    # Test whether name templating via PackageVariablesInfo functions as expected, and ensure that
+    # outputs are passed through to PackageArtifactsInfo.
+    pkg_files(
+        name = "{}_file_base".format(name),
+        srcs = ["foo"],
+        tags = ["manual"],
+    )
+
+    _declare_pkg_rpm(
+        name = name + "_no_extra_rpm",
+        srcs_ungrouped = [":{}_file_base".format(name)],
+    )
+
+    # Default "full" name defaults to the "NVR.A" format.
+    package_naming_test(
+        name = name + "_no_extra",
+        target_under_test = ":" + name + "_no_extra_rpm",
+        expected_name = name + "_no_extra_rpm-1.0-1.noarch.rpm",
+        expected_default_name = name + "_no_extra_rpm" + ".rpm",
+    )
+
+    ##################################################
+    # With pkg_variables
+    ##################################################
+
+    dummy_pkg_variables(
+        name = name + "_pkg_variables",
+    )
+
+    _declare_pkg_rpm(
+        name = name + "_with_different_name_rpm",
+        srcs_ungrouped = [":{}_file_base".format(name)],
+        package_variables = ":{}_pkg_variables".format(name),
+        package_file_name = name + "-{FOO}-{BAR}.rpm",
+    )
+
+    # Default "full" name defaults to the "NVR.A" format.  Set it to something
+    # super arbitrary.
+    package_naming_test(
+        name = name + "_with_different_name",
+        target_under_test = ":" + name + "_with_different_name_rpm",
+        expected_name = name + "-foo-bar.rpm",
+        expected_default_name = name + "_with_different_name_rpm" + ".rpm",
+    )
+
+    ##################################################
+    # Test suite declaration
+    ##################################################
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":{}_{}".format(name, test_name)
+            for test_name in [
+                "no_extra",
+                "with_different_name",
+            ]
+        ],
+    )
+
 def analysis_tests(name, **kwargs):
     # Need to test:
     #
-    # - Mutual exclusivity of certain options (low)
+    # - Mutual exclusivity of certain options (low priority)
     #
     _test_conflicting_inputs(name = name + "_conflicting_inputs")
+    _test_naming(name = name + "_naming")
     native.test_suite(
         name = name,
         tests = [
             name + "_conflicting_inputs",
+            name + "_naming",
         ],
     )


### PR DESCRIPTION
This change modifies the `pkg_filegroup`-using `pkg_rpm` rule to use the same
naming attributes and output system as other packaging rules, specifically:

- `package_variables` corresponds to a rule providing `PackageVariablesInfo`,
   used for templating of various package attributes.

- `package_file_name` corresponds to the output filename, and uses the value
  provided to `package_variables` to construct an "expanded" output file name.

- `package_name` corresponds to the "name" of the package, as recognized by the
  package manager.  This replaces `rpm_name`.

- The expanded output file name is identified via a `PackageArtifactInfo`
  provider.  The default, unexpanded name is derived from `package_name`, or
  `name` if not provided.

If `package_file_name` is not provided, then the default name is formatted
according to the preferred RPM "NVRA" format.  File names will look like
`$name-$version-$release.$architecture.rpm`.

As a side-effect, this removes the deprecated `outputs` output from `pkg_rpm`.
This resolves #283 for this rule, but not the soon-to-be-legacy rule in
`rpm.bzl`.   If it is desired to do this, I will do so in a follow-on-change.

Since (both versions of) `pkg_rpm` are structured differently from the other
packaging rules, `setup_output_files` in `private/util.bzl` was modified to
support deriving the default output file name from a macro argument instead of
relying on `ctx.outputs.out`, as it is not present in `pkg_rpm`.  The
documentation was also updated to mention this and to improve clarity.

Documentation was also opportunistically fixed in `experimental/rpm.bzl`.

Tests are also provided.