### PR TITLE
[pkg_tar] specify tar format

### DIFF
--- a/pkg/private/archive.py
+++ b/pkg/private/archive.py
@@ -177,7 +177,8 @@ class TarFileWriter(object):
     self.root_directory = root_directory.rstrip('/').rstrip('\\')
     self.root_directory = self.root_directory.replace('\\', '/')
 
-    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
+    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj,
+                            format=tarfile.GNU_FORMAT)
     self.members = set([])
     self.directories = set([])
 


### PR DESCRIPTION
Python's tarfile.DEFAULT_FORMAT changed from GNU to Pax from Python 3.8
onwards ([doc][1]):

```
tarfile.DEFAULT_FORMAT
The default format for creating archives. This is currently PAX_FORMAT.
```

Hardcode *a particular format* (the old one, for wider compatibility with what's out there), so the produced tars are more hermetic against the differences in the host system.

This is of particular interest when tarballs are combined with `pkg_tar` rule:

```
pkg_tar(
  name = "other",
  srcs = [...],
)

pkg_tar(
  name = "final",
  deps = [
      "//src/...", # assume it was generated by a tool which emits a gnu-tarball
      ":other",
  ]
)
```

Since the archives of `;final` are not repacked, just appended, the resulting concatenated tar contains archives of different types, which, for exampe, `dpkg` is complaining about. A tar with mixed format is better to be avoided, esp. that the messages are quite cryptic:

```
dpkg: error processing archive /<...>.deb (--install):
 corrupted filesystem tarfile in package archive: unsupported PAX tar header type 'x'
```

[1]: https://docs.python.org/3/library/tarfile.html#tarfile.DEFAULT_FORMAT