### PR TITLE
Parameterize the manifest golden tests.

### DIFF
--- a/pkg/tests/mappings/BUILD
+++ b/pkg/tests/mappings/BUILD
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(":mappings_test.bzl", "mappings_analysis_tests", "mappings_unit_tests")
+load(
+    ":mappings_test.bzl",
+     "manifest_golden_test",
+     "mappings_analysis_tests",
+     "mappings_unit_tests",
+)
 load(
     "//:mappings.bzl",
     "pkg_attributes",
@@ -24,6 +29,15 @@ load(
 )
 load("//tests/util:defs.bzl", "write_content_manifest")
 load("@rules_python//python:defs.bzl", "py_test")
+
+py_library(
+    name = "manifest_test_lib",
+    srcs = ["manifest_test_lib.py"],
+    srcs_version = "PY3",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+    ],
+)
 
 mappings_analysis_tests()
 
@@ -57,30 +71,8 @@ write_content_manifest(
     ],
 )
 
-# TODO(aiuto): This rule and the small srcs should be generated from just the
-# pair of write_content_manifest name and the golden file name.
-# We could even inline the golden data into a string which gets parsed as
-# json and written out.
-py_test(
+manifest_golden_test(
     name = "all_test",
-    srcs = [
-        "all_test.py",
-    ],
-    data = [
-        "all.manifest.golden",
-        ":all.manifest",
-    ],
-    python_version = "PY3",
-    deps = [
-        ":manifest_test_lib",
-    ],
-)
-
-py_library(
-    name = "manifest_test_lib",
-    srcs = ["manifest_test_lib.py"],
-    srcs_version = "PY3",
-    deps = [
-        "@bazel_tools//tools/python/runfiles",
-    ],
+    target = "all",
+    expected = "all.manifest.golden",
 )

--- a/pkg/tests/mappings/manifest_test_lib.py
+++ b/pkg/tests/mappings/manifest_test_lib.py
@@ -32,10 +32,10 @@ class ContentManifestTest(unittest.TestCase):
     """
     e_file = ContentManifestTest.run_files.Rlocation(
         'rules_pkg/tests/mappings/' + expected)
-    with open(e_file, 'r') as e_fp:
+    with open(e_file, mode='rb') as e_fp:
       expected = json.load(e_fp)
     g_file = ContentManifestTest.run_files.Rlocation(
         'rules_pkg/tests/mappings/' + got)
-    with open(g_file, 'r') as g_fp:
+    with open(g_file, mode='rb') as g_fp:
       got = json.load(g_fp)
     self.assertEquals(expected, got)

--- a/pkg/tests/mappings/manifest_test_main.py.tpl
+++ b/pkg/tests/mappings/manifest_test_main.py.tpl
@@ -13,16 +13,14 @@
 # limitations under the License.
 """Tests for generated content manifest."""
 
-# TODO(aiuto): Generate this file.
-
 import unittest
 
-import manifest_test_lib
+from rules_pkg.tests.mappings import manifest_test_lib
 
-class ManifestAllTest(manifest_test_lib.ContentManifestTest):
+class ${TEST_NAME}(manifest_test_lib.ContentManifestTest):
 
   def test_match(self):
-    self.assertManifestsMatch('all.manifest.golden', 'all.manifest')
+    self.assertManifestsMatch('${EXPECTED}', '${TARGET}')
 
 
 if __name__ == '__main__':

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@rules_python//python:defs.bzl", "py_test")
 load("//:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 load(
     "//:mappings.bzl",
@@ -973,4 +974,54 @@ def mappings_unit_tests():
     unittest.suite(
         "mappings_unit_tests",
         strip_prefix_test,
+    )
+
+def _gen_manifest_test_main_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.out,
+        substitutions = {
+            "${EXPECTED}": ctx.attr.expected,
+            "${TARGET}": ctx.attr.target,
+            "${TEST_NAME}": ctx.attr.test_name,
+        },
+    )
+    return [
+        DefaultInfo(files = depset([ctx.outputs.out])),
+    ]
+
+_gen_manifest_test_main = rule(
+    implementation = _gen_manifest_test_main_impl,
+    attrs = {
+        "_template": attr.label(
+            default = Label("//tests/mappings:manifest_test_main.py.tpl"),
+            allow_single_file = True,
+        ),
+        "out": attr.output(mandatory = True),
+        "expected": attr.string(),
+        "target": attr.string(),
+        "test_name": attr.string(),
+    },
+)
+
+
+def manifest_golden_test(name, target, expected):
+    _gen_manifest_test_main(
+        name = name + "_main",
+        out = name + ".py",
+        expected = expected,
+        target = target + ".manifest",
+        test_name = target + "Test",
+    )
+    py_test(
+        name = name,
+        srcs = [":" + name + ".py"],
+        data = [
+            ":" + target + ".manifest",
+            expected,
+        ],
+        python_version = "PY3",
+        deps = [
+            ":manifest_test_lib",
+        ],
     )

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -993,19 +993,29 @@ def _gen_manifest_test_main_impl(ctx):
 _gen_manifest_test_main = rule(
     implementation = _gen_manifest_test_main_impl,
     attrs = {
+        "out": attr.output(mandatory = True),
+        "expected": attr.string(mandatory = True),
+        "target": attr.string(mandatory = True),
+        "test_name": attr.string(mandatory = True),
         "_template": attr.label(
             default = Label("//tests/mappings:manifest_test_main.py.tpl"),
             allow_single_file = True,
         ),
-        "out": attr.output(mandatory = True),
-        "expected": attr.string(),
-        "target": attr.string(),
-        "test_name": attr.string(),
     },
 )
 
 
 def manifest_golden_test(name, target, expected):
+    """Tests that a content manifest file matches a golden copy.
+
+    This test is used to verify that a generated manifest file matches the
+    expected content.
+
+    Args:
+      target: A target which produces a content manifest with the name
+          <target> + ".manifest"
+      expected: label of a file containing the expected content.
+    """
     _gen_manifest_test_main(
         name = name + "_main",
         out = name + ".py",


### PR DESCRIPTION
This was split out from #376 to make that review easier.
I want to get this in place before adding a fix for #392.
The UTF-8 tests are lower priority.