### PR TITLE
Post tree-reorganization cleanup

### DIFF
--- a/install.bzl
+++ b/install.bzl
@@ -1,0 +1,20 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "//pkg:install.bzl",
+    _pkg_install = "pkg_install"
+)
+
+pkg_install = _pkg_install

--- a/mappings.bzl
+++ b/mappings.bzl
@@ -21,7 +21,10 @@ load(
     _pkg_mkdirs = "pkg_mkdirs",
     _pkg_mklink = "pkg_mklink",
     _strip_prefix = "strip_prefix",
+    _REMOVE_BASE_DIRECTORY = "REMOVE_BASE_DIRECTORY",
 )
+
+REMOVE_BASE_DIRECTORY = _REMOVE_BASE_DIRECTORY
 
 filter_directory = _filter_directory
 

--- a/pkg/install.bzl
+++ b/pkg/install.bzl
@@ -172,7 +172,7 @@ def pkg_install(name, srcs, **kwargs):
         name = name,
         srcs = [":" + name + "_install_script"],
         main = name + "_install_script.py",
-        deps = ["//pkg/private:manifest"],
+        deps = [Label("//pkg/private:manifest")],
         srcs_version = "PY3",
         python_version = "PY3",
         **kwargs


### PR DESCRIPTION
#443 reorganized the source tree: moving the WORKSPACE to the root of the
repository as is convention.  To help maintain backward compatibility, numerous
stub files were added to the root of the repository.

I noticed the following in local testing:

- The `install.bzl` stub was empty.
- The `mappings.bzl` stub was missing `REMOVE_BASE_DIRECTORY`
- The renaming of the `deps` value in the `pkg_install` macro confuses bazel; force it to use a rules_pkg-relative label instead (with the `Label` constructor) 

These slipped through the cracks in the review.  This change rectifies the above issues.