### PR TITLE
add recurse option to pkg_zip to maintain directory structure

### DIFF
--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -593,8 +593,6 @@ def _pkg_zip_impl(ctx):
     args.add("-d", ctx.attr.package_dir)
     args.add("-t", ctx.attr.timestamp)
     args.add("-m", ctx.attr.mode)
-    if ctx.attr.recurse:
-        args.add("-r")
     inputs = []
     if ctx.attr.stamp == 1 or (ctx.attr.stamp == -1 and
                                ctx.attr.private_stamp_detect):
@@ -622,7 +620,7 @@ def _pkg_zip_impl(ctx):
         ):
             # Add in the files of srcs which are not pkg_* types
             for f in src.files.to_list():
-                d_path = dest_path(f, data_path, data_path_without_prefix)
+                d_path = dest_path(f, data_path, data_path_without_prefix) if not ctx.attr.recurse else dest_path(f, data_path_without_prefix, data_path_without_prefix)
                 if f.is_directory:
                     # Tree artifacts need a name, but the name is never really
                     # the important part. The likely behavior people want is

--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -593,6 +593,8 @@ def _pkg_zip_impl(ctx):
     args.add("-d", ctx.attr.package_dir)
     args.add("-t", ctx.attr.timestamp)
     args.add("-m", ctx.attr.mode)
+    if ctx.attr.recurse:
+        args.add("-r")
     inputs = []
     if ctx.attr.stamp == 1 or (ctx.attr.stamp == -1 and
                                ctx.attr.private_stamp_detect):
@@ -670,6 +672,7 @@ pkg_zip_impl = rule(
         "srcs": attr.label_list(allow_files = True),
         "strip_prefix": attr.string(),
         "timestamp": attr.int(default = 315532800),
+        "recurse": attr.bool(default = False),
 
         # Common attributes
         "out": attr.output(mandatory = True),

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -322,6 +322,23 @@ filegroup(
     "/abc/def/",
 ])]
 
+pkg_zip(
+    name = "test_zip_recurse",
+    srcs = glob(
+        ["testdata/**/*.txt"]
+    ),
+    recurse = True
+)
+
+pkg_zip(
+    name = "test_zip_recurse_package_dir",
+    srcs = glob(
+        ["testdata/**/*.txt"]
+    ),
+    recurse = True,
+    package_dir = "abc/def"
+)
+
 py_test(
     name = "zip_test",
     srcs = [

--- a/pkg/tests/BUILD
+++ b/pkg/tests/BUILD
@@ -324,17 +324,21 @@ filegroup(
 
 pkg_zip(
     name = "test_zip_recurse",
-    srcs = glob(
-        ["testdata/**/*.txt"]
-    ),
+    srcs = glob([
+        "testdata/nested/*.txt",
+        "testdata/hello.txt",
+        "testdata/loremipsum.txt",
+    ]),
     recurse = True
 )
 
 pkg_zip(
     name = "test_zip_recurse_package_dir",
-    srcs = glob(
-        ["testdata/**/*.txt"]
-    ),
+    srcs = glob([
+        "testdata/nested/*.txt",
+        "testdata/hello.txt",
+        "testdata/loremipsum.txt",
+    ]),
     recurse = True,
     package_dir = "abc/def"
 )
@@ -354,6 +358,8 @@ py_test(
         "test-zip-strip_prefix-none.zip",
         "test-zip-strip_prefix-zipcontent.zip",
         "test-zip-strip_prefix-dot.zip",
+        "test_zip_recurse.zip",
+        "test_zip_recurse_package_dir.zip",
 
         # these could be replaced with diff_test() rules (from skylib)
         "test_zip_basic_timestamp_before_epoch.zip",

--- a/pkg/tests/testdata/nested/nested.txt
+++ b/pkg/tests/testdata/nested/nested.txt
@@ -1,0 +1,1 @@
+Nested Text

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -92,18 +92,16 @@ class ZipContentsCase(ZipTest):
 
   def test_recurse(self):
     self.assertZipFileContent("test_zip_recurse.zip", [
-        {"filename": "nested/", "isdir": True, "attr": 0o711},
-        {"filename": "nested/nested.txt", "crc": NESTED_CRC},
-        {"filename": "hello.txt", "crc": HELLO_CRC},
-        {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+        {"filename": "testdata/hello.txt", "crc": HELLO_CRC},
+        {"filename": "testdata/loremipsum.txt", "crc": LOREM_CRC},
+        {"filename": "testdata/nested/nested.txt", "crc": NESTED_CRC},
     ])
 
   def test_recurse_package_dir(self):
-    self.assertZipFileContent("test_zip_recurse.zip", [
-        {"filename": "abc/def/nested/", "isdir": True, "attr": 0o711},
-        {"filename": "abc/def/nested/nested.txt", "crc": NESTED_CRC},
-        {"filename": "abc/def/hello.txt", "crc": HELLO_CRC},
-        {"filename": "abc/def/loremipsum.txt", "crc": LOREM_CRC},
+    self.assertZipFileContent("test_zip_recurse_package_dir.zip", [
+        {"filename": "abc/def/testdata/hello.txt", "crc": HELLO_CRC},
+        {"filename": "abc/def/testdata/loremipsum.txt", "crc": LOREM_CRC},
+        {"filename": "abc/def/testdata/nested/nested.txt", "crc": NESTED_CRC},
     ])
 
   def test_timestamp(self):

--- a/pkg/tests/zip_test.py
+++ b/pkg/tests/zip_test.py
@@ -21,6 +21,7 @@ from bazel_tools.tools.python.runfiles import runfiles
 
 HELLO_CRC = 2069210904
 LOREM_CRC = 2178844372
+NESTED_CRC = 143981220
 EXECUTABLE_CRC = 342626072
 
 # Unix dir bit and Windows dir bit. Magic from zip spec
@@ -87,6 +88,22 @@ class ZipContentsCase(ZipTest):
         {"filename": "foodir/", "isdir": True, "attr": 0o711},
         {"filename": "hello.txt", "crc": HELLO_CRC},
         {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+    ])
+
+  def test_recurse(self):
+    self.assertZipFileContent("test_zip_recurse.zip", [
+        {"filename": "nested/", "isdir": True, "attr": 0o711},
+        {"filename": "nested/nested.txt", "crc": NESTED_CRC},
+        {"filename": "hello.txt", "crc": HELLO_CRC},
+        {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+    ])
+
+  def test_recurse_package_dir(self):
+    self.assertZipFileContent("test_zip_recurse.zip", [
+        {"filename": "abc/def/nested/", "isdir": True, "attr": 0o711},
+        {"filename": "abc/def/nested/nested.txt", "crc": NESTED_CRC},
+        {"filename": "abc/def/hello.txt", "crc": HELLO_CRC},
+        {"filename": "abc/def/loremipsum.txt", "crc": LOREM_CRC},
     ])
 
   def test_timestamp(self):


### PR DESCRIPTION
Need to maintain the zip directory structure for zipping cocoapods as a part of the build, otherwise the glob wont match from the podspec file (or i'd end up matching test files from a test_spec as well as source files)

```ruby
...
s.source_files = "SomePod/Sources/**/*.swift"
s.test_spec do |tests|
  tests.source_files = "SomePod/Tests/**/*.swift"
end
```

`pkg_zip` with `glob(["SomePod/Sources/**/*.swift"])` will produce a zip with all swift files in a flat directory

I can solve this simple example with `package_dir = 'SomePod/Sources'` but looking for a longer term solution because i want to use this on pods with multiple subspecs