### PR TITLE
Split mappings tests that use an external repo from the others

### DIFF
--- a/pkg/tests/mappings/BUILD
+++ b/pkg/tests/mappings/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load(":mappings_test.bzl", "mappings_analysis_tests", "mappings_unit_tests")
+load(":mappings_external_repo_test.bzl", "mappings_external_repo_analysis_tests")
 load(
     "//:mappings.bzl",
     "pkg_attributes",
@@ -25,9 +26,11 @@ load(
 load("//tests/util:defs.bzl", "write_content_manifest")
 load("@rules_python//python:defs.bzl", "py_test")
 
+mappings_unit_tests()
+
 mappings_analysis_tests()
 
-mappings_unit_tests()
+mappings_external_repo_analysis_tests()
 
 pkg_mkdirs(
     name = "dirs",

--- a/pkg/tests/mappings/mappings_external_repo_test.bzl
+++ b/pkg/tests/mappings/mappings_external_repo_test.bzl
@@ -1,0 +1,183 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for file mapping routines in pkg/mappings.bzl"""
+
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
+load("//:mappings.bzl", "pkg_files", "strip_prefix")
+
+##########
+# Helpers
+##########
+
+def _flatten(list_of_lists):
+    """Transform a list of lists into a single list, preserving relative order."""
+    return [item for sublist in list_of_lists for item in sublist]
+
+##########
+# pkg_files tests
+##########
+
+def _pkg_files_contents_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    expected_dests = {e: None for e in ctx.attr.expected_dests}
+    n_found = 0
+    for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
+        asserts.true(
+            got in expected_dests,
+            "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests))
+        n_found += 1
+    asserts.equals(env, len(expected_dests), n_found)
+
+
+    # Simple equality checks for the others, if specified
+    if ctx.attr.expected_attributes:
+        asserts.equals(
+            env,
+            json.decode(ctx.attr.expected_attributes),
+            target_under_test[PackageFilesInfo].attributes,
+            "pkg_files attributes do not match expectations",
+        )
+
+    # TODO(nacl): verify DefaultInfo propagation
+
+    return analysistest.end(env)
+
+pkg_files_contents_test = analysistest.make(
+    _pkg_files_contents_test_impl,
+    attrs = {
+        # Other attributes can be tested here, but the most important one is the
+        # destinations.
+        "expected_dests": attr.string_list(
+            mandatory = True,
+        ),
+        "expected_attributes": attr.string(),
+    },
+)
+
+# Tests involving external repositories
+def _test_pkg_files_extrepo():
+    # From external repo root, basenames only
+    pkg_files(
+        name = "pf_extrepo_strip_all_g",
+        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
+        tags = ["manual"],
+    )
+    pkg_files_contents_test(
+        name = "pf_extrepo_strip_all",
+        target_under_test = ":pf_extrepo_strip_all_g",
+        expected_dests = ["extproj.sh", "script"],
+    )
+
+    # From external repo root, relative to the "pkg" package
+    pkg_files(
+        name = "pf_extrepo_strip_from_pkg_g",
+        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
+        strip_prefix = strip_prefix.from_pkg("dir"),
+        tags = ["manual"],
+    )
+    pkg_files_contents_test(
+        name = "pf_extrepo_strip_from_pkg",
+        target_under_test = ":pf_extrepo_strip_from_pkg_g",
+        expected_dests = [
+            "extproj.sh",
+            "script",
+        ],
+    )
+
+    # From external repo root, relative to the "pkg" directory
+    pkg_files(
+        name = "pf_extrepo_strip_from_root_g",
+        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
+        strip_prefix = strip_prefix.from_root("pkg"),
+        tags = ["manual"],
+    )
+    pkg_files_contents_test(
+        name = "pf_extrepo_strip_from_root",
+        target_under_test = ":pf_extrepo_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh", "dir/script"],
+    )
+
+    native.filegroup(
+        name = "extrepo_test_fg",
+        srcs = ["@mappings_test_external_repo//pkg:dir/extproj.sh"],
+    )
+
+    # Test the case when a have a pkg_files that targets a local filegroup
+    # that has files in an external repo.
+    pkg_files(
+        name = "pf_extrepo_filegroup_strip_from_pkg_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = strip_prefix.from_pkg(""),
+    )
+    pkg_files_contents_test(
+        name = "pf_extrepo_filegroup_strip_from_pkg",
+        target_under_test = ":pf_extrepo_filegroup_strip_from_pkg_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Ditto, except strip from the workspace root instead
+    pkg_files(
+        name = "pf_extrepo_filegroup_strip_from_root_g",
+        srcs = [":extrepo_test_fg"],
+        # Files within filegroups should be considered relative to their
+        # destination paths.
+        strip_prefix = strip_prefix.from_root("pkg"),
+    )
+    pkg_files_contents_test(
+        name = "pf_extrepo_filegroup_strip_from_root",
+        target_under_test = ":pf_extrepo_filegroup_strip_from_root_g",
+        expected_dests = ["dir/extproj.sh"],
+    )
+
+    # Reference a pkg_files in @mappings_test_external_repo
+    pkg_files_contents_test(
+        name = "pf_pkg_files_in_extrepo",
+        target_under_test = "@mappings_test_external_repo//pkg:extproj_script_pf",
+        expected_dests = ["usr/bin/dir/extproj.sh"],
+    )
+
+
+def mappings_external_repo_analysis_tests():
+    """Declare mappings.bzl analysis tests"""
+    _test_pkg_files_extrepo()
+
+    native.test_suite(
+        name = "pkg_files_external_repo_analysis_tests",
+        # We should find a way to get rid of this test list; it would be nice if
+        # it could be derived from something else...
+        tests = [
+            # buildifier: don't sort
+            # Tests involving external repositories
+            ":pf_extrepo_strip_all",
+            ":pf_extrepo_strip_from_pkg",
+            ":pf_extrepo_strip_from_root",
+            ":pf_extrepo_filegroup_strip_from_pkg",
+            ":pf_extrepo_filegroup_strip_from_root",
+            ":pf_pkg_files_in_extrepo",
+            ":pf_file_rename_to_empty",
+            ":pf_directory_rename_to_empty",
+            # This one fits into the same category, but can't be aliased, apparently.
+            #
+            # The main purpose behind it is to verify cases wherein we build a
+            # file, but then have it consumed by some remote package.
+            "@mappings_test_external_repo//pkg:pf_local_file_in_extrepo",
+        ],
+    )

--- a/pkg/tests/mappings/mappings_test.bzl
+++ b/pkg/tests/mappings/mappings_test.bzl
@@ -334,90 +334,6 @@ def _test_pkg_files_exclusions():
         expected_dests = ["testdata/hello.txt"],
     )
 
-# Tests involving external repositories
-def _test_pkg_files_extrepo():
-    # From external repo root, basenames only
-    pkg_files(
-        name = "pf_extrepo_strip_all_g",
-        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
-        tags = ["manual"],
-    )
-    pkg_files_contents_test(
-        name = "pf_extrepo_strip_all",
-        target_under_test = ":pf_extrepo_strip_all_g",
-        expected_dests = ["extproj.sh", "script"],
-    )
-
-    # From external repo root, relative to the "pkg" package
-    pkg_files(
-        name = "pf_extrepo_strip_from_pkg_g",
-        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
-        strip_prefix = strip_prefix.from_pkg("dir"),
-        tags = ["manual"],
-    )
-    pkg_files_contents_test(
-        name = "pf_extrepo_strip_from_pkg",
-        target_under_test = ":pf_extrepo_strip_from_pkg_g",
-        expected_dests = [
-            "extproj.sh",
-            "script",
-        ],
-    )
-
-    # From external repo root, relative to the "pkg" directory
-    pkg_files(
-        name = "pf_extrepo_strip_from_root_g",
-        srcs = ["@mappings_test_external_repo//pkg:dir/script"],
-        strip_prefix = strip_prefix.from_root("pkg"),
-        tags = ["manual"],
-    )
-    pkg_files_contents_test(
-        name = "pf_extrepo_strip_from_root",
-        target_under_test = ":pf_extrepo_strip_from_root_g",
-        expected_dests = ["dir/extproj.sh", "dir/script"],
-    )
-
-    native.filegroup(
-        name = "extrepo_test_fg",
-        srcs = ["@mappings_test_external_repo//pkg:dir/extproj.sh"],
-    )
-
-    # Test the case when a have a pkg_files that targets a local filegroup
-    # that has files in an external repo.
-    pkg_files(
-        name = "pf_extrepo_filegroup_strip_from_pkg_g",
-        srcs = [":extrepo_test_fg"],
-        # Files within filegroups should be considered relative to their
-        # destination paths.
-        strip_prefix = strip_prefix.from_pkg(""),
-    )
-    pkg_files_contents_test(
-        name = "pf_extrepo_filegroup_strip_from_pkg",
-        target_under_test = ":pf_extrepo_filegroup_strip_from_pkg_g",
-        expected_dests = ["dir/extproj.sh"],
-    )
-
-    # Ditto, except strip from the workspace root instead
-    pkg_files(
-        name = "pf_extrepo_filegroup_strip_from_root_g",
-        srcs = [":extrepo_test_fg"],
-        # Files within filegroups should be considered relative to their
-        # destination paths.
-        strip_prefix = strip_prefix.from_root("pkg"),
-    )
-    pkg_files_contents_test(
-        name = "pf_extrepo_filegroup_strip_from_root",
-        target_under_test = ":pf_extrepo_filegroup_strip_from_root_g",
-        expected_dests = ["dir/extproj.sh"],
-    )
-
-    # Reference a pkg_files in @mappings_test_external_repo
-    pkg_files_contents_test(
-        name = "pf_pkg_files_in_extrepo",
-        target_under_test = "@mappings_test_external_repo//pkg:extproj_script_pf",
-        expected_dests = ["usr/bin/dir/extproj.sh"],
-    )
-
 def _test_pkg_files_rename():
     pkg_files(
         name = "pf_rename_multiple_g",
@@ -907,7 +823,6 @@ def mappings_analysis_tests():
     """Declare mappings.bzl analysis tests"""
     _test_pkg_files_contents()
     _test_pkg_files_exclusions()
-    _test_pkg_files_extrepo()
     _test_pkg_files_rename()
     _test_pkg_mkdirs()
     _test_pkg_mklink()
@@ -939,20 +854,7 @@ def mappings_analysis_tests():
             ":pf_destination_collision_invalid",
             ":pf_strip_prefix_from_package_invalid",
             ":pf_strip_prefix_from_root_invalid",
-            # Tests involving external repositories
-            ":pf_extrepo_strip_all",
-            ":pf_extrepo_strip_from_pkg",
-            ":pf_extrepo_strip_from_root",
-            ":pf_extrepo_filegroup_strip_from_pkg",
-            ":pf_extrepo_filegroup_strip_from_root",
-            ":pf_pkg_files_in_extrepo",
-            ":pf_file_rename_to_empty",
-            ":pf_directory_rename_to_empty",
-            # This one fits into the same category, but can't be aliased, apparently.
             #
-            # The main purpose behind it is to verify cases wherein we build a
-            # file, but then have it consumed by some remote package.
-            "@mappings_test_external_repo//pkg:pf_local_file_in_extrepo",
             # Tests involving file renaming
             ":pf_rename_multiple",
             ":pf_rename_rule_with_multiple_outputs",


### PR DESCRIPTION
Split mappings tests that use an external repo from the others.
This make it easier to exclude those tests from a `bazel test ...` pattern when used in a repo that does not allow WORKSPACE file customizations.