### PR TITLE
Stop importing single methods from modules. Use the entire thing.

### DIFF
--- a/pkg/make_deb.py
+++ b/pkg/make_deb.py
@@ -31,7 +31,7 @@ else:
 
 # list of debian fields : (name, mandatory, wrap[, default])
 # see http://www.debian.org/doc/debian-policy/ch-controlfields.html
-from private.helpers import GetFlagValue
+from private import helpers
 
 DEBIAN_FIELDS = [
     ('Package', True, False),
@@ -295,7 +295,7 @@ def CreateChanges(output,
 
 def GetFlagValues(flagvalues):
   if flagvalues:
-    return [GetFlagValue(f, False) for f in flagvalues]
+    return [helpers.GetFlagValue(f, False) for f in flagvalues]
   else:
     return None
 
@@ -342,18 +342,18 @@ def main():
   CreateDeb(
       options.output,
       options.data,
-      preinst=GetFlagValue(options.preinst, False),
-      postinst=GetFlagValue(options.postinst, False),
-      prerm=GetFlagValue(options.prerm, False),
-      postrm=GetFlagValue(options.postrm, False),
-      config=GetFlagValue(options.config, False),
-      templates=GetFlagValue(options.templates, False),
-      triggers=GetFlagValue(options.triggers, False),
+      preinst=helpers.GetFlagValue(options.preinst, False),
+      postinst=helpers.GetFlagValue(options.postinst, False),
+      prerm=helpers.GetFlagValue(options.prerm, False),
+      postrm=helpers.GetFlagValue(options.postrm, False),
+      config=helpers.GetFlagValue(options.config, False),
+      templates=helpers.GetFlagValue(options.templates, False),
+      triggers=helpers.GetFlagValue(options.triggers, False),
       conffiles=GetFlagValues(options.conffile),
       package=options.package,
-      version=GetFlagValue(options.version),
-      description=GetFlagValue(options.description),
-      maintainer=GetFlagValue(options.maintainer),
+      version=helpers.GetFlagValue(options.version),
+      description=helpers.GetFlagValue(options.description),
+      maintainer=helpers.GetFlagValue(options.maintainer),
       section=options.section,
       architecture=options.architecture,
       depends=GetFlagValues(options.depends),
@@ -363,19 +363,19 @@ def main():
       recommends=options.recommends,
       replaces=options.replaces,
       provides=options.provides,
-      homepage=GetFlagValue(options.homepage),
-      builtUsing=GetFlagValue(options.built_using),
+      homepage=helpers.GetFlagValue(options.homepage),
+      builtUsing=helpers.GetFlagValue(options.built_using),
       priority=options.priority,
       conflicts=options.conflicts,
       breaks=options.breaks,
-      installedSize=GetFlagValue(options.installed_size))
+      installedSize=helpers.GetFlagValue(options.installed_size))
   CreateChanges(
       output=options.changes,
       deb_file=options.output,
       architecture=options.architecture,
-      short_description=GetFlagValue(options.description).split('\n')[0],
-      maintainer=GetFlagValue(options.maintainer), package=options.package,
-      version=GetFlagValue(options.version), section=options.section,
+      short_description=helpers.GetFlagValue(options.description).split('\n')[0],
+      maintainer=helpers.GetFlagValue(options.maintainer), package=options.package,
+      version=helpers.GetFlagValue(options.version), section=options.section,
       priority=options.priority, distribution=options.distribution,
       urgency=options.urgency)
 

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 from string import Template
 
-from rules_pkg.private.helpers import GetFlagValue
+from private import helpers
 
 
 # Setup to safely create a temporary directory and clean it up when done.
@@ -182,13 +182,13 @@ class RpmBuilder(object):
                source_date_epoch=None,
                debug=False):
     self.name = name
-    self.version = GetFlagValue(version)
-    self.release = GetFlagValue(release)
+    self.version = helpers.GetFlagValue(version)
+    self.release = helpers.GetFlagValue(release)
     self.arch = arch
     self.files = []
     self.rpmbuild_path = FindRpmbuild(rpmbuild_path)
     self.rpm_path = None
-    self.source_date_epoch = GetFlagValue(source_date_epoch)
+    self.source_date_epoch = helpers.GetFlagValue(source_date_epoch)
     self.debug = debug
 
     # The below are initialized in SetupWorkdir()

--- a/pkg/private/build_zip.py
+++ b/pkg/private/build_zip.py
@@ -17,7 +17,7 @@ import argparse
 import datetime
 import zipfile
 
-from rules_pkg.private.helpers import SplitNameValuePairAtSeparator
+from rules_pkg.private import helpers
 
 ZIP_EPOCH = 315532800
 
@@ -73,7 +73,7 @@ def main(args):
 
   with zipfile.ZipFile(args.output, 'w') as zip_file:
     for f in args.files or []:
-      (src_path, dst_path) = SplitNameValuePairAtSeparator(f, '=')
+      (src_path, dst_path) = helpers.SplitNameValuePairAtSeparator(f, '=')
 
       dst_path = _combine_paths(args.directory, dst_path)
 


### PR DESCRIPTION
That is
```
from private.helpers import Foo
...
x = Foo()
```
becomes
```
from private import helpers
...
x = helpers.Foo()
```

This is for consistency of usage and it makes it easier to write [copybara](https://github.com/google/copybara) scripts to import the code.