### PR TITLE
Initial support for pkg_* rules as srcs of pkg_tar

### DIFF
--- a/pkg/distro/BUILD
+++ b/pkg/distro/BUILD
@@ -98,13 +98,14 @@ genrule(
 bzl_library(
     name = "rules_pkg_lib",
     srcs = [
-        "//private:util.bzl",
         "//:package_variables.bzl",
         "//:path.bzl",
         "//:pkg.bzl",
         "//:providers.bzl",
         "//:rpm.bzl",
         "//:version.bzl",
+        "//private:pkg_files.bzl",
+        "//private:util.bzl",
     ],
     visibility = ["//visibility:private"],
 )

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -160,7 +160,7 @@ def _pkg_tar_impl(ctx):
     # Add runfiles if requested
     runfiles_depsets = []
     if ctx.attr.include_runfiles:
-        # TODO(aiuto): Rethink this w.r.t. binaries in pkg_files() rules.
+        # TODO(#339): Rethink this w.r.t. binaries in pkg_files() rules.
         for f in ctx.attr.srcs:
             default_runfiles = f[DefaultInfo].default_runfiles
             if default_runfiles != None:

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -151,12 +151,11 @@ def _pkg_tar_impl(ctx):
                     # I am fine with that if it makes the code more readable.
                     dest = _remap(remap_paths, d_path)
                     add_single_file(content_map, dest, f, src.label)
-    """
-    TODO(aiuto): I want the code to look like this, but we don't have lambdas.
-    transform_path = lambda f: _remap(
-        remap_paths, dest_path(f, data_path, data_path_without_prefix))
-    add_label_list(ctx, content_map, file_deps, ctx.attr.srcs, transform_path)
-    """
+
+    # TODO(aiuto): I want the code to look like this, but we don't have lambdas.
+    # transform_path = lambda f: _remap(
+    #    remap_paths, dest_path(f, data_path, data_path_without_prefix))
+    # add_label_list(ctx, content_map, file_deps, ctx.attr.srcs, transform_path)
 
     # Add runfiles if requested
     runfiles_depsets = []

--- a/pkg/private/build_tar.py
+++ b/pkg/private/build_tar.py
@@ -23,6 +23,11 @@ import archive
 import helpers
 import build_info
 
+# These must be kept in sync with the vlues from private/pkg_files.bzl
+ENTRY_IS_FILE = 0  # Entry is a file -> take content from <src>
+ENTRY_IS_DIR = 1  # Entry is an emptry dir
+ENTRY_IS_TREE = 2  # Entry is a tree artifact -> take tree from <src>
+
 
 class TarFile(object):
   """A class to generates a TAR file."""
@@ -255,7 +260,7 @@ class TarFile(object):
             gname=names[1])
 
   def add_manifest_entry(self, entry, file_attributes):
-    dest, src, mode, user, group, link, is_dir = entry
+    dest, src, mode, user, group, link, entry_type = entry
 
     # Use the pkg_tar mode/owner remaping as a fallback
     non_abs_path = dest.strip('/')
@@ -274,9 +279,9 @@ class TarFile(object):
         attrs['names'] = (user, attrs.get('names')[1])
     if link:
       self.add_link(dest, link)
-    elif is_dir == 1:
+    elif entry_type == ENTRY_IS_DIR:
       self.add_empty_dir(dest, **attrs)
-    elif is_dir == 2:
+    elif entry_type == ENTRY_IS_TREE:
       self.add_tree(src, dest, **attrs)
     else:
       self.add_file(src, dest, **attrs)

--- a/pkg/private/build_tar.py
+++ b/pkg/private/build_tar.py
@@ -301,7 +301,7 @@ def main():
   parser.add_argument('--manifest',
                       help='manifest of contents to add to the layer.')
   parser.add_argument('--legacy_manifest',
-                      help='JSON manifest of contents to add to the layer.')
+                      help='DEPRECATED: JSON manifest of contents to add to the layer.')
   parser.add_argument('--mode',
                       help='Force the mode on the added files (in octal).')
   parser.add_argument(
@@ -419,6 +419,7 @@ def main():
           'names': names_map.get(filename, default_ownername),
       }
 
