### PR TITLE
Allow runfiles to be used alongside the `rpmbuild` toolchain

### DIFF
--- a/pkg/experimental/rpm.bzl
+++ b/pkg/experimental/rpm.bzl
@@ -141,10 +141,9 @@ def _pkg_rpm_impl(ctx):
         if toolchain.path:
             args.append("--rpmbuild=" + toolchain.path)
         else:
-            executable = toolchain.label.files_to_run.executable
-            tools.append(executable)
-            tools += toolchain.label.default_runfiles.files.to_list()
-            args.append("--rpmbuild=%s" % executable.path)
+            executable_files = toolchain.label[DefaultInfo].files_to_run
+            tools.append(executable_files)
+            args.append("--rpmbuild=%s" % executable_files.executable.path)
 
     #### Calculate output file name
     # rpm_name takes precedence over name if provided

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -49,10 +49,9 @@ def _pkg_rpm_impl(ctx):
         if toolchain.path:
             args += ["--rpmbuild=" + toolchain.path]
         else:
-            executable = toolchain.label.files_to_run.executable
-            tools += [executable]
-            tools += toolchain.label.default_runfiles.files.to_list()
-            args += ["--rpmbuild=%s" % executable.path]
+            executable_files = toolchain.label[DefaultInfo].files_to_run
+            tools.append(executable_files)
+            args.append("--rpmbuild=%s" % executable_files.executable.path)
 
     # Version can be specified by a file or inlined.
     if ctx.attr.version_file:


### PR DESCRIPTION
The current rpmbuild toolchain setup do not seem to propagate the runfiles
needed by `rpmbuild` when `pkg_rpm` calls `make_rpm.py`, despite it apparently
having everything it needs passed into `ctx.actions.run#tools`.

It seems as though passing in the associated `FilesToRunProvider` fixes this,
although I'm not sure why.  This change is implemented here, as well as pulling
accessing the fields of `DefaultInfo` via the provider rather than directly
through the `Target` structure (marked as [deprecated] in most recent
documentation).

Fix was implemented in both instances of `pkg_rpm`; the code is sufficiently
similar to allow for copy+paste to be used effectively.

[deprecated]: https://docs.bazel.build/versions/master/skylark/lib/Target.html

Fixes the symptoms of #328.