### PR TITLE
Ensure tree_artifact test RPMs have consistent permissions

### DIFF
--- a/pkg/experimental/tests/rpm/tree_artifacts/BUILD
+++ b/pkg/experimental/tests/rpm/tree_artifacts/BUILD
@@ -16,6 +16,7 @@ load("//tests/util:defs.bzl", "directory")
 load(
     "@rules_pkg//:mappings.bzl",
     "REMOVE_BASE_DIRECTORY",
+    "pkg_attributes",
     "pkg_filegroup",
     "pkg_files",
     "strip_prefix",
@@ -99,6 +100,11 @@ pkg_filegroup(
 pkg_files(
     name = "test_dir1_pf",
     srcs = [":test_dir1"],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0644",
+        user = "root",
+    ),
     strip_prefix = strip_prefix.from_pkg(""),
 )
 
@@ -117,6 +123,11 @@ directory(
 pkg_files(
     name = "test_files_from_rules",
     srcs = [":my_files"],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0644",
+        user = "root",
+    ),
     prefix = "test_dir",
 )
 
@@ -233,5 +244,10 @@ pkg_files(
     srcs = [
         ":test_dir1",
     ],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0644",
+        user = "root",
+    ),
     renames = {":test_dir1": REMOVE_BASE_DIRECTORY},
 )


### PR DESCRIPTION
The recently created tree_artifact experimental pkg_rpm tests assumed that the
default `user:group` for files in the RPM is `root:root`.  When run on macOS (I
have a local copy of `rpm`), it ended up being `root:wheel`.

Fix this by setting `attributes` in all `pkg_files`s in
`pkg/experimental/tests/rpm/tree_artifacts/BUILD`.