### PR TITLE
Add a rule to make artifacts that mimic binaries

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -32,7 +32,6 @@ tasks:
     - "-//distro/..."
     - "-//legacy/tests/rpm/..."
     - "-//tests:make_rpm_test"
-    - "-//tests:package_naming_aggregate_test"
     - "-//tests:path_test"
     - "-//tests/mappings/filter_directory/..."
     - "-//tests/rpm/..."

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -32,6 +32,7 @@ tasks:
     - "-//distro/..."
     - "-//legacy/tests/rpm/..."
     - "-//tests:make_rpm_test"
+    - "-//tests:package_naming_aggregate_test"
     - "-//tests:path_test"
     - "-//tests/mappings/filter_directory/..."
     - "-//tests/rpm/..."

--- a/pkg/tests/mappings/external_repo/pkg/BUILD
+++ b/pkg/tests/mappings/external_repo/pkg/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@//tests/util:defs.bzl", "fake_artifact")
 load("test.bzl", "test_referencing_remote_file")
 
 package(default_visibility = ["//visibility:public"])
@@ -21,9 +22,9 @@ exports_files(
     glob(["**"]),
 )
 
-sh_binary(
+fake_artifact(
     name = "dir/script",
-    srcs = ["dir/extproj.sh"],
+    files = ["dir/extproj.sh"],
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -53,10 +53,6 @@ def _pkg_files_contents_test_impl(ctx):
     expected_dests = {e: None for e in ctx.attr.expected_dests}
     n_found = 0
     for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
-        # skip .exe files because they are unexpected extra outputs of
-        # sh_binary on Windows.
-        if got.endswith(".exe"):
-            continue
         asserts.true(
             got in expected_dests,
             "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests))
@@ -133,7 +129,7 @@ def _test_pkg_files_contents():
     # Used in the following tests
     fake_artifact(
         name = "testdata/test_script",
-        runfiles = ["testdata/a_script.sh"],
+        files = ["testdata/a_script.sh"],
         tags = ["manual"],
     )
 
@@ -448,7 +444,7 @@ def _test_pkg_files_rename():
     # Used in the following tests
     fake_artifact(
         name = "test_script_rename",
-        runfiles = ["testdata/a_script.sh"],
+        files = ["testdata/a_script.sh"],
         tags = ["manual"],
     )
 

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -27,7 +27,12 @@ load(
     "strip_prefix",
     "REMOVE_BASE_DIRECTORY",
 )
-load("//tests/util:defs.bzl", "directory", "generic_base_case_test", "generic_negative_test")
+load("//tests/util:defs.bzl",
+     "directory",
+     "fake_artifact",
+     "generic_base_case_test",
+     "generic_negative_test"
+)
 
 ##########
 # Helpers
@@ -126,12 +131,9 @@ def _test_pkg_files_contents():
     )
 
     # Used in the following tests
-    #
-    # Note that since the pkg_files rule is never actually used in anything
-    # other than this test, nonexistent_script can be included with no ill effects. :P
-    native.sh_binary(
+    fake_artifact(
         name = "testdata/test_script",
-        srcs = ["testdata/nonexistent_script.sh"],
+        runfiles = ["testdata/a_script.sh"],
         tags = ["manual"],
     )
 
@@ -153,7 +155,7 @@ def _test_pkg_files_contents():
             # Static file
             "hello.txt",
             # The script itself
-            "nonexistent_script.sh",
+            "a_script.sh",
             # The generated target output, in this case, a symlink
             "test_script",
         ],
@@ -177,7 +179,7 @@ def _test_pkg_files_contents():
         target_under_test = ":pf_from_root_g",
         expected_dests = [
             # The script itself
-            "testdata/nonexistent_script.sh",
+            "testdata/a_script.sh",
             # The generated target output, in this case, a symlink
             "testdata/test_script",
         ],
@@ -444,13 +446,9 @@ def _test_pkg_files_rename():
     )
 
     # Used in the following tests
-    #
-    # Note that since the pkg_files rule is never actually used in anything
-    # other than this test, nonexistent_script can be included with no ill
-    # effects. :P
-    native.sh_binary(
+    fake_artifact(
         name = "test_script_rename",
-        srcs = ["testdata/nonexistent_script.sh"],
+        runfiles = ["testdata/a_script.sh"],
         tags = ["manual"],
     )
 
@@ -461,7 +459,7 @@ def _test_pkg_files_rename():
         name = "pf_rename_rule_with_multiple_outputs_g",
         srcs = ["test_script_rename"],
         renames = {
-            ":test_script_rename": "still_nonexistent_script",
+            ":test_script_rename": "still_a_script",
         },
         tags = ["manual"],
     )
@@ -477,7 +475,7 @@ def _test_pkg_files_rename():
         srcs = ["testdata/hello.txt"],
         prefix = "usr",
         renames = {
-            "nonexistent_script": "nonexistent_output_location",
+            "a_script": "an_output_location",
         },
         tags = ["manual"],
     )

--- a/pkg/tests/mappings/testdata
+++ b/pkg/tests/mappings/testdata
@@ -1,1 +1,0 @@
-../testdata

--- a/pkg/tests/mappings/testdata/a_script.sh
+++ b/pkg/tests/mappings/testdata/a_script.sh
@@ -1,0 +1,1 @@
+echo a_script

--- a/pkg/tests/mappings/testdata/config
+++ b/pkg/tests/mappings/testdata/config
@@ -1,0 +1,1 @@
+# test config file

--- a/pkg/tests/mappings/testdata/hello.txt
+++ b/pkg/tests/mappings/testdata/hello.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/pkg/tests/util/defs.bzl
+++ b/pkg/tests/util/defs.bzl
@@ -67,7 +67,8 @@ def _fake_artifact_impl(ctx):
         is_executable = ctx.attr.executable,
     )
     return DefaultInfo(
-        files = depset([out_file]+ctx.files.runfiles),
+        files = depset([out_file] + ctx.files.files),
+        runfiles = ctx.runfiles(files = ctx.files.runfiles),
         executable = out_file if ctx.attr.executable else None,
     )
 
@@ -75,14 +76,17 @@ fake_artifact = rule(
     doc = """Rule to create a fake artifact that depends on its srcs.
 
 This rule creates a file that appears to depend on its srcs and passes along
-some runfiles. It creates a script that echos all the file names. It is useful
-for building an object that is like a cc_binary in complexity, but does not
-depend on a large toolchain.
-    """,
+other targets in DefaultInfo as files and/or runfiles. It creates a script that
+echos all the file names. It is useful for building an object that is like a
+cc_binary in complexity, but does not depend on a large toolchain.""",
     implementation = _fake_artifact_impl,
     attrs = {
         "deps": attr.label_list(
             doc = "Dependencies to trigger other rules, but are then discarded.",
+            allow_files = True,
+        ),
+        "files": attr.label_list(
+            doc = "Deps which are passed in DefaultInfo as files.",
             allow_files = True,
         ),
         "runfiles": attr.label_list(


### PR DESCRIPTION
`fake_artifact` is a new rule in the test infrastructure.  It creates an output with the ability to set it as executable, and to specify runfiles. It is designed only to be able to mimic complex objects like a cc_binary, without having to depend on the cc_toolchain.

In this specific PR, it is used to replace a sh_binary that was not really a runnable binary. It just looked enough like a binary so we could build a tests with it as data. Using a `fake_artifact` makes it more obvious that the target has no behavior itself.