### PR TITLE
fix markdown formatting

### DIFF
--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -17,9 +17,9 @@ pkg_rpm() depends on the existence of an rpmbuild toolchain. Many users will
 find to convenient to use the one provided with their system. To enable that
 toolchain add the following stanza to WORKSPACE:
 
-  # Find rpmbuild if it exists.
-  load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
-  find_system_rpmbuild(name="rules_pkg_rpmbuild")
+    # Find rpmbuild if it exists.
+    load("@rules_pkg//toolchains:rpmbuild_configure.bzl", "find_system_rpmbuild")
+    find_system_rpmbuild(name="rules_pkg_rpmbuild")
 """
 
 rpm_filetype = [".rpm"]


### PR DESCRIPTION
Code blocks need to be indented four spaces