### PR TITLE
Fix most mapping tests to work on windows.

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -40,6 +40,9 @@ tasks:
     - "//tests:is_compressed_test"
     - "//tests:pkg_deb_test"
     - "//tests:pkg_tar_test"
+    - "//tests:strip_test"
     - "//tests:test_tar_compression"
     - "//tests:zip_test"
+    - "//tests/mappings/..."
+    - "-//tests/mappings/filter_directory/..."
 

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -40,7 +40,7 @@ tasks:
     - "//tests:is_compressed_test"
     - "//tests:pkg_deb_test"
     - "//tests:pkg_tar_test"
-    - "//tests:strip_test"
+    - "//tests:stamp_test"
     - "//tests:test_tar_compression"
     - "//tests:zip_test"
     - "//tests/mappings/..."

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -46,12 +46,18 @@ def _pkg_files_contents_test_impl(ctx):
     target_under_test = analysistest.target_under_test(env)
 
     expected_dests = {e: None for e in ctx.attr.expected_dests}
+    n_found = 0
     for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
+        # skip .exe files because they are unexpected extra outputs of
+        # sh_binary on Windows.
         if got.endswith(".exe"):
             continue
         asserts.true(
             got in expected_dests,
             "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests))
+        n_found += 1
+    asserts.equals(env, len(expected_dests), n_found)
+
 
     # Simple equality checks for the others, if specified
     if ctx.attr.expected_attributes:

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -45,10 +45,13 @@ def _pkg_files_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
     target_under_test = analysistest.target_under_test(env)
 
-    expected_dests = sets.make(ctx.attr.expected_dests)
-    actual_dests = sets.make(target_under_test[PackageFilesInfo].dest_src_map.keys())
-
-    asserts.new_set_equals(env, expected_dests, actual_dests, "pkg_files dests do not match expectations")
+    expected_dests = {e: None for e in ctx.attr.expected_dests}
+    for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
+        if got.endswith(".exe"):
+            continue
+        asserts.true(
+            got in expected_dests,
+            "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests))
 
     # Simple equality checks for the others, if specified
     if ctx.attr.expected_attributes:


### PR DESCRIPTION
The problem is the sh_binary emits an extra "name.exe".
The tests were failing because the .exe was not expected.
Instead we strip it from the content matcher.
It's a hack, but that is fine for a test.

Fix CI test paths