### PR TITLE
Revert "Remove uses of `incompatible_use_toolchain_transition` now th…

### DIFF
--- a/examples/naming_package_files/my_package_name.bzl
+++ b/examples/naming_package_files/my_package_name.bzl
@@ -89,6 +89,7 @@ names_from_toolchains = rule(
         ),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )
 
 #
@@ -96,7 +97,6 @@ names_from_toolchains = rule(
 #
 def _name_part_from_command_line_naming_impl(ctx):
     values = {"name_part": ctx.build_setting_value}
-
     # Just pass the value from the command line through. An implementation
     # could also perform validation, such as done in
     # https://github.com/bazelbuild/bazel-skylib/blob/master/rules/common_settings.bzl


### PR DESCRIPTION
…at it is enabled by (#452)"

This is still needed for bazel 4.x compatibility, and it a no-op in
Bazel 5.x, so it should be kept.

The API will be removed in Bazel 6.0.

Part of bazelbuild/bazel#14127.

This reverts commit e203d5b32bb0b8d1040543514d421f7f9cd944f5.