+    # TODO(aiuto): Make sure this is unused and remove the code.
     if options.legacy_manifest:
       with open(options.legacy_manifest, 'r') as manifest_fp:
         manifest = json.load(manifest_fp)

--- a/pkg/private/build_tar.py
+++ b/pkg/private/build_tar.py
@@ -23,10 +23,10 @@ import archive
 import helpers
 import build_info
 
-# These must be kept in sync with the vlues from private/pkg_files.bzl
+# These must be kept in sync with the values from private/pkg_files.bzl
 ENTRY_IS_FILE = 0  # Entry is a file: take content from <src>
 ENTRY_IS_LINK = 1  # Entry is a symlink: dest -> <src>
-ENTRY_IS_DIR = 2  # Entry is an emptry dir
+ENTRY_IS_DIR = 2  # Entry is an empty dir
 ENTRY_IS_TREE = 3  # Entry is a tree artifact: take tree from <src>
 
 
@@ -63,7 +63,7 @@ class TarFile(object):
     Args:
        f: the file to add to the layer
        destfile: the name of the file in the layer
-       mode: force to set the specified mode, by default the value from the
+       mode: (int) force to set the specified mode, by default the value from the
          source is taken.
        ids: (uid, gid) for the file to set ownership
        names: (username, groupname) for the file to set ownership. `f` will be
@@ -209,8 +209,8 @@ class TarFile(object):
     Args:
        tree_top: the top of the tree to add
        destpath: the path under which to place the files
-       mode: (int) force to set the specified posix mode. The default is
-         derived from the source . Tip: Standard posix octal notation.
+       mode: (int) force to set the specified posix mode (e.g. 0o755). The
+         default is derived from the source
        ids: (uid, gid) for the file to set ownership
        names: (username, groupname) for the file to set ownership. `f` will be
          copied to `self.directory/destfile` in the layer.

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -41,6 +41,11 @@ load(
     "PackageSymlinkInfo",
 )
 
