### PR TITLE
Create "where is my output" example

### DIFF
--- a/examples/where_is_my_output/BUILD
+++ b/examples/where_is_my_output/BUILD
@@ -1,0 +1,43 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -*- coding: utf-8 -*-
+
+# Build a trivial .deb package to show how to find the output files.
+
+load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+
+licenses(["notice"])
+
+genrule(
+    name = "generate_files",
+    outs = [
+        "etc/example.conf",
+        "usr/bin/a_binary",
+    ],
+    cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+)
+
+pkg_tar(
+    name = "content",
+    srcs = [":generate_files"],
+)
+
+pkg_deb(
+    name = "deb",
+    data = ":content",
+    description = "My wonderful product",
+    maintainer = "someone@somewhere.com",
+    package = "mwp",
+    version = "3.14",
+)

--- a/examples/where_is_my_output/WORKSPACE
+++ b/examples/where_is_my_output/WORKSPACE
@@ -1,0 +1,26 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "rich_structure")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "rules_pkg",
+    path = "../../pkg",
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/examples/where_is_my_output/show_deb_outputs.bzl
+++ b/examples/where_is_my_output/show_deb_outputs.bzl
@@ -1,0 +1,12 @@
+# Extract the paths to the various outputs of pkg_deb
+#
+# Usage:
+#   bazel cquery //:debian --output=starlark --starlark:file=show_deb_outputs.bzl
+#
+
+def format(target):
+  provider_map = providers(target)
+  return '\n'.join([
+      'deb: ' + provider_map["OutputGroupInfo"].deb.to_list()[0].path,
+      'changes: ' + provider_map["OutputGroupInfo"].changes.to_list()[0].path,
+      ])


### PR DESCRIPTION
Show cquery --output=starlark trick to print exact paths to files.