### PR TITLE
turn on use of target_compatible_with for make_rpm.

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -58,11 +58,10 @@ py_binary(
     srcs = ["make_rpm.py"],
     python_version = "PY3",
     srcs_version = "PY3",
-    # TODO(aiuto): Enable this for bazel 4.x
-    #target_compatible_with = select({
-    #    "//toolchains:have_rpmbuild": [],
-    #    "//conditions:default": [":not_compatible"],
-    #}),
+    target_compatible_with = select({
+        "//toolchains:have_rpmbuild": [],
+        "//conditions:default": [":not_compatible"],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         "//private:archive",


### PR DESCRIPTION
Let's see what happens.
Note: This would have smaller impact if we refactored rules so rpm were distinct.