### PR TITLE
Stop running integration tests on ubuntu16. The platform is EOL and unsupported.

### DIFF
--- a/.bazelci/examples.yml
+++ b/.bazelci/examples.yml
@@ -7,10 +7,6 @@ tasks:
     platform: centos7
     working_directory: /workdir/examples/naming_package_files
     <<: *common
-  ubuntu1604:
-    platform: ubuntu1604
-    working_directory: /workdir/examples/naming_package_files
-    <<: *common
   ubuntu1804:
     platform: ubuntu1804
     working_directory: /workdir/examples/naming_package_files

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -5,9 +5,6 @@ common: &common
   - "distro:*"
 
 tasks:
-  ubuntu1604:
-    platform: ubuntu1604
-    <<: *common
   ubuntu1804:
     platform: ubuntu1804
     <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -15,9 +15,6 @@ tasks:
     # This includes the rpm tests, which are not (yet) supported in the below
     # cases.
     - "..."
-  ubuntu1604:
-    platform: ubuntu1604
-    <<: *common
   ubuntu1804:
     platform: ubuntu1804
     <<: *common


### PR DESCRIPTION
Remove ubuntu16 from CI.