### PR TITLE
encode relnotes to utf8

### DIFF
--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -64,7 +64,7 @@ def print_notes(org, repo, version, tarball_path, mirror_host=None,
       'repo': repo,
       'version': version,
       'workspace_stanza': workspace_stanza,
-  }))
+  }).encode('utf8'))
   if mirror_url:
     file = os.path.basename(tarball_path)
     path = 'github.com/{org}/{repo}/releases/download/{version}/{file}'.format(


### PR DESCRIPTION
otherwise, if my surname (that contains `š`) is in the changelog, it
breaks with:

```
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/37f7baa4bbab719582d6cb52a0ca346b/sandbox/processwrapper-sandbox/130/execroot/rules_pkg/bazel-out/host/bin/releasing/print_rel_notes.runfiles/rules_pkg/re
leasing/print_rel_notes.py", line 144, in <module>
    main()
  File "/root/.cache/bazel/_bazel_root/37f7baa4bbab719582d6cb52a0ca346b/sandbox/processwrapper-sandbox/130/execroot/rules_pkg/bazel-out/host/bin/releasing/print_rel_notes.runfiles/rules_pkg/re
leasing/print_rel_notes.py", line 140, in main
    toolchains_method=options.toolchains_method)
  File "/root/.cache/bazel/_bazel_root/37f7baa4bbab719582d6cb52a0ca346b/sandbox/processwrapper-sandbox/130/execroot/rules_pkg/bazel-out/host/bin/releasing/print_rel_notes.runfiles/rules_pkg/re
leasing/print_rel_notes.py", line 71, in print_notes
    print(u"\u0161oo")
UnicodeEncodeError: 'ascii' codec can't encode character '\u0161' in position 0: ordinal not in range(128)
```

I am quite puzzled on why that is; a `string` is already utf8-encoded
and thus should be printed appropriately in python3, but hey, it isn't
on the environment that the integration tests are running at.

This will fix CI failures in #418 and #422.