### PR TITLE
Modularize manifest python code

### DIFF
--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -116,3 +116,10 @@ py_binary(
         ":helpers",
     ],
 )
+
+py_library(
+    name = "manifest",
+    srcs = ["manifest.py"],
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -91,6 +91,7 @@ py_binary(
         ":archive",
         ":build_info",
         ":helpers",
+        ":manifest",
     ],
 )
 

--- a/pkg/private/manifest.py
+++ b/pkg/private/manifest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common package builder manfiest helpers
+"""Common package builder manifest helpers
 """
 
 import collections

--- a/pkg/private/manifest.py
+++ b/pkg/private/manifest.py
@@ -1,0 +1,41 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common package builder manfiest helpers
+"""
+
+import collections
+
+# These must be kept in sync with the declarations in private/pkg_files.bzl
+ENTRY_IS_FILE = 0  # Entry is a file: take content from <src>
+ENTRY_IS_LINK = 1  # Entry is a symlink: dest -> <src>
+ENTRY_IS_DIR = 2  # Entry is an owned dir, possibly empty
+ENTRY_IS_TREE = 3  # Entry is a tree artifact: take tree from <src>
+
+ManifestEntry = collections.namedtuple("ManifestEntry",
+                                       ['entry_type', 'dest', 'src', 'mode', 'user', 'group'])
+
+
+def entry_type_to_string(et):
+    """Entry type stringifier"""
+    if et == ENTRY_IS_FILE:
+        return "file"
+    elif et == ENTRY_IS_LINK:
+        return "symlink",
+    elif et == ENTRY_IS_DIR:
+        return "directory"
+    elif et == ENTRY_IS_TREE:
+        return "tree"
+    else:
+        raise ValueError("Invalid entry id {}".format(et))

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -42,7 +42,7 @@ load(
 )
 
 # Possible values for entry_type
-# These must be kept in sync with the declarations in private/build_*.py
+# These must be kept in sync with the declarations in private/manifest.py.
 ENTRY_IS_FILE = 0  # Entry is a file: take content from <src>
 ENTRY_IS_LINK = 1  # Entry is a symlink: dest -> <src>
 ENTRY_IS_DIR = 2  # Entry is an empty dir


### PR DESCRIPTION
The manifest code used in pkg_tar has uses outside of pkg_tar.  Let's modularize
it to reduce the number of places it has to be duplicated (it needs to be
duplicated in `pkg/private/pkg_files.bzl` to be loaded) into starlark.

As a part of this, we create an entry type stringifier for ManifestEntry, and a
`collections.namedtuple` representing the fields in the entry.

`pkg/private/build_tar.py` was also opportunistically modified to use all of the
above.