### PR TITLE
Fix AUTHORS attribution to account for deb_packages being moved down …

### DIFF
--- a/deb_packages/AUTHORS
+++ b/deb_packages/AUTHORS
@@ -7,3 +7,4 @@
 # The email address is not required for organizations.
 
 Google Inc.
+mgIT GmbH


### PR DESCRIPTION
…and deprecated.

The current AUTHORS now reflects the actual authorship of the rules_pkg distribution.