### PR TITLE
Added `//:bzl_lib` target so users can generate stardoc docs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(
     ["WORKSPACE"],
     visibility = ["//visibility:public"],
@@ -33,4 +35,21 @@ filegroup(
         "LICENSE",
     ],
     visibility = ["//distro:__pkg__"],
+)
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]) + [
+        "//pkg:bzl_srcs",
+        "//toolchains:bzl_srcs",
+    ],
+)
+
+bzl_library(
+    name = "bzl_lib",
+    srcs = [
+        ":bzl_srcs",
+        "@bazel_skylib//lib:paths",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -83,3 +83,14 @@ py_binary(
     python_version = "PY3",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]) + [
+        "//pkg/legacy:bzl_srcs",
+        "//pkg/private:bzl_srcs",
+        "//pkg/releasing:bzl_srcs",
+        "//pkg/rpm:bzl_srcs",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/pkg/legacy/BUILD
+++ b/pkg/legacy/BUILD
@@ -23,3 +23,9 @@ filegroup(
     ],
     visibility = ["//pkg:__pkg__"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -111,3 +111,12 @@ py_library(
     srcs_version = "PY3",
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]) + [
+        "//pkg/private/deb:bzl_srcs",
+        "//pkg/private/zip:bzl_srcs",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/pkg/private/deb/BUILD
+++ b/pkg/private/deb/BUILD
@@ -48,3 +48,9 @@ py_binary(
         "//pkg/private:helpers",
     ],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/pkg/private/zip/BUILD
+++ b/pkg/private/zip/BUILD
@@ -53,3 +53,9 @@ py_binary(
         "//pkg/private:manifest",
     ],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -67,3 +67,9 @@ py_binary(
     # TODO(https://github.com/bazelbuild/bazel/issues/7377): Make this private.
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/pkg/rpm/BUILD
+++ b/pkg/rpm/BUILD
@@ -41,3 +41,9 @@ py_binary(
     srcs = ["augment_rpm_files_install.py"],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -74,3 +74,11 @@ toolchain(
     toolchain = ":no_rpmbuild",
     toolchain_type = ":rpmbuild_toolchain_type",
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]) + [
+        "//toolchains/git:bzl_srcs",
+    ],
+    visibility = ["//:__subpackages__"],
+)

--- a/toolchains/git/BUILD
+++ b/toolchains/git/BUILD
@@ -71,3 +71,9 @@ toolchain(
     toolchain = ":no_git",
     toolchain_type = ":git_toolchain_type",
 )
+
+filegroup(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
As a consumer of `rules_pkg` I want to be able to generate docs via [stardoc](https://github.com/bazelbuild/stardoc). This requires the tree of `.bzl` source files to be consumable publicly. This change adds `@rules_pkg//:bzl_lib` which is a [bzl_library](https://github.com/bazelbuild/bazel-skylib/blob/1.1.1/bzl_library.bzl). With this publicly visible target, users are able to generate docs.