### PR TITLE
Support long file names by ignoring 'path' PAX header. (#250)

### DIFF
--- a/pkg/archive.py
+++ b/pkg/archive.py
@@ -402,6 +402,12 @@ class TarFileWriter(object):
             tarinfo.linkname = '.' + root + link.lstrip('.')
         tarinfo.name = name
 
+        # Remove path pax header to ensure that the proposed name is going
+        # to be used. Without this, files with long names will not be
+        # properly written to its new path.
+        if 'path' in tarinfo.pax_headers:
+          del tarinfo.pax_headers['path']
+
         if tarinfo.isfile():
           # use extractfile(tarinfo) instead of tarinfo.name to preserve
           # seek position in intar

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -463,6 +463,7 @@ py_test(
         ":test-tar-strip_prefix-none.tar",
         ":test-tar-strip_prefix-substring.tar",
         ":test_tar_package_dir_substitution.tar",
+        ":test-tar-long-filename",
         ":test-tar-repackaging-long-filename.tar",
     ] + [
         ":test-tar-basic-%s" % compression

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -13,12 +13,12 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-licenses(["notice"])
-
 load("//:pkg.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_deb", "pkg_tar", "pkg_zip")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load(":my_package_name.bzl", "my_package_naming")
+
+licenses(["notice"])
 
 exports_files(glob(["testdata/**"]))
 
@@ -430,6 +430,22 @@ pkg_tar(
     portable_mtime = False,
 )
 
+pkg_tar(
+    name = "test-tar-long-filename",
+    srcs = [
+        "testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt",
+    ],
+    strip_prefix = "testdata",
+)
+
+pkg_tar(
+    name = "test-tar-repackaging-long-filename",
+    package_dir = "can_i_repackage_a_file_with_a_long_name",
+    deps = [
+        ":test-tar-long-filename",
+    ],
+)
+
 py_test(
     name = "pkg_tar_test",
     size = "medium",
@@ -447,6 +463,7 @@ py_test(
         ":test-tar-strip_prefix-none.tar",
         ":test-tar-strip_prefix-substring.tar",
         ":test_tar_package_dir_substitution.tar",
+        ":test-tar-repackaging-long-filename.tar",
     ] + [
         ":test-tar-basic-%s" % compression
         for compression in SUPPORTED_TAR_COMPRESSIONS

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -191,6 +191,13 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test_tar_package_dir_substitution.tar', content)
 
+  def test_tar_with_long_file_name(self):
+    content = [
+      {'name': '.'},
+      {'name': './file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
+    ]
+    self.assertTarFileContent('test-tar-long-filename.tar', content)
+
   def test_repackage_file_with_long_name(self):
     content = [
       {'name': '.'},

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -191,6 +191,13 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test_tar_package_dir_substitution.tar', content)
 
+  def test_repackage_file_with_long_name(self):
+    content = [
+      {'name': '.'},
+      {'name': './can_i_repackage_a_file_with_a_long_name'},
+      {'name': 'can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
+    ]
+    self.assertTarFileContent('test-tar-repackaging-long-filename.tar', content)
 
 if __name__ == '__main__':
   unittest.main()

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -195,7 +195,7 @@ class PkgTarTest(unittest.TestCase):
     content = [
       {'name': '.'},
       {'name': './can_i_repackage_a_file_with_a_long_name'},
-      {'name': 'can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
+      {'name': './can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
     ]
     self.assertTarFileContent('test-tar-repackaging-long-filename.tar', content)
 

--- a/pkg/tests/testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt
+++ b/pkg/tests/testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt
@@ -1,0 +1,1 @@
+Hello there!


### PR DESCRIPTION
The 'path' PAX header is normally used to handle long file names. When re-packaging a tar
containing a file with a long name we wouldn't touch that header and the file wouldn't
go to its new path. To fix that we simply delete the header before writing as the tarfile
library will handle writing a new one if needed.

Side note: Right now this code is not following the 4-spaces styleguide. I would've fixed
it now but then the change I'm making would be hidden in the noise.

See also #216.