### PR TITLE
Remove uses of `incompatible_use_toolchain_transition`.

### DIFF
--- a/examples/naming_package_files/my_package_name.bzl
+++ b/examples/naming_package_files/my_package_name.bzl
@@ -89,7 +89,6 @@ names_from_toolchains = rule(
         ),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 #


### PR DESCRIPTION
It is now the default for Bazel.