+# Possible values for entry_type
+ENTRY_IS_FILE = 0  # Entry is a file -> take content from <src>
+ENTRY_IS_DIR = 1  # Entry is an emptry dir
+ENTRY_IS_TREE = 2  # Entry is a tree artifact -> take tree from <src>
+
 _DestFile = provider(
     doc = """Information about each destination in the final package.""",
     fields = {
@@ -49,8 +54,7 @@ _DestFile = provider(
         "user": "user, or empty",
         "group": "group, or empty",
         "link_to": "path to link to. src must not be set",
-        "is_dir": "int. if 1, create empty dir at dest. If 2 src" +
-                  " is a the top of a tree artifact to place at dest",
+        "entry_type": "int. See ENTRY_IS_* values above.",
         "origin": "target which added this",
     },
 )
@@ -78,7 +82,7 @@ def _process_pkg_dirs(content_map, pkg_dirs_info, origin, default_mode, default_
         _check_dest(content_map, dest, origin)
         content_map[dest] = _DestFile(
             src = None,
-            is_dir = 1,
+            entry_type = ENTRY_IS_DIR,
             mode = attrs[0],
             user = attrs[1],
             group = attrs[2],
@@ -186,7 +190,7 @@ def add_directory(content_map, dir_path, origin, mode=None, user=None, group=Non
     """
     content_map[dir_path.strip('/')] = _DestFile(
         src = None,
-        is_dir = 1,
+        entry_type = ENTRY_IS_DIR,
         origin = origin,
         mode = mode,
         user = user,
@@ -270,7 +274,7 @@ def add_tree_artifact(content_map, dest_path, src, origin, mode=None, user=None,
     content_map[dest_path] = _DestFile(
         src = src,
         origin = origin,
-        is_dir = 2,
+        entry_type = ENTRY_IS_TREE,
         mode = mode,
         user = user,
         group = group,
@@ -301,5 +305,5 @@ def _encode_manifest_entry(dest, df):
         df.user or None,
         df.group or None,
         df.link_to if hasattr(df, "link_to") else "",
-        df.is_dir if hasattr(df, "is_dir") else 0,
+        df.entry_type if hasattr(df, "entry_type") else 0,
         ])

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -11,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Internal methods for processing pkg_file* instances.
+"""Internal functions for processing pkg_file* instances.
 
 Concepts and terms:
 
   DestFile: A provider holding the source path, attributes and other
             information about a file that should appear in the package.
             When attributes are empty in DestFile, we let the package
-            tool decided their values.
+            tool decide their values.
 
   content map: The map of destination paths to DestFile instances. Note that
                several distinct destinations make share the same source path.
@@ -261,7 +261,7 @@ def add_single_file(content_map, dest_path, src, origin, mode=None, user=None, g
     )
 
 def add_tree_artifact(content_map, dest_path, src, origin, mode=None, user=None, group=None):
-    """Add an single file to the content map.
+    """Add an tree artifact (directory output) to the content map.
 
     Args:
       content_map: The content map

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -42,9 +42,10 @@ load(
 )
 
 # Possible values for entry_type
+# These must be kept in sync with the declarations in private/build_*.py
 ENTRY_IS_FILE = 0  # Entry is a file: take content from <src>
 ENTRY_IS_LINK = 1  # Entry is a symlink: dest -> <src>
-ENTRY_IS_DIR = 2  # Entry is an emptry dir
+ENTRY_IS_DIR = 2  # Entry is an empty dir
 ENTRY_IS_TREE = 3  # Entry is a tree artifact: take tree from <src>
 
 _DestFile = provider(

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -1,0 +1,305 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Internal methods for processing pkg_file* instances.
+
+Concepts and terms:
+
+  DestFile: A provider holding the source path, attributes and other
+            information about a file that should appear in the package.
+            When attributes are empty in DestFile, we let the package
+            tool decided their values.
+
+  content map: The map of destination paths to DestFile instances. Note that
+               several distinct destinations make share the same source path.
+               Attempting to insert a duplicate entry in the content map is
+               an error, because it means you are collapsing files together.
+               We may want to relax this in the future if their DestFiles
+               are equal.
+
+  manifest: The file which represents the content map. This is generated
+            by rule implementations and passed to the build_*.py helpers.
+"""
+
+load("//:path.bzl", "compute_data_path", "dest_path")
+load(
+    "//:providers.bzl",
+    "PackageArtifactInfo",
+    "PackageDirsInfo",
+    "PackageFilegroupInfo",
+    "PackageFilesInfo",
+    "PackageSymlinkInfo",
+)
+
+_DestFile = provider(
+    doc = """Information about each destination in the final package.""",
+    fields = {
+        "src": "source file",
+        "mode": "mode, or empty",
+        "user": "user, or empty",
+        "group": "group, or empty",
+        "link_to": "path to link to. src must not be set",
+        "is_dir": "int. if 1, create empty dir at dest. If 2 src" +
+                  " is a the top of a tree artifact to place at dest",
+        "origin": "target which added this",
+    },
+)
+
+def _check_dest(content_map, dest, origin):
+    if dest in content_map:
+        fail("Duplicate output path: <%s>, declared in %s and %s" % (
+            dest,
+            origin,
+            content_map[dest].origin,
+        ))
+
+def _merge_attributes(info, mode, user, group):
+    if hasattr(info, "attributes"):
+        attrs = info.attributes
+        mode = attrs.get("mode") or mode
+        user = attrs.get("user") or user
+        group = attrs.get("group") or group
+    return (mode, user, group)
+
+def _process_pkg_dirs(content_map, pkg_dirs_info, origin, default_mode, default_user, default_group):
+    attrs = _merge_attributes(pkg_dirs_info, default_mode, default_user, default_group)
+    for dir in pkg_dirs_info.dirs:
+        dest = dir.strip('/')
+        _check_dest(content_map, dest, origin)
+        content_map[dest] = _DestFile(
+            src = None,
+            is_dir = 1,
+            mode = attrs[0],
+            user = attrs[1],
+            group = attrs[2],
+            origin = origin,
+        )
+
+def _process_pkg_files(content_map, pkg_files_info, origin, default_mode, default_user, default_group):
+    attrs = _merge_attributes(pkg_files_info, default_mode, default_user, default_group)
+    for filename, src in pkg_files_info.dest_src_map.items():
+        dest = filename.strip('/')
+        _check_dest(content_map, dest, origin)
+        content_map[dest] = _DestFile(
+            src = src,
+            mode = attrs[0],
+            user = attrs[1],
+            group = attrs[2],
+            origin = origin,
+        )
+
+def _process_pkg_symlink(content_map, pkg_symlink_info, origin, default_mode, default_user, default_group):
+    dest = pkg_symlink_info.destination.strip('/')
+    attrs = _merge_attributes(pkg_symlink_info, default_mode, default_user, default_group)
+    _check_dest(content_map, dest, origin)
+    content_map[dest] = _DestFile(
+        src = None,
+        mode = attrs[0],
+        user = attrs[1],
+        group = attrs[2],
+        origin = origin,
+        link_to = pkg_symlink_info.source,
+    )
+
+def _process_pkg_filegroup(content_map, pkg_filegroup_info, origin, default_mode, default_user, default_group):
+    for d in pkg_filegroup_info.pkg_dirs:
+        _process_pkg_dirs(content_map, d[0], d[1], default_mode, default_user, default_group)
+    for pf in pkg_filegroup_info.pkg_files:
+        _process_pkg_files(content_map, pf[0], pf[1], default_mode, default_user, default_group)
+    for psl in pkg_filegroup_info.pkg_symlinks:
+        _process_pkg_symlink(content_map, psl[0], psl[1], default_mode, default_user, default_group)
+
+def process_src(content_map, src, origin, default_mode, default_user, default_group):
+    """Add an entry to the content map.
+
+    Args:
+      content_map: The content map
+      src: Source Package*Info object
+      origin: The rule instance adding this entry
+      default_mode: fallback mode to use for Package*Info elements without mode
+      default_user: fallback user to use for Package*Info elements without user
+      default_group: fallback mode to use for Package*Info elements without group
+
+    Returns:
+      True if src was a Package*Info and added to content_map.
+    """
+    if PackageFilesInfo in src:
+        _process_pkg_files(
+            content_map,
+            src[PackageFilesInfo],
+            origin,
+            default_mode,
+            default_user,
+            default_group,
+        )
+    elif PackageFilegroupInfo in src:
+        _process_pkg_filegroup(
+            content_map,
+            src[PackageFilegroupInfo],
+            origin,
+            default_mode,
+            default_user,
+            default_group,
+        )
+    elif PackageSymlinkInfo in src:
+        _process_pkg_symlink(
+            content_map,
+            src[PackageSymlinkInfo],
+            origin,
+            default_mode,
+            default_user,
+            default_group,
+        )
+    elif PackageDirsInfo in src:
+        _process_pkg_dirs(
+            content_map,
+            src[PackageDirsInfo],
+            origin,
+            "0555",
+            default_user,
+            default_group,
+        )
+    else:
+        return False
+    return True
+
+def add_directory(content_map, dir_path, origin, mode=None, user=None, group=None):
+    """Add an single file to the content map.
+
+    Args:
+      content_map: The content map
+      dir_path: Where to place the file in the package.
+      origin: The rule instance adding this entry
+      mode: fallback mode to use for Package*Info elements without mode
+      user: fallback user to use for Package*Info elements without user
+      group: fallback mode to use for Package*Info elements without group
+    """
+    content_map[dir_path.strip('/')] = _DestFile(
+        src = None,
+        is_dir = 1,
+        origin = origin,
+        mode = mode,
+        user = user,
+        group = group,
+    )
+
+def add_label_list(ctx, content_map, file_deps, srcs):
+    """Helper method to add a list of labels (typically 'srcs') to a content_map.
+
+    Args:
+      ctx: rule context.
+      content_map: (r/w) The content map to update.
+      file_deps: (r/w) The list of File objects srcs depend on.
+      srcs: List of source objects.
+    """
+    # Compute the relative path
+    data_path = compute_data_path(
+        ctx,
+        ctx.attr.strip_prefix if hasattr(ctx.attr, "strip_prefix") else "")
+    data_path_without_prefix = compute_data_path(ctx, ".")
+
+    for src in srcs:
+        # Gather the files for every srcs entry here, even if it is not from
+        # a pkg_* rule.
+        if DefaultInfo in src:
+            file_deps.append(src[DefaultInfo].files)
+        if not process_src(
+            content_map,
+            src,
+            src.label,
+            default_mode = None,
+            default_user = None,
+            default_group = None,
+        ):
+            # Add in the files of srcs which are not pkg_* types
+            for f in src.files.to_list():
+                d_path = dest_path(f, data_path, data_path_without_prefix)
+                if f.is_directory:
+                    # Tree artifacts need a name, but the name is never really
+                    # the important part. The likely behavior people want is
+                    # just the content, so we strip the directory name.
+                    dest = '/'.join(d_path.split('/')[0:-1])
+                    add_tree_artifact(content_map, dest, f, src.label)
+                else:
+                    add_single_file(content_map, d_path, f, src.label)
+
+def add_single_file(content_map, dest_path, src, origin, mode=None, user=None, group=None):
+    """Add an single file to the content map.
+
+    Args:
+      content_map: The content map
+      dest_path: Where to place the file in the package.
+      src: Source object. Must have len(src[DefaultInfo].files) == 1
+      origin: The rule instance adding this entry
+      mode: fallback mode to use for Package*Info elements without mode
+      user: fallback user to use for Package*Info elements without user
+      group: fallback mode to use for Package*Info elements without group
+    """
+    dest = dest_path.strip('/')
+    _check_dest(content_map, dest, origin)
+    content_map[dest] = _DestFile(
+        src = src,
+        origin = origin,
+        mode = mode,
+        user = user,
+        group = group,
+    )
+
+def add_tree_artifact(content_map, dest_path, src, origin, mode=None, user=None, group=None):
+    """Add an single file to the content map.
+
+    Args:
+      content_map: The content map
+      dest_path: Where to place the file in the package.
+      src: Source object. Must have len(src[DefaultInfo].files) == 1
+      origin: The rule instance adding this entry
+      mode: fallback mode to use for Package*Info elements without mode
+      user: fallback user to use for Package*Info elements without user
+      group: fallback mode to use for Package*Info elements without group
+    """
+    content_map[dest_path] = _DestFile(
+        src = src,
+        origin = origin,
+        is_dir = 2,
+        mode = mode,
+        user = user,
+        group = group,
+    )
+
+def write_manifest(ctx, manifest_file, content_map):
+    """Write a content map to a manifest file.
+
+    The format of this file is currently undocumented, as it is a private
+    contract between the rule implementation and the package writers.  It will
+    become a published interface in a future release.
+
+    For reproducibility, the manifest file must be ordered consistently.
+    """
+    ctx.actions.write(
+        manifest_file,
+        "[\n" + ",\n".join(
+            [_encode_manifest_entry(dst, content_map[dst])
+             for dst in sorted(content_map.keys())]
+            ) + "\n]\n"
+    )
+
+def _encode_manifest_entry(dest, df):
+    return json.encode([
+        dest.strip('/'),
+        df.src.path if df.src else None,
+        df.mode or "",
+        df.user or None,
+        df.group or None,
+        df.link_to if hasattr(df, "link_to") else "",
+        df.is_dir if hasattr(df, "is_dir") else 0,
+        ])

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -138,6 +138,7 @@ def process_src(content_map, src, origin, default_mode, default_user, default_gr
     Returns:
       True if src was a Package*Info and added to content_map.
     """
+    found_info = False
     if PackageFilesInfo in src:
         _process_pkg_files(
             content_map,
@@ -147,7 +148,8 @@ def process_src(content_map, src, origin, default_mode, default_user, default_gr
             default_user,
             default_group,
         )
-    elif PackageFilegroupInfo in src:
+        found_info = True
+    if PackageFilegroupInfo in src:
         _process_pkg_filegroup(
             content_map,
             src[PackageFilegroupInfo],
@@ -156,7 +158,8 @@ def process_src(content_map, src, origin, default_mode, default_user, default_gr
             default_user,
             default_group,
         )
-    elif PackageSymlinkInfo in src:
+        found_info = True
+    if PackageSymlinkInfo in src:
         _process_pkg_symlink(
             content_map,
             src[PackageSymlinkInfo],
@@ -165,7 +168,8 @@ def process_src(content_map, src, origin, default_mode, default_user, default_gr
             default_user,
             default_group,
         )
-    elif PackageDirsInfo in src:
+        found_info = True
+    if PackageDirsInfo in src:
         _process_pkg_dirs(
             content_map,
             src[PackageDirsInfo],
@@ -174,9 +178,8 @@ def process_src(content_map, src, origin, default_mode, default_user, default_gr
             default_user,
             default_group,
         )
-    else:
-        return False
-    return True
+        found_info = True
+    return found_info
 
 def add_directory(content_map, dir_path, origin, mode=None, user=None, group=None):
     """Add an single file to the content map.

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -14,6 +14,7 @@
 # -*- coding: utf-8 -*-
 
 load("//:pkg.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_deb", "pkg_tar", "pkg_zip")
+load("//tests/util:defs.bzl", "directory")
 load("@rules_python//python:defs.bzl", "py_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load(":my_package_name.bzl", "my_package_naming")
@@ -86,6 +87,19 @@ genrule(
         "usr/titi",
     ],
     cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+)
+
+directory(
+    name = "generate_tree",
+    filenames = [
+        # buildifier: don't sort
+        "b/e",
+        "a/a",
+        "b/c/d",
+        "b/d",
+        "a/b/c",
+    ],
+    contents = "hello there",
 )
 
 copy_file(
@@ -466,6 +480,14 @@ pkg_tar(
     ],
 )
 
+pkg_tar(
+    name = "test-tar-tree-artifact",
+    package_dir = "a_tree",
+    srcs = [
+        ":generate_tree"
+    ],
+)
+
 py_test(
     name = "pkg_tar_test",
     size = "medium",
@@ -485,6 +507,7 @@ py_test(
         ":test_tar_package_dir_substitution.tar",
         ":test-tar-long-filename",
         ":test-tar-repackaging-long-filename.tar",
+        ":test-tar-tree-artifact",
     ] + [
         ":test-tar-basic-%s" % compression
         for compression in SUPPORTED_TAR_COMPRESSIONS

--- a/pkg/tests/mappings/BUILD
+++ b/pkg/tests/mappings/BUILD
@@ -13,7 +13,74 @@
 # limitations under the License.
 
 load(":mappings_test.bzl", "mappings_analysis_tests", "mappings_unit_tests")
+load(
+    "//:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_files",
+    "pkg_mkdirs",
+    "pkg_mklink",
+    "strip_prefix",
+)
+load("//tests/util:defs.bzl", "write_content_manifest")
+load("@rules_python//python:defs.bzl", "py_test")
 
 mappings_analysis_tests()
 
 mappings_unit_tests()
+
+pkg_mkdirs(
+    name = "dirs",
+    attributes = pkg_attributes(
+        group = "bar",
+        mode = "711",
+        user = "foo",
+    ),
+    dirs = [
+        "foodir",
+    ],
+)
+
+pkg_files(
+    name = "files",
+    srcs = [
+        "mappings_test.bzl",
+    ],
+)
+
+write_content_manifest(
+    name = "all",
+    srcs = [
+        "BUILD",
+        ":dirs",
+        ":files",
+    ],
+)
+
+# TODO(aiuto): This rule and the small srcs should be generated from just the
+# pair of write_content_manifest name and the golden file name.
+# We could even inline the golden data into a string which gets parsed as
+# json and written out.
+py_test(
+    name = "all_test",
+    srcs = [
+        "all_test.py",
+    ],
+    data = [
+        "all.manifest.golden",
+        ":all.manifest",
+    ],
+    python_version = "PY3",
+    deps = [
+        ":manifest_test_lib",
+    ],
+)
+
+py_library(
+    name = "manifest_test_lib",
+    srcs = ["manifest_test_lib.py"],
+    srcs_version = "PY3",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+    ],
+)

--- a/pkg/tests/mappings/all.manifest.golden
+++ b/pkg/tests/mappings/all.manifest.golden
@@ -1,5 +1,5 @@
 [
-["BUILD","tests/mappings/BUILD","",null,null,"",0],
-["foodir",null,"711","foo","bar","",1],
-["mappings_test.bzl","tests/mappings/mappings_test.bzl","0644",null,null,"",0]
+[0, "BUILD","tests/mappings/BUILD","",null,null],
+[2, "foodir",null,"711","foo","bar"],
+[0, "mappings_test.bzl","tests/mappings/mappings_test.bzl","0644",null,null]
 ]

--- a/pkg/tests/mappings/all.manifest.golden
+++ b/pkg/tests/mappings/all.manifest.golden
@@ -1,0 +1,5 @@
+[
+["BUILD","tests/mappings/BUILD","",null,null,"",0],
+["foodir",null,"711","foo","bar","",1],
+["mappings_test.bzl","tests/mappings/mappings_test.bzl","0644",null,null,"",0]
+]

--- a/pkg/tests/mappings/all_test.py
+++ b/pkg/tests/mappings/all_test.py
@@ -1,0 +1,29 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for generated content manifest."""
+
+# TODO(aiuto): Generate this file.
+
+import unittest
+
+import manifest_test_lib
+
+class MyTest(manifest_test_lib.ContentManifestTest):
+
+  def test_match(self):
+    self.assertManifestsMatch('all.manifest.golden', 'all.manifest')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/pkg/tests/mappings/all_test.py
+++ b/pkg/tests/mappings/all_test.py
@@ -19,7 +19,7 @@ import unittest
 
 import manifest_test_lib
 
-class MyTest(manifest_test_lib.ContentManifestTest):
+class ManifestAllTest(manifest_test_lib.ContentManifestTest):
 
   def test_match(self):
     self.assertManifestsMatch('all.manifest.golden', 'all.manifest')

--- a/pkg/tests/mappings/manifest_test_lib.py
+++ b/pkg/tests/mappings/manifest_test_lib.py
@@ -1,0 +1,37 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compare to content manifest files."""
+
+import json
+import unittest
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+class ContentManifestTest(unittest.TestCase):
+  """Test harness to see if we wrote the content manifest correctly."""
+
+  def assertManifestsMatch(self, expected, got):
+    """Check two manifest files for equality.
+
+    Args:
+        expected: The path to the content we expect.
+        go: The path to the content we got.
+    """
+    e_file = runfiles.Create().Rlocation('rules_pkg/tests/mappings/' + expected)
+    with open(e_file, 'r') as e_fp:
+      expected = json.load(e_fp)
+    g_file = runfiles.Create().Rlocation('rules_pkg/tests/mappings/' + got)
+    with open(g_file, 'r') as g_fp:
+      got = json.load(g_fp)
+    self.assertEquals(expected, got)

--- a/pkg/tests/mappings/manifest_test_lib.py
+++ b/pkg/tests/mappings/manifest_test_lib.py
@@ -21,17 +21,21 @@ from bazel_tools.tools.python.runfiles import runfiles
 class ContentManifestTest(unittest.TestCase):
   """Test harness to see if we wrote the content manifest correctly."""
 
+  run_files = runfiles.Create()
+
   def assertManifestsMatch(self, expected, got):
     """Check two manifest files for equality.
 
     Args:
         expected: The path to the content we expect.
-        go: The path to the content we got.
+        got: The path to the content we got.
     """
-    e_file = runfiles.Create().Rlocation('rules_pkg/tests/mappings/' + expected)
+    e_file = ContentManifestTest.run_files.Rlocation(
+        'rules_pkg/tests/mappings/' + expected)
     with open(e_file, 'r') as e_fp:
       expected = json.load(e_fp)
-    g_file = runfiles.Create().Rlocation('rules_pkg/tests/mappings/' + got)
+    g_file = ContentManifestTest.run_files.Rlocation(
+        'rules_pkg/tests/mappings/' + got)
     with open(g_file, 'r') as g_fp:
       got = json.load(g_fp)
     self.assertEquals(expected, got)

--- a/pkg/tests/pkg_tar_test.py
+++ b/pkg/tests/pkg_tar_test.py
@@ -127,9 +127,9 @@ class PkgTarTest(unittest.TestCase):
   def test_empty_dirs(self):
     content = [
         {'name': '.'},
-        {'name': './tmp', 'isdir': True, 'size': 0, 'uid': 0,
-         'mtime': PORTABLE_MTIME},
         {'name': './pmt', 'isdir': True, 'size': 0, 'uid': 0,
+         'mtime': PORTABLE_MTIME},
+        {'name': './tmp', 'isdir': True, 'size': 0, 'uid': 0,
          'mtime': PORTABLE_MTIME},
     ]
     self.assertTarFileContent('test-tar-empty_dirs.tar', content)
@@ -205,6 +205,29 @@ class PkgTarTest(unittest.TestCase):
       {'name': './can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
     ]
     self.assertTarFileContent('test-tar-repackaging-long-filename.tar', content)
+
+  def test_tar_with_tree_artifact(self):
+    # (sorted) list of files:
+    #  "a/a"
+    #  "a/b/c"
+    #  "b/c/d"
+    #  "b/d"
+    #  "b/e"
+
+    content = [
+      {'name': '.'},
+      {'name': './a_tree', 'isdir': True},
+      {'name': './a_tree/a', 'isdir': True},
+      {'name': './a_tree/a/a'},
+      {'name': './a_tree/a/b', 'isdir': True},
+      {'name': './a_tree/a/b/c'},
+      {'name': './a_tree/b', 'isdir': True},
+      {'name': './a_tree/b/c', 'isdir': True},
+      {'name': './a_tree/b/c/d'},
+      {'name': './a_tree/b/d'},
+      {'name': './a_tree/b/e'},
+    ]
+    self.assertTarFileContent('test-tar-tree-artifact.tar', content)
 
 if __name__ == '__main__':
   unittest.main()

--- a/pkg/tests/util/defs.bzl
+++ b/pkg/tests/util/defs.bzl
@@ -122,7 +122,7 @@ This is intended only for testing the manifest creation features.""",
 )
 
 def write_content_manifest(name, srcs):
-    _write_content_manifest(name=name, srcs=srcs, out=name + ".manifest")
+    _write_content_manifest(name = name, srcs = srcs, out = name + ".manifest")
 
 ############################################################
 # Test boilerplate


### PR DESCRIPTION
1. Create helper methods to turn srcs of type Pkg*Info into a manifest file
   that can drive pkg_tar.
2. Test generation of the manifest using those rules
3. Use it in pkg_tar
4. Change compute_data_path to use ctx as an input instead of
   output_file. This is important refactoring for a future step where we can
   move the loop which creates the manifest from srcs to a helper method
   that all the pkg_* rules can share. I can break that out to a cleanup
   first.
5. Add support for tree artifacts in the manifest and pkg_tar.

Design points:
- Do we disallow srcs with pkg_files to be mixed with remap in pkg_tar?
- Does the pf test strategy, by looking at the generated manifest seem right

Next steps:
- Now that we don't pass --files or --empty_dirs to build_tar, eliminate
  them from build_tar. Not done in this PR to keep it smaller
- we may need to add the concept of uid/gid to Package*Info along with
  username/group name. This is for tar, which can keep both. We do not
  have to solve this before moving on.