### PR TITLE
Add .bazelignore to skip deb_packages, examples subdirectories

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,5 @@
+# The following directories have their own WORKSPACEs (or contain WORKSPACEs),
+# so they shouldn't be built when in the main part of the rules_pkg repository.
+
+deb_packages/
+examples/


### PR DESCRIPTION
As of #443, all of the rules_pkg files are now in a WORKSPACE relative to the
root of the repository.  These are now shared with the `deb_packages/` and
`examples/` subdirectories, which contain their own WORKSPACE files.  This
confuses Bazel and prevents us from testing `//...`.

This changes allows us to build/test `//...` by adding those directories to a
.bazelignore file at the root of the repository.

Most people working on rules_pkg aren't going to be touching these, and if they
are, they need to be in those WORKSPACEs anyway, so there should be no harm in
this.