### PR TITLE
Added buildifier to CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,3 +1,7 @@
+buildifier:
+  version: latest
+  warnings: "all"
+
 imports:
 - tests.yml
 - examples_naming.yml

--- a/deb_packages/BUILD
+++ b/deb_packages/BUILD
@@ -1,15 +1,15 @@
-package(default_visibility = ["//visibility:public"])
-
 # rules_go boilerplate
 load("@bazel_gazelle//:def.bzl", "gazelle")
+
+# update_deb_packages boilerplate
+load("@rules_pkg//tools/update_deb_packages:update_deb_packages.bzl", "update_deb_packages")
+
+package(default_visibility = ["//visibility:public"])
 
 gazelle(
     name = "gazelle",
     prefix = "github.com/bazelbuild/rules_pkg",
 )
-
-# update_deb_packages boilerplate
-load("@rules_pkg//tools/update_deb_packages:update_deb_packages.bzl", "update_deb_packages")
 
 update_deb_packages(
     name = "update_deb_packages",

--- a/deb_packages/WORKSPACE
+++ b/deb_packages/WORKSPACE
@@ -4,22 +4,25 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
     sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
 )
+
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
     sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
 )
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
-go_rules_dependencies()
-go_register_toolchains()
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-gazelle_dependencies()
 
-# Go dependencies of the update_deb_packages helper tool
-load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+gazelle_dependencies()
 
 # "golang.org/x/crypto/openpgp"
 go_repository(

--- a/deb_packages/deb_packages.bzl
+++ b/deb_packages/deb_packages.bzl
@@ -1,59 +1,61 @@
+# buildifier: disable=module-docstring
 def _deb_packages_impl(repository_ctx):
-  # check that keys in "packages" and "packages_sha256" are the same
-  for package in repository_ctx.attr.packages:
-    if package not in repository_ctx.attr.packages_sha256:
-      fail("Package named \"%s\" was not found in packages_sha256 of rule %s" % (package, repository_ctx.name))
+    # check that keys in "packages" and "packages_sha256" are the same
+    for package in repository_ctx.attr.packages:
+        if package not in repository_ctx.attr.packages_sha256:
+            fail("Package named \"%s\" was not found in packages_sha256 of rule %s" % (package, repository_ctx.name))
 
-  # download each package
-  package_rule_dict = {}
-  for package in repository_ctx.attr.packages:
-    urllist = []
-    for mirror in repository_ctx.attr.mirrors:
-      # allow mirror URLs that don't end in /
-      if mirror.endswith("/"):
-        urllist.append(mirror + repository_ctx.attr.packages[package])
-      else:
-        urllist.append(mirror + "/" + repository_ctx.attr.packages[package])
-    repository_ctx.download(
-        urllist,
-        output="debs/" + repository_ctx.attr.packages_sha256[package] + ".deb",
-        sha256=repository_ctx.attr.packages_sha256[package],
-        executable=False)
-    package_rule_dict[package] = "@" + repository_ctx.name + "//debs:" + repository_ctx.attr.packages_sha256[package] + ".deb"
+    # download each package
+    package_rule_dict = {}
+    for package in repository_ctx.attr.packages:
+        urllist = []
+        for mirror in repository_ctx.attr.mirrors:
+            # allow mirror URLs that don't end in /
+            if mirror.endswith("/"):
+                urllist.append(mirror + repository_ctx.attr.packages[package])
+            else:
+                urllist.append(mirror + "/" + repository_ctx.attr.packages[package])
+        repository_ctx.download(
+            urllist,
+            output = "debs/" + repository_ctx.attr.packages_sha256[package] + ".deb",
+            sha256 = repository_ctx.attr.packages_sha256[package],
+            executable = False,
+        )
+        package_rule_dict[package] = "@" + repository_ctx.name + "//debs:" + repository_ctx.attr.packages_sha256[package] + ".deb"
 
-  # create the deb_packages.bzl file that contains the package name : filename mapping
-  repository_ctx.file("debs/deb_packages.bzl", repository_ctx.name + " = " + struct(**package_rule_dict).to_json(), executable=False)
+    # create the deb_packages.bzl file that contains the package name : filename mapping
+    repository_ctx.file("debs/deb_packages.bzl", repository_ctx.name + " = " + struct(**package_rule_dict).to_json(), executable = False)
 
-  # create the BUILD file that globs all the deb files
-  repository_ctx.file("debs/BUILD", """
+    # create the BUILD file that globs all the deb files
+    repository_ctx.file("debs/BUILD", """
 package(default_visibility = ["//visibility:public"])
 deb_files = glob(["*.deb"])
 exports_files(deb_files + ["deb_packages.bzl"])
-""", executable=False)
+""", executable = False)
 
 _deb_packages = repository_rule(
     _deb_packages_impl,
     attrs = {
-        "distro_type": attr.string(
-            doc = "the name of the distribution type, required - e.g. debian or ubuntu",
+        "arch": attr.string(
+            doc = "the target package architecture, required - e.g. arm64 or amd64",
+        ),
+        "components": attr.string_list(
+            doc = "a list of accepted components - e.g. universe, multiverse",
         ),
         "distro": attr.string(
             doc = "the name of the distribution, required - e.g. wheezy or jessie-backports",
         ),
-        "arch": attr.string(
-            doc = "the target package architecture, required - e.g. arm64 or amd64",
+        "distro_type": attr.string(
+            doc = "the name of the distribution type, required - e.g. debian or ubuntu",
+        ),
+        "mirrors": attr.string_list(
+            doc = "a list of full URLs of the package repository, required - e.g. http://deb.debian.org/debian",
         ),
         "packages": attr.string_dict(
             doc = "a dictionary mapping packagename to package_path, required - e.g. {\"foo\":\"pool/main/f/foo/foo_1.2.3-0_amd64.deb\"}",
         ),
         "packages_sha256": attr.string_dict(
             doc = "a dictionary mapping packagename to package_hash, required - e.g. {\"foo\":\"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef\"}",
-        ),
-        "mirrors": attr.string_list(
-            doc = "a list of full URLs of the package repository, required - e.g. http://deb.debian.org/debian",
-        ),
-        "components": attr.string_list(
-            doc = "a list of accepted components - e.g. universe, multiverse",
         ),
         "pgp_key": attr.string(
             doc = "the name of the http_file rule that contains the pgp key that signed the Release file at <mirrorURL>/dists/<distro>/Release, required",
@@ -62,4 +64,4 @@ _deb_packages = repository_rule(
 )
 
 def deb_packages(**kwargs):
-  _deb_packages(**kwargs)
+    _deb_packages(**kwargs)

--- a/deb_packages/examples/deb_packages_base/BUILD
+++ b/deb_packages/examples/deb_packages_base/BUILD
@@ -1,3 +1,12 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@debian_jessie_amd64//debs:deb_packages.bzl", "debian_jessie_amd64")
+load("@debian_stretch_amd64//debs:deb_packages.bzl", "debian_stretch_amd64")
+load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_file")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
+load("//examples/deb_packages/deb_packages_base:cacerts.bzl", "cacerts")
+
 package(default_visibility = ["//visibility:public"])
 
 # Extracting the ca-certificates deb package
@@ -20,12 +29,6 @@ genrule(
            tar -cf $@ busybox",
 )
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
-load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-
 # Create a default passwd_file rule and put it in a tarball.
 
 passwd_file(
@@ -42,10 +45,6 @@ pkg_tar(
     mode = "0644",
     package_dir = "etc",
 )
-
-load("//examples/deb_packages/deb_packages_base:cacerts.bzl", "cacerts")
-load("@debian_jessie_amd64//debs:deb_packages.bzl", "debian_jessie_amd64")
-load("@debian_stretch_amd64//debs:deb_packages.bzl", "debian_stretch_amd64")
 
 cacerts(
     name = "cacerts_jessie",

--- a/deb_packages/examples/deb_packages_base/cacerts.bzl
+++ b/deb_packages/examples/deb_packages_base/cacerts.bzl
@@ -2,15 +2,16 @@
 
 def _impl(ctx):
     args = "%s %s %s" % (ctx.executable._extract.path, ctx.file.deb.path, ctx.outputs.out.path)
-    ctx.action(command = args,
-            inputs = [ctx.executable._extract, ctx.file.deb],
-            outputs = [ctx.outputs.out])
+    ctx.actions.run_shell(
+        command = args,
+        inputs = [ctx.executable._extract, ctx.file.deb],
+        outputs = [ctx.outputs.out],
+    )
 
 cacerts = rule(
     attrs = {
         "deb": attr.label(
-            allow_files = [".deb"],
-            single_file = True,
+            allow_single_file = [".deb"],
             mandatory = True,
         ),
         # Implicit dependencies.

--- a/deb_packages/tools/update_deb_packages/update_deb_packages.bzl
+++ b/deb_packages/tools/update_deb_packages/update_deb_packages.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# buildifier: disable=module-docstring
 _script_content = """
 BASE=$(pwd)
 WORKSPACE=$(dirname $(readlink WORKSPACE))
@@ -20,14 +21,14 @@ $BASE/{update_deb_packages} {args} $@
 """
 
 def _update_deb_packages_script_impl(ctx):
-  args = ctx.attr.args
-  script_content = _script_content.format(update_deb_packages=ctx.file._update_deb_packages.short_path, args=" ".join(args))
-  script_file = ctx.new_file(ctx.label.name+".bash")
-  ctx.file_action(output=script_file, executable=True, content=script_content)
-  return struct(
-    files = depset([script_file]),
-    runfiles = ctx.runfiles([ctx.file._update_deb_packages])
-  )
+    args = ctx.attr.args
+    script_content = _script_content.format(update_deb_packages = ctx.file._update_deb_packages.short_path, args = " ".join(args))
+    script_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    ctx.actions.write(output = script_file, is_executable = True, content = script_content)
+    return DefaultInfo(
+        files = depset([script_file]),
+        runfiles = ctx.runfiles([ctx.file._update_deb_packages]),
+    )
 
 _update_deb_packages_script = rule(
     _update_deb_packages_script_impl,
@@ -44,15 +45,15 @@ _update_deb_packages_script = rule(
 )
 
 def update_deb_packages(name, pgp_keys, **kwargs):
-  script_name = name+"_script"
-  _update_deb_packages_script(
-      name = script_name,
-      tags = ["manual"],
-      **kwargs
-  )
-  native.sh_binary(
-      name = name,
-      srcs = [script_name],
-      data = ["//:WORKSPACE"] + pgp_keys,
-      tags = ["manual"],
-  )
+    script_name = name + "_script"
+    _update_deb_packages_script(
+        name = script_name,
+        tags = ["manual"],
+        **kwargs
+    )
+    native.sh_binary(
+        name = name,
+        srcs = [script_name],
+        data = ["//:WORKSPACE"] + pgp_keys,
+        tags = ["manual"],
+    )

--- a/deps.bzl
+++ b/deps.bzl
@@ -17,6 +17,7 @@
 #     load("//pkg:deps.bzl", "rules_pkg_dependencies")
 # going forward.
 
+# buildifier: disable=module-docstring
 load("//pkg:deps.bzl", _rules_pkg_dependencies = "rules_pkg_dependencies")
 
 rules_pkg_dependencies = _rules_pkg_dependencies

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@rules_python//python:defs.bzl", "py_test")
 load("//:version.bzl", "version")
 load("//pkg:pkg.bzl", "pkg_tar")
 load("//pkg/releasing:defs.bzl", "print_rel_notes")
 load("//pkg/releasing:git.bzl", "git_changelog")
-load("@rules_python//python:defs.bzl", "py_test")
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 licenses(["notice"])
 

--- a/examples/naming_package_files/BUILD
+++ b/examples/naming_package_files/BUILD
@@ -13,11 +13,11 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-licenses(["notice"])
-
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
-load(":package_upload.bzl", "debian_upload")
 load(":my_package_name.bzl", "basic_naming", "name_part_from_command_line", "names_from_toolchains")
+load(":package_upload.bzl", "debian_upload")
+
+licenses(["notice"])
 
 config_setting(
     name = "special_build",
@@ -25,21 +25,19 @@ config_setting(
 )
 
 VERSION = "1"
+
 REVISION = "2"
 
 # Exposes the value of the compilation mode to the package naming.
 basic_naming(
     name = "my_naming_vars",
 
-    # Explicit values to use in all package names
-    version = VERSION,
-    revision = REVISION,
-
     # We make the product name a variable rather than put it in every rule.
     # This technique can be useful if you need to create packages in many
     # different formats but have not decided on the final naming yet. You
     # can use a placeholder and change it on one location.
     product_name = "RulesPkgExamples",
+    revision = REVISION,
 
     # Use a config_setting flag to specify part of the package name.
     # In this example, we define the config_setting based on a command line
@@ -50,6 +48,9 @@ basic_naming(
         ":special_build": "-IsSpecial",
         "//conditions:default": "",
     }),
+
+    # Explicit values to use in all package names
+    version = VERSION,
 )
 
 # Try building with various flag combinations to explore.
@@ -73,8 +74,8 @@ pkg_tar(
     srcs = [
         ":BUILD",
     ],
-    package_file_name = "example2-{product_name}-{target_cpu}-{compilation_mode}{special_build}.tar",
     package_dir = "example1/{product_name}/{target_cpu}/{compilation_mode}{special_build}",
+    package_file_name = "example2-{product_name}-{target_cpu}-{compilation_mode}{special_build}.tar",
     package_variables = ":my_naming_vars",
 )
 

--- a/examples/naming_package_files/WORKSPACE
+++ b/examples/naming_package_files/WORKSPACE
@@ -21,16 +21,13 @@ local_repository(
     path = "../..",
 )
 
-http_archive
-
-
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
 http_archive(
     name = "rules_cc",
-    url = "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
     sha256 = "d0c573b94a6ef20ef6ff20154a23d0efcb409fb0e1ff0979cec318dfe42f0cdd",
     strip_prefix = "rules_cc-b1c40e1de81913a3c40e5948f78719c28152486d",
+    url = "https://github.com/bazelbuild/rules_cc/archive/b1c40e1de81913a3c40e5948f78719c28152486d.zip",
 )

--- a/examples/naming_package_files/my_package_name.bzl
+++ b/examples/naming_package_files/my_package_name.bzl
@@ -14,8 +14,8 @@
 
 """Example rules to show package naming techniques."""
 
-load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
+load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
 
 def _basic_naming_impl(ctx):
     values = {}
@@ -44,11 +44,11 @@ basic_naming = rule(
         "revision": attr.string(
             doc = "Placeholder for our release revision.",
         ),
-        "version": attr.string(
-            doc = "Placeholder for our release version.",
-        ),
         "special_build": attr.string(
             doc = "Indicates that we have built with a 'special' option.",
+        ),
+        "version": attr.string(
+            doc = "Placeholder for our release version.",
         ),
     },
 )
@@ -97,6 +97,7 @@ names_from_toolchains = rule(
 #
 def _name_part_from_command_line_naming_impl(ctx):
     values = {"name_part": ctx.build_setting_value}
+
     # Just pass the value from the command line through. An implementation
     # could also perform validation, such as done in
     # https://github.com/bazelbuild/bazel-skylib/blob/master/rules/common_settings.bzl

--- a/examples/naming_package_files/package_upload.bzl
+++ b/examples/naming_package_files/package_upload.bzl
@@ -33,11 +33,6 @@ debian_upload = rule(
     implementation = _debian_upload_impl,
     doc = """A demonstraion of consuming PackageArtifactInfo to get a file name.""",
     attrs = {
-        "package": attr.label(
-            doc = "Package to upload",
-            mandatory = True,
-            providers = [PackageArtifactInfo],
-        ),
         "host": attr.string(
             doc = "Host to upload to",
             mandatory = True,
@@ -45,6 +40,11 @@ debian_upload = rule(
         "out": attr.output(
             doc = "Script file to create.",
             mandatory = True,
+        ),
+        "package": attr.label(
+            doc = "Package to upload",
+            mandatory = True,
+            providers = [PackageArtifactInfo],
         ),
     },
 )

--- a/examples/rich_structure/BUILD
+++ b/examples/rich_structure/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
+load("@rules_pkg//:mappings.bzl", "pkg_filegroup", "pkg_files", "strip_prefix")
 load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
 
 # This is the top level BUILD for a hypothetical project Foo.  It has a client,
@@ -28,10 +28,10 @@ pkg_files(
     srcs = [
         "//docs",
     ],
-    # Required, but why?: see #354
-    strip_prefix = strip_prefix.from_pkg(),
     # Where it should be in the final package
     prefix = "usr/share/doc/foo",
+    # Required, but why?: see #354
+    strip_prefix = strip_prefix.from_pkg(),
 )
 
 pkg_filegroup(
@@ -42,7 +42,6 @@ pkg_filegroup(
     ],
     prefix = "/usr/share",
 )
-
 
 pkg_tar(
     name = "foo_tar",

--- a/examples/rich_structure/WORKSPACE
+++ b/examples/rich_structure/WORKSPACE
@@ -14,8 +14,6 @@
 
 workspace(name = "rich_structure")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "rules_pkg",
     path = "../..",

--- a/examples/rich_structure/docs/BUILD
+++ b/examples/rich_structure/docs/BUILD
@@ -2,6 +2,9 @@
 
 filegroup(
     name = "docs",
-    srcs = glob(["**/*"], exclude=["BUILD"]),
+    srcs = glob(
+        ["**/*"],
+        exclude = ["BUILD"],
+    ),
     visibility = ["//visibility:public"],
 )

--- a/examples/rich_structure/resources/l10n/BUILD
+++ b/examples/rich_structure/resources/l10n/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//:foo_defs.bzl", "shared_object_path_selector")
 
 # There are localized message catalogs for all the components.

--- a/examples/rich_structure/src/client/BUILD
+++ b/examples/rich_structure/src/client/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//:foo_defs.bzl", "shared_object_path_selector")

--- a/examples/rich_structure/src/server/BUILD
+++ b/examples/rich_structure/src/server/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//:foo_defs.bzl", "shared_object_path_selector")
 
 cc_library(
     name = "foolib",

--- a/examples/time_stamping/BUILD
+++ b/examples/time_stamping/BUILD
@@ -13,9 +13,9 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-licenses(["notice"])
-
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+licenses(["notice"])
 
 pkg_tar(
     name = "never_stamped",

--- a/examples/where_is_my_output/WORKSPACE
+++ b/examples/where_is_my_output/WORKSPACE
@@ -14,8 +14,6 @@
 
 workspace(name = "rich_structure")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 local_repository(
     name = "rules_pkg",
     path = "../..",

--- a/examples/where_is_my_output/show_deb_outputs.bzl
+++ b/examples/where_is_my_output/show_deb_outputs.bzl
@@ -19,9 +19,12 @@
 #   bazel cquery //:debian --output=starlark --starlark:file=show_deb_outputs.bzl
 #
 
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring
 def format(target):
     provider_map = providers(target)
     output_group_info = provider_map["OutputGroupInfo"]
+
     # Look at the attributes of the provider. Visit the depsets.
     ret = []
     for attr in dir(output_group_info):

--- a/mappings.bzl
+++ b/mappings.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# buildifier: disable=module-docstring
 load(
     "//pkg:mappings.bzl",
     _filter_directory = "filter_directory",

--- a/package_variables.bzl
+++ b/package_variables.bzl
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//pkg/package_variables.bzl",
+# buildifier: disable=module-docstring
+load(
+    "//pkg/package_variables.bzl",
     _add_ctx_variables = "add_ctx_variables",
 )
+
 add_ctx_variables = _add_ctx_variables

--- a/pkg.bzl
+++ b/pkg.bzl
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# buildifier: disable=module-docstring
 load(
     "//pkg:pkg.bzl",
     _pkg_deb = "pkg_deb",

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -59,8 +59,8 @@ py_binary(
     #}),
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/private:archive",
         "//pkg:make_rpm_lib",
+        "//pkg/private:archive",
     ],
 )
 

--- a/pkg/deb.bzl
+++ b/pkg/deb.bzl
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# buildifier: disable=module-docstring
 load("//pkg/private/deb:deb.bzl", _pkg_deb = "pkg_deb")
 
 pkg_deb = _pkg_deb

--- a/pkg/deps.bzl
+++ b/pkg/deps.bzl
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Workspace dependencies for rules_pkg/pkg
+"""Workspace dependencies for rules_pkg/pkg"""
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
@@ -36,7 +35,6 @@ def rules_pkg_dependencies():
         url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
         sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
     )
-
 
 def rules_pkg_register_toolchains():
     pass

--- a/pkg/install.bzl
+++ b/pkg/install.bzl
@@ -19,9 +19,9 @@ run`-able installation script.
 
 """
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("//pkg:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 load("//pkg/private:pkg_files.bzl", "process_src", "write_manifest")
-load("@rules_python//python:defs.bzl", "py_binary")
 
 def _pkg_install_script_impl(ctx):
     script_file = ctx.actions.declare_file(ctx.attr.name + ".py")
@@ -50,7 +50,7 @@ def _pkg_install_script_impl(ctx):
     # This is super brittle, but I don't know how to otherwise get this
     # information without creating a circular dependency given the current state
     # of rules_python.
-    
+
     # The name of the binary is the name of this target, minus
     # "_install_script".
     label_str = str(ctx.label)[:-len("_install_script")]
@@ -60,11 +60,11 @@ def _pkg_install_script_impl(ctx):
         output = script_file,
         substitutions = {
             "{MANIFEST_INCLUSION}": manifest_file.short_path,
+            # Used to annotate --help with "bazel run //path/to/your:installer"
+            "{TARGET_LABEL}": label_str,
             # This is used to extend the manifest paths when the script is run
             # inside a build.
             "{WORKSPACE_NAME}": ctx.workspace_name,
-            # Used to annotate --help with "bazel run //path/to/your:installer"
-            "{TARGET_LABEL}": label_str,
         },
         is_executable = True,
     )
@@ -141,7 +141,7 @@ def pkg_install(name, srcs, **kwargs):
     ```
     bazel run -- //path/to:install --help
     ```
-    
+
     WARNING: While this rule does function when being run from within a bazel
     rule, such use is not recommended.  If you do, **always** use the
     `--destdir` argument to specify the desired location for the installation to

--- a/pkg/legacy/rpm.bzl
+++ b/pkg/legacy/rpm.bzl
@@ -36,10 +36,10 @@ def _pkg_rpm_impl(ctx):
     tools = []
     args = ["--name=" + ctx.label.name]
     if ctx.attr.debug:
-        args += ["--debug"]
+        args.append("--debug")
 
     if ctx.attr.rpmbuild_path:
-        args += ["--rpmbuild=" + ctx.attr.rpmbuild_path]
+        args.append("--rpmbuild=" + ctx.attr.rpmbuild_path)
 
         # buildifier: disable=print
         print("rpmbuild_path is deprecated. See the README for instructions on how" +
@@ -50,7 +50,7 @@ def _pkg_rpm_impl(ctx):
             fail("The rpmbuild_toolchain is not properly configured: " +
                  toolchain.name)
         if toolchain.path:
-            args += ["--rpmbuild=" + toolchain.path]
+            args.append("--rpmbuild=" + toolchain.path)
         else:
             executable_files = toolchain.label[DefaultInfo].files_to_run
             tools.append(executable_files)
@@ -60,31 +60,31 @@ def _pkg_rpm_impl(ctx):
     if ctx.attr.version_file:
         if ctx.attr.version:
             fail("Both version and version_file attributes were specified")
-        args += ["--version=@" + ctx.file.version_file.path]
-        files += [ctx.file.version_file]
+        args.append("--version=@" + ctx.file.version_file.path)
+        files.append(ctx.file.version_file)
     elif ctx.attr.version:
-        args += ["--version=" + ctx.attr.version]
+        args.append("--version=" + ctx.attr.version)
 
     # Release can be specified by a file or inlined.
     if ctx.attr.release_file:
         if ctx.attr.release:
             fail("Both release and release_file attributes were specified")
-        args += ["--release=@" + ctx.file.release_file.path]
-        files += [ctx.file.release_file]
+        args.append("--release=@" + ctx.file.release_file.path)
+        files.append(ctx.file.release_file)
     elif ctx.attr.release:
-        args += ["--release=" + ctx.attr.release]
+        args.append("--release=" + ctx.attr.release)
 
     # SOURCE_DATE_EPOCH can be specified by a file or inlined.
     if ctx.attr.source_date_epoch_file:
         if ctx.attr.source_date_epoch:
             fail("Both source_date_epoch and source_date_epoch_file attributes were specified")
-        args += ["--source_date_epoch=@" + ctx.file.source_date_epoch_file.path]
-        files += [ctx.file.source_date_epoch_file]
+        args.append("--source_date_epoch=@" + ctx.file.source_date_epoch_file.path)
+        files.append(ctx.file.source_date_epoch_file)
     elif ctx.attr.source_date_epoch != None:
-        args += ["--source_date_epoch=" + str(ctx.attr.source_date_epoch)]
+        args.append("--source_date_epoch=" + str(ctx.attr.source_date_epoch))
 
     if ctx.attr.architecture:
-        args += ["--arch=" + ctx.attr.architecture]
+        args.append("--arch=" + ctx.attr.architecture)
 
     if not ctx.attr.spec_file:
         fail("spec_file was not specified")
@@ -102,19 +102,19 @@ def _pkg_rpm_impl(ctx):
         output = spec_file,
         substitutions = substitutions,
     )
-    args += ["--spec_file=" + spec_file.path]
-    files += [spec_file]
+    args.append("--spec_file=" + spec_file.path)
+    files.append(spec_file)
 
-    args += ["--out_file=" + ctx.outputs.rpm.path]
+    args.append("--out_file=" + ctx.outputs.rpm.path)
 
     # Add data files.
     if ctx.file.changelog:
-        files += [ctx.file.changelog]
-        args += [ctx.file.changelog.path]
+        files.append(ctx.file.changelog)
+        args.append(ctx.file.changelog.path)
     files += ctx.files.data
 
     for f in ctx.files.data:
-        args += [f.path]
+        args.append(f.path)
 
     # Call the generator script.
     ctx.actions.run(
@@ -163,15 +163,7 @@ def _pkg_rpm_outputs(version, release):
 # Define the rule.
 pkg_rpm = rule(
     attrs = {
-        "spec_file": attr.label(
-            mandatory = True,
-            allow_single_file = spec_filetype,
-        ),
         "architecture": attr.string(default = "all"),
-        "version_file": attr.label(
-            allow_single_file = True,
-        ),
-        "version": attr.string(),
         "changelog": attr.label(
             allow_single_file = True,
         ),
@@ -179,14 +171,22 @@ pkg_rpm = rule(
             mandatory = True,
             allow_files = True,
         ),
-        "release_file": attr.label(allow_single_file = True),
-        "release": attr.string(),
-        "source_date_epoch_file": attr.label(allow_single_file = True),
-        "source_date_epoch": attr.int(),
         "debug": attr.bool(default = False),
+        "release": attr.string(),
+        "release_file": attr.label(allow_single_file = True),
 
         # Implicit dependencies.
         "rpmbuild_path": attr.string(),  # deprecated
+        "source_date_epoch": attr.int(),
+        "source_date_epoch_file": attr.label(allow_single_file = True),
+        "spec_file": attr.label(
+            mandatory = True,
+            allow_single_file = spec_filetype,
+        ),
+        "version": attr.string(),
+        "version_file": attr.label(
+            allow_single_file = True,
+        ),
         "_make_rpm": attr.label(
             default = Label("//pkg:make_rpm"),
             cfg = "exec",

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -27,8 +27,8 @@ Rules that actually make use of the outputs of the above rules are not specified
 here.
 """
 
-load("//pkg:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//pkg:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
 
 # TODO(#333): strip_prefix module functions should produce unique outputs.  In
 # particular, this one and `_sp_from_pkg` can overlap.

--- a/pkg/package_variables.bzl
+++ b/pkg/package_variables.bzl
@@ -16,6 +16,6 @@
 
 def add_ctx_variables(ctx, values):
     """Add selected variables from ctx."""
-    values['target_cpu'] = ctx.var.get("TARGET_CPU")
-    values['compilation_mode'] = ctx.var.get("COMPILATION_MODE")
+    values["target_cpu"] = ctx.var.get("TARGET_CPU")
+    values["compilation_mode"] = ctx.var.get("COMPILATION_MODE")
     return values

--- a/pkg/path.bzl
+++ b/pkg/path.bzl
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helper functions that don't depend on Skylark, so can be unit tested."""
+"""Helper functions that don't depend on Starlark, so can be unit tested."""
 
+# buildifier: disable=function-docstring-return
+# buildifier: disable=function-docstring-args
 def safe_short_path(file_):
     """Like `File.short_path` but safe for use with files from external repositories.
     """
@@ -27,7 +29,7 @@ def safe_short_path(file_):
     # Beginning with `file_.path`, remove optional `F.root.path`.
     working_path = file_.path
     if not file_.is_source:
-        working_path = working_path[len(file_.root.path)+1:]
+        working_path = working_path[len(file_.root.path) + 1:]
     return working_path
 
 def _short_path_dirname(path):
@@ -39,6 +41,8 @@ def _short_path_dirname(path):
         return ""
     return sp[:last_pkg]
 
+# buildifier: disable=function-docstring-args
+# buildifier: disable=function-docstring-return
 def dest_path(f, strip_prefix, data_path_without_prefix = ""):
     """Returns the short path of f, stripped of strip_prefix."""
     f_short_path = safe_short_path(f)
@@ -56,23 +60,24 @@ def dest_path(f, strip_prefix, data_path_without_prefix = ""):
 
         # Avoid stripping prefix if final directory is incomplete
         if prefix_last_dir not in f_short_path.split("/"):
-          strip_prefix = data_path_without_prefix
+            strip_prefix = data_path_without_prefix
 
         return f_short_path[len(strip_prefix):]
     return f_short_path
 
+# buildifier: disable=function-docstring-return
 def compute_data_path(ctx, data_path):
     """Compute the relative data path prefix from the data_path attribute.
 
     Args:
-      ctx: rule implementation ctx.
-      data_path: path to a file, relative to the package of the rule ctx.
+        ctx: rule implementation ctx.
+        data_path: path to a file, relative to the package of the rule ctx.
     """
     build_dir = ctx.label.package
     if data_path:
         # Strip ./ from the beginning if specified.
         # There is no way to handle .// correctly (no function that would make
-        # that possible and Skylark is not turing complete) so just consider it
+        # that possible and Starlark is not turing complete) so just consider it
         # as an absolute path.
         if len(data_path) >= 2 and data_path[0:2] == "./":
             data_path = data_path[2:]

--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -16,7 +16,7 @@
 All interfaces are subject to change at any time.
 """
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 licenses(["notice"])
 

--- a/pkg/private/deb/BUILD
+++ b/pkg/private/deb/BUILD
@@ -16,7 +16,7 @@
 All interfaces are subject to change at any time.
 """
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 filegroup(
     name = "standard_package",

--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -50,39 +50,39 @@ def _pkg_deb_impl(ctx):
     if ctx.attr.architecture_file:
         if ctx.attr.architecture != "all":
             fail("Both architecture and architecture_file attributes were specified")
-        args += ["--architecture=@" + ctx.file.architecture_file.path]
-        files += [ctx.file.architecture_file]
+        args.append("--architecture=@" + ctx.file.architecture_file.path)
+        files.append(ctx.file.architecture_file)
     else:
-        args += ["--architecture=" + ctx.attr.architecture]
+        args.append("--architecture=" + ctx.attr.architecture)
 
     if ctx.attr.preinst:
-        args += ["--preinst=@" + ctx.file.preinst.path]
-        files += [ctx.file.preinst]
+        args.append("--preinst=@" + ctx.file.preinst.path)
+        files.append(ctx.file.preinst)
     if ctx.attr.postinst:
-        args += ["--postinst=@" + ctx.file.postinst.path]
-        files += [ctx.file.postinst]
+        args.append("--postinst=@" + ctx.file.postinst.path)
+        files.append(ctx.file.postinst)
     if ctx.attr.prerm:
-        args += ["--prerm=@" + ctx.file.prerm.path]
-        files += [ctx.file.prerm]
+        args.append("--prerm=@" + ctx.file.prerm.path)
+        files.append(ctx.file.prerm)
     if ctx.attr.postrm:
-        args += ["--postrm=@" + ctx.file.postrm.path]
-        files += [ctx.file.postrm]
+        args.append("--postrm=@" + ctx.file.postrm.path)
+        files.append(ctx.file.postrm)
     if ctx.attr.config:
-        args += ["--config=@" + ctx.file.config.path]
-        files += [ctx.file.config]
+        args.append("--config=@" + ctx.file.config.path)
+        files.append(ctx.file.config)
     if ctx.attr.templates:
-        args += ["--templates=@" + ctx.file.templates.path]
-        files += [ctx.file.templates]
+        args.append("--templates=@" + ctx.file.templates.path)
+        files.append(ctx.file.templates)
     if ctx.attr.triggers:
-        args += ["--triggers=@" + ctx.file.triggers.path]
-        files += [ctx.file.triggers]
+        args.append("--triggers=@" + ctx.file.triggers.path)
+        files.append(ctx.file.triggers)
 
     # Conffiles can be specified by a file or a string list
     if ctx.attr.conffiles_file:
         if ctx.attr.conffiles:
             fail("Both conffiles and conffiles_file attributes were specified")
-        args += ["--conffile=@" + ctx.file.conffiles_file.path]
-        files += [ctx.file.conffiles_file]
+        args.append("--conffile=@" + ctx.file.conffiles_file.path)
+        files.append(ctx.file.conffiles_file)
     elif ctx.attr.conffiles:
         args += ["--conffile=%s" % cf for cf in ctx.attr.conffiles]
 
@@ -90,20 +90,20 @@ def _pkg_deb_impl(ctx):
     if ctx.attr.version_file:
         if ctx.attr.version:
             fail("Both version and version_file attributes were specified")
-        args += ["--version=@" + ctx.file.version_file.path]
-        files += [ctx.file.version_file]
+        args.append("--version=@" + ctx.file.version_file.path)
+        files.append(ctx.file.version_file)
     elif ctx.attr.version:
-        args += ["--version=" + ctx.attr.version]
+        args.append("--version=" + ctx.attr.version)
     else:
         fail("Neither version_file nor version attribute was specified")
 
     if ctx.attr.description_file:
         if ctx.attr.description:
             fail("Both description and description_file attributes were specified")
-        args += ["--description=@" + ctx.file.description_file.path]
-        files += [ctx.file.description_file]
+        args.append("--description=@" + ctx.file.description_file.path)
+        files.append(ctx.file.description_file)
     elif ctx.attr.description:
-        args += ["--description=" + ctx.attr.description]
+        args.append("--description=" + ctx.attr.description)
     else:
         fail("Neither description_file nor description attribute was specified")
 
@@ -111,28 +111,28 @@ def _pkg_deb_impl(ctx):
     if ctx.attr.built_using_file:
         if ctx.attr.built_using:
             fail("Both build_using and built_using_file attributes were specified")
-        args += ["--built_using=@" + ctx.file.built_using_file.path]
-        files += [ctx.file.built_using_file]
+        args.append("--built_using=@" + ctx.file.built_using_file.path)
+        files.append(ctx.file.built_using_file)
     elif ctx.attr.built_using:
-        args += ["--built_using=" + ctx.attr.built_using]
+        args.append("--built_using=" + ctx.attr.built_using)
 
     if ctx.attr.depends_file:
         if ctx.attr.depends:
             fail("Both depends and depends_file attributes were specified")
-        args += ["--depends=@" + ctx.file.depends_file.path]
-        files += [ctx.file.depends_file]
+        args.append("--depends=@" + ctx.file.depends_file.path)
+        files.append(ctx.file.depends_file)
     elif ctx.attr.depends:
         args += ["--depends=" + d for d in ctx.attr.depends]
 
     if ctx.attr.priority:
-        args += ["--priority=" + ctx.attr.priority]
+        args.append("--priority=" + ctx.attr.priority)
     if ctx.attr.section:
-        args += ["--section=" + ctx.attr.section]
+        args.append("--section=" + ctx.attr.section)
     if ctx.attr.homepage:
-        args += ["--homepage=" + ctx.attr.homepage]
+        args.append("--homepage=" + ctx.attr.homepage)
 
-    args += ["--distribution=" + ctx.attr.distribution]
-    args += ["--urgency=" + ctx.attr.urgency]
+    args.append("--distribution=" + ctx.attr.distribution)
+    args.append("--urgency=" + ctx.attr.urgency)
     args += ["--suggests=" + d for d in ctx.attr.suggests]
     args += ["--enhances=" + d for d in ctx.attr.enhances]
     args += ["--conflicts=" + d for d in ctx.attr.conflicts]
@@ -156,9 +156,9 @@ def _pkg_deb_impl(ctx):
         },
     )
     output_groups = {
-        "out": [ctx.outputs.out],
-        "deb": [output_file],
         "changes": [changes_file],
+        "deb": [output_file],
+        "out": [ctx.outputs.out],
     }
     return [
         OutputGroupInfo(**output_groups),
@@ -177,16 +177,6 @@ def _pkg_deb_impl(ctx):
 pkg_deb_impl = rule(
     implementation = _pkg_deb_impl,
     attrs = {
-        # @unsorted-dict-items
-        "data": attr.label(
-            doc = """A tar file that contains the data for the debian package.""",
-            mandatory = True,
-            allow_single_file = _tar_filetype,
-        ),
-        "package": attr.string(
-            doc = "The name of the package",
-            mandatory = True,
-        ),
         "architecture": attr.string(
             default = "all",
             doc = """Package architecture. Must not be used with architecture_file.""",
@@ -196,74 +186,16 @@ pkg_deb_impl = rule(
             Must not be used with architecture.""",
             allow_single_file = True,
         ),
-        "maintainer": attr.string(
-            doc = "The maintainer of the package.",
-            mandatory = True,
-        ),
-        "version": attr.string(
-            doc = """Package version. Must not be used with `version_file`.""",
-        ),
-        "version_file": attr.label(
-            doc = """File that contains the package version.
-            Must not be used with `version`.""",
-            allow_single_file = True,
-        ),
-        "config": attr.label(
-            doc = """config file used for debconf integration.
-            See https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts.""",
-            allow_single_file = True,
-        ),
-        "description": attr.string(
-            doc = """The package description. Must not be used with `description_file`.""",
-        ),
-        "description_file": attr.label(
-            doc = """The package description. Must not be used with `description`.""",
-            allow_single_file = True
-        ),
-        "distribution": attr.string(
-            doc = """"distribution: See http://www.debian.org/doc/debian-policy.""",
-            default = "unstable",
-        ),
-        "urgency": attr.string(
-            doc = """"urgency: See http://www.debian.org/doc/debian-policy.""",
-            default = "medium",
-        ),
-        "preinst": attr.label(
-            doc = """"The pre-install script for the package.
-            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
-            allow_single_file = True,
-        ),
-        "postinst": attr.label(
-            doc = """The post-install script for the package.
-            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
-            allow_single_file = True,
-        ),
-        "prerm": attr.label(
-            doc = """The pre-remove script for the package.
-            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
-            allow_single_file = True,
-        ),
-        "postrm": attr.label(
-            doc = """The post-remove script for the package.
-            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
-            allow_single_file = True,
-        ),
-        "templates": attr.label(
-            doc = """templates file used for debconf integration.
-            See https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts.""",
-            allow_single_file = True,
-        ),
-        "triggers": attr.label(
-            doc = """triggers file for configuring installation events exchanged by packages.
-            See https://wiki.debian.org/DpkgTriggers.""",
-            allow_single_file = True,
+        "breaks": attr.string_list(
+            doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
+            default = [],
         ),
         "built_using": attr.string(
-            doc="""The tool that were used to build this package provided either inline (with built_using) or from a file (with built_using_file)."""
+            doc = """The tool that were used to build this package provided either inline (with built_using) or from a file (with built_using_file).""",
         ),
         "built_using_file": attr.label(
-            doc="""The tool that were used to build this package provided either inline (with built_using) or from a file (with built_using_file).""",
-            allow_single_file = True
+            doc = """The tool that were used to build this package provided either inline (with built_using) or from a file (with built_using_file).""",
+            allow_single_file = True,
         ),
         "conffiles": attr.string_list(
             doc = """The list of conffiles or a file containing one conffile per line. Each item is an absolute path on the target system where the deb is installed.
@@ -275,23 +207,20 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
 See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
             allow_single_file = True,
         ),
-        "priority": attr.string(
-            doc = """The priority of the package.
-            See http://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities.""",
-        ),
-        "section": attr.string(
-            doc = """The section of the package.
-            See http://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections.""",
-        ),
-        "homepage": attr.string(doc = """The homepage of the project."""),
-
-        "breaks": attr.string_list(
-            doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
-            default = [],
+        "config": attr.label(
+            doc = """config file used for debconf integration.
+            See https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts.""",
+            allow_single_file = True,
         ),
         "conflicts": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
+        ),
+        # @unsorted-dict-items
+        "data": attr.label(
+            doc = """A tar file that contains the data for the debian package.""",
+            mandatory = True,
+            allow_single_file = _tar_filetype,
         ),
         "depends": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
@@ -302,15 +231,73 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
             See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             allow_single_file = True,
         ),
+        "description": attr.string(
+            doc = """The package description. Must not be used with `description_file`.""",
+        ),
+        "description_file": attr.label(
+            doc = """The package description. Must not be used with `description`.""",
+            allow_single_file = True,
+        ),
+        "distribution": attr.string(
+            doc = """"distribution: See http://www.debian.org/doc/debian-policy.""",
+            default = "unstable",
+        ),
         "enhances": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
         ),
-        "provides": attr.string_list(
+        "homepage": attr.string(doc = """The homepage of the project."""),
+        "maintainer": attr.string(
+            doc = "The maintainer of the package.",
+            mandatory = True,
+        ),
+
+        # Common attributes
+        "out": attr.output(
+            doc = """See Common Attributes""",
+            mandatory = True,
+        ),
+        "package": attr.string(
+            doc = "The name of the package",
+            mandatory = True,
+        ),
+        "package_file_name": attr.string(
+            doc = """See Common Attributes.
+            Default: "{package}-{version}-{architecture}.deb""",
+        ),
+        "package_variables": attr.label(
+            doc = """See Common Attributes""",
+            providers = [PackageVariablesInfo],
+        ),
+        "postinst": attr.label(
+            doc = """The post-install script for the package.
+            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
+            allow_single_file = True,
+        ),
+        "postrm": attr.label(
+            doc = """The post-remove script for the package.
+            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
+            allow_single_file = True,
+        ),
+        "predepends": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
         ),
-        "predepends": attr.string_list(
+        "preinst": attr.label(
+            doc = """"The pre-install script for the package.
+            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
+            allow_single_file = True,
+        ),
+        "prerm": attr.label(
+            doc = """The pre-remove script for the package.
+            See http://www.debian.org/doc/debian-policy/ch-maintainerscripts.html.""",
+            allow_single_file = True,
+        ),
+        "priority": attr.string(
+            doc = """The priority of the package.
+            See http://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities.""",
+        ),
+        "provides": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
         ),
@@ -322,23 +309,35 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
         ),
+        "section": attr.string(
+            doc = """The section of the package.
+            See http://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections.""",
+        ),
         "suggests": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
         ),
-
-        # Common attributes
-        "out": attr.output(
-            doc = """See Common Attributes""",
-            mandatory = True
+        "templates": attr.label(
+            doc = """templates file used for debconf integration.
+            See https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts.""",
+            allow_single_file = True,
         ),
-        "package_file_name": attr.string(
-            doc = """See Common Attributes.
-            Default: "{package}-{version}-{architecture}.deb""",
+        "triggers": attr.label(
+            doc = """triggers file for configuring installation events exchanged by packages.
+            See https://wiki.debian.org/DpkgTriggers.""",
+            allow_single_file = True,
         ),
-        "package_variables": attr.label(
-            doc = """See Common Attributes""",
-            providers = [PackageVariablesInfo],
+        "urgency": attr.string(
+            doc = """"urgency: See http://www.debian.org/doc/debian-policy.""",
+            default = "medium",
+        ),
+        "version": attr.string(
+            doc = """Package version. Must not be used with `version_file`.""",
+        ),
+        "version_file": attr.label(
+            doc = """File that contains the package version.
+            Must not be used with `version`.""",
+            allow_single_file = True,
         ),
 
         # Implicit dependencies.
@@ -352,6 +351,7 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
     provides = [PackageArtifactInfo],
 )
 
+# buildifier: disable=function-docstring-args
 def pkg_deb(name, archive_name = None, **kwargs):
     """Creates a deb file. See pkg_deb_impl."""
     if archive_name:

--- a/pkg/providers.bzl
+++ b/pkg/providers.bzl
@@ -84,8 +84,8 @@ PackageFilegroupInfo = provider(
 
     """,
     fields = {
-        "pkg_files": "list of tuples of (PackageFilesInfo, origin)",
         "pkg_dirs": "list of tuples of (PackageDirsInfo, origin)",
+        "pkg_files": "list of tuples of (PackageFilesInfo, origin)",
         "pkg_symlinks": "list of tuples of (PackageSymlinkInfo, origin)",
     },
 )

--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -1,5 +1,4 @@
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
-load("git.bzl", "git_changelog")
 
 licenses(["notice"])
 
@@ -21,10 +20,11 @@ package(
 filegroup(
     name = "standard_package",
     srcs = glob([
-        "BUILD",
         "*.bzl",
         "*.py",
-    ]),
+    ]) + [
+        "BUILD",
+    ],
     visibility = ["//distro:__pkg__"],
 )
 

--- a/pkg/releasing/defs.bzl
+++ b/pkg/releasing/defs.bzl
@@ -1,3 +1,5 @@
+# buildifier: disable=module-docstring
+# buildifier: disable=function-docstring
 def print_rel_notes(
         name,
         repo,
@@ -10,6 +12,7 @@ def print_rel_notes(
         changelog = None,
         mirror_host = None):
     tarball_name = ":%s-%s.tar.gz" % (repo, version)
+
     # Must use Label to get a path relative to the rules_pkg repository,
     # instead of the calling BUILD file.
     print_rel_notes_helper = Label("//pkg/releasing:print_rel_notes")
@@ -29,6 +32,7 @@ def print_rel_notes(
         cmd.append("--toolchains_method=%s" % toolchains_method)
     if changelog:
         cmd.append("--changelog=$(location %s)" % changelog)
+
         # We should depend on a changelog as a tool so that it is always built
         # for the host configuration. If the changelog is generated on the fly,
         # then we would have to run commands against our revision control

--- a/pkg/releasing/git.bzl
+++ b/pkg/releasing/git.bzl
@@ -63,11 +63,11 @@ _git_changelog = rule(
             doc = "lower commit ref. The default is to use the latest tag",
             default = "_LATEST_TAG_",
         ),
+        "out": attr.output(mandatory = True),
         "to_ref": attr.string(
             doc = "upper commit ref. The default is HEAD",
             default = "HEAD",
         ),
-        "out": attr.output(mandatory = True),
         "verbose": attr.bool(
             doc = "Be verbose",
             default = False,
@@ -83,7 +83,6 @@ _git_changelog = rule(
     toolchains = ["@rules_pkg//toolchains/git:git_toolchain_type"],
 )
 
-
 def git_changelog(name, **kwargs):
     _git_changelog(
         name = name,
@@ -93,5 +92,5 @@ def git_changelog(name, **kwargs):
             str(Label("//toolchains/git:have_git")): [],
             "//conditions:default": ["//:not_compatible"],
         }),
-        **kwargs,
+        **kwargs
     )

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -29,8 +29,8 @@ The mechanism for choosing between the two is documented in the function itself.
 
 """
 
-load("//pkg/legacy:rpm.bzl", pkg_rpm_legacy = "pkg_rpm")
 load("//pkg:rpm_pfg.bzl", pkg_rpm_pfg = "pkg_rpm")
+load("//pkg/legacy:rpm.bzl", pkg_rpm_legacy = "pkg_rpm")
 
 def pkg_rpm(name, srcs = None, spec_file = None, **kwargs):
     """pkg_rpm wrapper

--- a/providers.bzl
+++ b/providers.bzl
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//pkg:providers.bzl",
+# buildifier: disable=module-docstring
+load(
+    "//pkg:providers.bzl",
     _PackageArtifactInfo = "PackageArtifactInfo",
     _PackageDirsInfo = "PackageDirsInfo",
     _PackageFilegroupInfo = "PackageFilegroupInfo",

--- a/rpm.bzl
+++ b/rpm.bzl
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//pkg:rpm.bzl",
+# buildifier: disable=module-docstring
+load(
+    "//pkg:rpm.bzl",
     _pkg_rpm = "pkg_rpm",
 )
+
 pkg_rpm = _pkg_rpm

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,14 +13,14 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-load("my_package_name.bzl", "my_package_naming")
-load("path_test.bzl", "path_tests")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("//pkg:deb.bzl", "pkg_deb")
-load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs", "pkg_mklink")
+load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("//pkg:pkg.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_tar", "pkg_zip")
 load("//tests/util:defs.bzl", "directory", "fake_artifact")
-load("@rules_python//python:defs.bzl", "py_test")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("my_package_name.bzl", "my_package_naming")
+load("path_test.bzl", "path_tests")
 
 licenses(["notice"])
 

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -16,11 +16,11 @@
 # Tests for pkg_deb specific behavior
 
 load("@rules_python//python:defs.bzl", "py_test")
-load(":deb_tests.bzl", "package_naming_test")
+load("//pkg:deb.bzl", "pkg_deb")
 load("//pkg:mappings.bzl", "pkg_mklink")
 load("//pkg:pkg.bzl", "pkg_tar")
-load("//pkg:deb.bzl", "pkg_deb")
 load("//tests:my_package_name.bzl", "my_package_naming")
+load(":deb_tests.bzl", "package_naming_test")
 
 genrule(
     name = "generate_files",
@@ -106,6 +106,6 @@ py_test(
 
 package_naming_test(
     name = "naming_test",
-    target_under_test = ":test_deb",
     expected_name = "fizzbuzz_test_all.deb",
+    target_under_test = ":test_deb",
 )

--- a/tests/deb/deb_tests.bzl
+++ b/tests/deb/deb_tests.bzl
@@ -43,7 +43,6 @@ def _package_naming_test_impl(ctx):
         )
     return analysistest.end(env)
 
-
 package_naming_test = analysistest.make(
     _package_naming_test_impl,
     attrs = {

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -12,24 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    ":mappings_test.bzl",
-     "manifest_golden_test",
-     "mappings_analysis_tests",
-     "mappings_unit_tests",
-)
-load(":mappings_external_repo_test.bzl", "mappings_external_repo_analysis_tests")
+load("@rules_python//python:defs.bzl", "py_library")
 load(
     "//pkg:mappings.bzl",
     "pkg_attributes",
-    "pkg_filegroup",
     "pkg_files",
     "pkg_mkdirs",
-    "pkg_mklink",
     "strip_prefix",
 )
 load("//tests/util:defs.bzl", "directory", "write_content_manifest")
-load("@rules_python//python:defs.bzl", "py_test")
+load(":mappings_external_repo_test.bzl", "mappings_external_repo_analysis_tests")
+load(
+    ":mappings_test.bzl",
+    "manifest_golden_test",
+    "mappings_analysis_tests",
+    "mappings_unit_tests",
+)
 
 py_library(
     name = "manifest_test_lib",
@@ -52,7 +50,10 @@ mappings_external_repo_analysis_tests()
 
 directory(
     name = "treeartifact",
-    filenames = ["artifact_in_tree1", "artifact_in_tree2"],
+    filenames = [
+        "artifact_in_tree1",
+        "artifact_in_tree2",
+    ],
 )
 
 pkg_files(
@@ -86,16 +87,16 @@ write_content_manifest(
     name = "all",
     srcs = [
         "BUILD",
+        ":directory-with-contents",
         ":dirs",
         ":files",
-        ":directory-with-contents",
     ],
 )
 
 manifest_golden_test(
     name = "all_test",
-    target = "all",
     expected = "all.manifest.golden",
+    target = "all",
 )
 
 #
@@ -118,6 +119,6 @@ write_content_manifest(
 
 manifest_golden_test(
     name = "utf8_manifest_test",
-    target = "utf8",
     expected = "utf8_manifest.golden",
+    target = "utf8",
 )

--- a/tests/mappings/filter_directory/BUILD
+++ b/tests/mappings/filter_directory/BUILD
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 load("@rules_python//python:defs.bzl", "py_test")
-load(":defs.bzl", "inspect_directory_test")
 load("//pkg:mappings.bzl", "filter_directory")
 load("//tests/util:defs.bzl", "directory")
+load(":defs.bzl", "inspect_directory_test")
 
 # TODO: the below tests only check for rule success and confirmation that
 # directory structure matches expectations.  A more thorough test implementation
@@ -55,8 +55,8 @@ filter_directory(
     name = "renames_in",
     src = ":test_directory",
     renames = {
-        "subdir/a": "a",
         "c": "subdir/c",
+        "subdir/a": "a",
     },
 )
 
@@ -75,8 +75,8 @@ filter_directory(
     name = "renames_loop_in",
     src = ":test_directory",
     renames = {
-        "subdir/c": "a",
         "a": "subdir/c",
+        "subdir/c": "a",
     },
 )
 

--- a/tests/mappings/filter_directory/defs.bzl
+++ b/tests/mappings/filter_directory/defs.bzl
@@ -22,8 +22,8 @@ def _inspect_directory_script_impl(ctx):
         template = ctx.file._inspector_template,
         output = script,
         substitutions = {
-            "%EXPECTED_STRUCTURE%": json.encode(ctx.attr.expected_structure),
             "%DIRECTORY_ROOT%": ctx.file.directory.short_path,
+            "%EXPECTED_STRUCTURE%": json.encode(ctx.attr.expected_structure),
         },
     )
 

--- a/tests/mappings/mappings_external_repo_test.bzl
+++ b/tests/mappings/mappings_external_repo_test.bzl
@@ -14,11 +14,8 @@
 
 """Tests for file mapping routines in pkg/mappings.bzl"""
 
-load("@bazel_skylib//lib:new_sets.bzl", "sets")
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-load(":mappings_test.bzl", "pkg_files_contents_test")
-load("//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
 load("//pkg:mappings.bzl", "pkg_files", "strip_prefix")
+load(":mappings_test.bzl", "pkg_files_contents_test")
 
 ##########
 # pkg_files tests involving external repositories
@@ -109,7 +106,7 @@ def _test_pkg_files_extrepo():
         expected_dests = ["usr/bin/dir/extproj.sh"],
     )
 
-
+# buildifier: disable=unnamed-macro
 def mappings_external_repo_analysis_tests():
     """Declare mappings.bzl analysis tests"""
     _test_pkg_files_extrepo()

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -14,32 +14,33 @@
 
 """Tests for file mapping routines in pkg/mappings.bzl"""
 
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-load(
-    "//pkg:providers.bzl",
-    "PackageDirsInfo",
-    "PackageFilegroupInfo",
-    "PackageFilesInfo",
-    "PackageSymlinkInfo",)
+load("@rules_python//python:defs.bzl", "py_test")
 load(
     "//pkg:mappings.bzl",
+    "REMOVE_BASE_DIRECTORY",
     "pkg_attributes",
     "pkg_filegroup",
     "pkg_files",
     "pkg_mkdirs",
     "pkg_mklink",
     "strip_prefix",
-    "REMOVE_BASE_DIRECTORY",
+)
+load(
+    "//pkg:providers.bzl",
+    "PackageDirsInfo",
+    "PackageFilegroupInfo",
+    "PackageFilesInfo",
+    "PackageSymlinkInfo",
 )
 load(
     "//tests/util:defs.bzl",
     "directory",
     "fake_artifact",
     "generic_base_case_test",
-    "generic_negative_test"
+    "generic_negative_test",
 )
-load("@bazel_skylib//lib:new_sets.bzl", "sets")
-load("@rules_python//python:defs.bzl", "py_test")
 
 ##########
 # Helpers
@@ -62,10 +63,10 @@ def _pkg_files_contents_test_impl(ctx):
     for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
         asserts.true(
             got in expected_dests,
-            "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests))
+            "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests),
+        )
         n_found += 1
     asserts.equals(env, len(expected_dests), n_found)
-
 
     # Simple equality checks for the others, if specified
     if ctx.attr.expected_attributes:
@@ -83,12 +84,12 @@ def _pkg_files_contents_test_impl(ctx):
 pkg_files_contents_test = analysistest.make(
     _pkg_files_contents_test_impl,
     attrs = {
+        "expected_attributes": attr.string(),
         # Other attributes can be tested here, but the most important one is the
         # destinations.
         "expected_dests": attr.string_list(
             mandatory = True,
         ),
-        "expected_attributes": attr.string(),
     },
 )
 
@@ -468,7 +469,6 @@ def _test_pkg_files_rename():
         target_under_test = ":pf_directory_rename_to_empty_g",
     )
 
-
 ##########
 # Test pkg_mkdirs
 ##########
@@ -583,9 +583,9 @@ def _pkg_mklink_contents_test_impl(ctx):
 pkg_mklink_contents_test = analysistest.make(
     _pkg_mklink_contents_test_impl,
     attrs = {
-        "expected_src": attr.string(mandatory = True),
-        "expected_dest": attr.string(mandatory = True),
         "expected_attributes": attr.string(),
+        "expected_dest": attr.string(mandatory = True),
+        "expected_src": attr.string(mandatory = True),
     },
 )
 
@@ -700,12 +700,12 @@ def _pkg_filegroup_contents_test_impl(ctx):
 pkg_filegroup_contents_test = analysistest.make(
     _pkg_filegroup_contents_test_impl,
     attrs = {
-        "expected_pkg_files": attr.label_list(
-            providers = [PackageFilesInfo],
-            default = [],
-        ),
         "expected_pkg_dirs": attr.label_list(
             providers = [PackageDirsInfo],
+            default = [],
+        ),
+        "expected_pkg_files": attr.label_list(
+            providers = [PackageFilesInfo],
             default = [],
         ),
         "expected_pkg_symlinks": attr.label_list(
@@ -883,6 +883,7 @@ def _strip_prefix_test_impl(ctx):
 
 strip_prefix_test = unittest.make(_strip_prefix_test_impl)
 
+# buildifier: disable=unnamed-macro
 def mappings_analysis_tests():
     """Declare mappings.bzl analysis tests"""
     _test_pkg_files_contents()
@@ -958,8 +959,8 @@ def _gen_manifest_test_main_impl(ctx):
 _gen_manifest_test_main = rule(
     implementation = _gen_manifest_test_main_impl,
     attrs = {
-        "out": attr.output(mandatory = True),
         "expected": attr.string(mandatory = True),
+        "out": attr.output(mandatory = True),
         "target": attr.string(mandatory = True),
         "test_name": attr.string(mandatory = True),
         "_template": attr.label(
@@ -969,7 +970,6 @@ _gen_manifest_test_main = rule(
     },
 )
 
-
 def manifest_golden_test(name, target, expected):
     """Tests that a content manifest file matches a golden copy.
 
@@ -977,9 +977,10 @@ def manifest_golden_test(name, target, expected):
     expected content.
 
     Args:
-      target: A target which produces a content manifest with the name
-          <target> + ".manifest"
-      expected: label of a file containing the expected content.
+        name: The name of this target
+        target: A target which produces a content manifest with the name
+            <target> + ".manifest"
+        expected: label of a file containing the expected content.
     """
     _gen_manifest_test_main(
         name = name + "_main",

--- a/tests/path_test.bzl
+++ b/tests/path_test.bzl
@@ -14,9 +14,9 @@
 
 """Tests for path.bzl"""
 
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//pkg:mappings.bzl", "pkg_mkdirs")
 load("//pkg:path.bzl", "compute_data_path")
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
 ##########
 # Test compute_data_path
@@ -24,14 +24,15 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 def _compute_data_path_test_impl(ctx):
     env = analysistest.begin(ctx)
     target_under_test = analysistest.target_under_test(env)
+
     # Subtle: This allows you to vendor the library into your own repo at some
     # arbitrary path.
     expect = ctx.attr.expected_path
-    if expect.startswith('tests'):
-      expect = ctx.label.package + expect[5:]
+    if expect.startswith("tests"):
+        expect = ctx.label.package + expect[5:]
     asserts.equals(
         env,
-        expect, 
+        expect,
         compute_data_path(ctx, ctx.attr.in_path),
     )
     return analysistest.end(env)
@@ -39,8 +40,8 @@ def _compute_data_path_test_impl(ctx):
 compute_data_path_test = analysistest.make(
     _compute_data_path_test_impl,
     attrs = {
-        "in_path": attr.string(mandatory = True),
         "expected_path": attr.string(mandatory = True),
+        "in_path": attr.string(mandatory = True),
     },
 )
 
@@ -88,4 +89,4 @@ def _test_compute_data_path(name):
 
 def path_tests(name):
     """Declare path.bzl analysis tests."""
-    _test_compute_data_path(name=name + "_compute_data_path")
+    _test_compute_data_path(name = name + "_compute_data_path")

--- a/tests/rpm/analysis_tests.bzl
+++ b/tests/rpm/analysis_tests.bzl
@@ -14,6 +14,7 @@
 
 """Tests for RPM generation analysis"""
 
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load(
     "//pkg:mappings.bzl",
     "pkg_filegroup",
@@ -21,10 +22,9 @@ load(
     "pkg_mkdirs",
     "pkg_mklink",
 )
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//pkg:providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
 load("//pkg:rpm.bzl", "pkg_rpm")
-load("//tests/util:defs.bzl", "directory", "generic_base_case_test", "generic_negative_test")
+load("//tests/util:defs.bzl", "generic_base_case_test", "generic_negative_test")
 
 def _declare_pkg_rpm(name, srcs_ungrouped, tags = None, **kwargs):
     pfg_name = "{}_pfg".format(name)
@@ -191,7 +191,6 @@ def _package_naming_test_impl(ctx):
         elif f.basename == ctx.attr.expected_default_name and not default_name_found:
             default_name_found = True
 
-
     asserts.true(
         env,
         packaged_file != None,
@@ -215,8 +214,8 @@ def _package_naming_test_impl(ctx):
 package_naming_test = analysistest.make(
     _package_naming_test_impl,
     attrs = {
-        "expected_name": attr.string(),
         "expected_default_name": attr.string(),
+        "expected_name": attr.string(),
     },
 )
 
@@ -225,8 +224,8 @@ def _dummy_pkg_variables_impl(ctx):
     return [
         PackageVariablesInfo(
             values = {
-                "FOO": "foo",
                 "BAR": "bar",
+                "FOO": "foo",
             },
         ),
     ]

--- a/tests/rpm/toolchain_tests.bzl
+++ b/tests/rpm/toolchain_tests.bzl
@@ -58,13 +58,13 @@ def _toolchain_contents_test_impl(ctx):
 toolchain_contents_test = analysistest.make(
     _toolchain_contents_test_impl,
     attrs = {
-        "expect_valid": attr.bool(default = True),
         "expect_label": attr.label(
             cfg = "exec",
             executable = True,
             allow_files = True,
         ),
         "expect_path": attr.string(),
+        "expect_valid": attr.bool(default = True),
     },
 )
 
@@ -119,5 +119,6 @@ def _create_toolchain_creation_tests():
         expect_path = "/usr/bin/foo",
     )
 
+# buildifier: disable=unnamed-macro
 def create_toolchain_analysis_tests():
     _create_toolchain_creation_tests()

--- a/tests/rpm/tree_artifacts/BUILD
+++ b/tests/rpm/tree_artifacts/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_test")
 load(
     "//pkg:mappings.bzl",
     "REMOVE_BASE_DIRECTORY",
@@ -22,7 +23,6 @@ load(
 )
 load("//pkg:rpm.bzl", "pkg_rpm")
 load("//tests/util:defs.bzl", "directory")
-load("@rules_python//python:defs.bzl", "py_test")
 
 ############################################################################
 # Test handling of directory outputs

--- a/tests/util/defs.bzl
+++ b/tests/util/defs.bzl
@@ -14,9 +14,10 @@
 
 """Rules to aid testing"""
 
-load("//pkg/private:pkg_files.bzl", "add_label_list", "write_manifest")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
-load("@rules_python//python:defs.bzl", "py_binary")
+
+# buildifier: disable=bzl-visibility
+load("//pkg/private:pkg_files.bzl", "add_label_list", "write_manifest")
 
 def _directory_impl(ctx):
     out_dir_file = ctx.actions.declare_directory(ctx.attr.outdir or ctx.attr.name)
@@ -44,12 +45,12 @@ creation capabilities are "unsound".
     """,
     implementation = _directory_impl,
     attrs = {
+        "contents": attr.string(),
         "filenames": attr.string_list(
             doc = """Paths to create in the directory.
 
 Paths containing directories will also have the intermediate directories created too.""",
         ),
-        "contents": attr.string(),
         "outdir": attr.string(),
         "_dir_creator": attr.label(
             default = ":create_directory_with_contents",
@@ -61,10 +62,10 @@ Paths containing directories will also have the intermediate directories created
 
 def _fake_artifact_impl(ctx):
     out_file = ctx.actions.declare_file(ctx.attr.name)
-    content = ['echo ' + rf.path for rf in ctx.files.runfiles]
+    content = ["echo " + rf.path for rf in ctx.files.runfiles]
     ctx.actions.write(
         output = out_file,
-        content = '\r\n'.join(content),
+        content = "\r\n".join(content),
         is_executable = ctx.attr.executable,
     )
     return DefaultInfo(
@@ -86,6 +87,10 @@ cc_binary in complexity, but does not depend on a large toolchain.""",
             doc = "Dependencies to trigger other rules, but are then discarded.",
             allow_files = True,
         ),
+        "executable": attr.bool(
+            doc = "If True, the DefaultInfo will be marked as executable.",
+            default = False,
+        ),
         "files": attr.label_list(
             doc = "Deps which are passed in DefaultInfo as files.",
             allow_files = True,
@@ -93,10 +98,6 @@ cc_binary in complexity, but does not depend on a large toolchain.""",
         "runfiles": attr.label_list(
             doc = "Deps which are passed in DefaultInfo as runfiles.",
             allow_files = True,
-        ),
-        "executable": attr.bool(
-            doc = "If True, the DefaultInfo will be marked as executable.",
-            default = False,
         ),
     },
 )
@@ -113,11 +114,11 @@ _write_content_manifest = rule(
 This is intended only for testing the manifest creation features.""",
     implementation = _write_content_manifest_impl,
     attrs = {
+        "out": attr.output(),
         "srcs": attr.label_list(
             doc = """List of source inputs.""",
             allow_files = True,
         ),
-        "out": attr.output(),
         "use_short_path": attr.bool(
             doc = """Use the rootless path in the manifest.
 
@@ -137,7 +138,7 @@ def write_content_manifest(name, srcs):
         name = name,
         srcs = srcs,
         use_short_path = True,
-        out = name + ".manifest"
+        out = name + ".manifest",
     )
 
 ############################################################

--- a/toolchains/git/git.bzl
+++ b/toolchains/git/git.bzl
@@ -23,13 +23,13 @@ that escape the Bazel sandbox and pop back to the workspace/repo.
 GitInfo = provider(
     doc = """Information needed to invoke git.""",
     fields = {
-        "name": "The name of the toolchain",
-        "valid": "Is this toolchain valid and usable?",
-        "label": "Label of a target providing a git binary",
-        "path": "The path to a pre-built git",
         "client_top": "The path to the top of the git client." +
                       " In reality, we use the path to the WORKSPACE file as" +
                       " a proxy for a folder underneath the git client top.",
+        "label": "Label of a target providing a git binary",
+        "name": "The name of the toolchain",
+        "path": "The path to a pre-built git",
+        "valid": "Is this toolchain valid and usable?",
     },
 )
 
@@ -51,6 +51,9 @@ def _git_toolchain_impl(ctx):
 git_toolchain = rule(
     implementation = _git_toolchain_impl,
     attrs = {
+        "client_top": attr.string(
+            doc = "The top of your git client.",
+        ),
         "label": attr.label(
             doc = "A valid label of a target to build or a prebuilt binary. Mutually exclusive with path.",
             cfg = "exec",
@@ -59,9 +62,6 @@ git_toolchain = rule(
         ),
         "path": attr.string(
             doc = "The path to the git executable. Mutually exclusive with label.",
-        ),
-        "client_top": attr.string(
-            doc = "The top of your git client.",
         ),
     },
 )

--- a/toolchains/git/git_configure.bzl
+++ b/toolchains/git/git_configure.bzl
@@ -47,17 +47,18 @@ _find_system_git = repository_rule(
     doc = """Create a repository that defines an git toolchain based on the system git.""",
     local = True,
     attrs = {
+        "verbose": attr.bool(
+            doc = "If true, print status messages.",
+        ),
         "workspace_file": attr.label(
             doc = "Referece to calling repository WORKSPACE file.",
             allow_single_file = True,
             mandatory = True,
         ),
-        "verbose": attr.bool(
-            doc = "If true, print status messages.",
-        ),
     },
 )
 
+# buildifier: disable=function-docstring-args
 def experimental_find_system_git(name, workspace_file = None, verbose = False):
     """Create a toolchain that lets you run git.
 

--- a/toolchains/rpmbuild.bzl
+++ b/toolchains/rpmbuild.bzl
@@ -16,10 +16,10 @@
 RpmbuildInfo = provider(
     doc = """Platform inde artifact.""",
     fields = {
-        "name": "The name of the toolchain",
-        "valid": "Is this toolchain valid and usable?",
         "label": "The path to a target I will build",
+        "name": "The name of the toolchain",
         "path": "The path to a pre-built rpmbuild",
+        "valid": "Is this toolchain valid and usable?",
     },
 )
 
@@ -65,5 +65,6 @@ is_rpmbuild_available = rule(
     toolchains = ["@rules_pkg//toolchains:rpmbuild_toolchain_type"],
 )
 
+# buildifier: disable=unnamed-macro
 def rpmbuild_register_toolchains():
     native.register_toolchains("@rules_pkg//toolchains:rpmbuild_missing_toolchain")

--- a/toolchains/rpmbuild_configure.bzl
+++ b/toolchains/rpmbuild_configure.bzl
@@ -32,7 +32,7 @@ def _find_system_rpmbuild_impl(rctx):
         if rpmbuild_path:
             print("Found rpmbuild at '%s'" % rpmbuild_path)  # buildifier: disable=print
         else:
-          print("No system rpmbuild found.")  # buildifier: disable=print
+            print("No system rpmbuild found.")  # buildifier: disable=print
     _write_build(rctx = rctx, path = rpmbuild_path)
 
 _find_system_rpmbuild = repository_rule(
@@ -47,8 +47,9 @@ _find_system_rpmbuild = repository_rule(
     },
 )
 
-def find_system_rpmbuild(name, verbose=False):
-    _find_system_rpmbuild(name=name, verbose=verbose)
+def find_system_rpmbuild(name, verbose = False):
+    _find_system_rpmbuild(name = name, verbose = verbose)
     native.register_toolchains(
         "@%s//:rpmbuild_auto_toolchain" % name,
-        "@rules_pkg//toolchains:rpmbuild_missing_toolchain")
+        "@rules_pkg//toolchains:rpmbuild_missing_toolchain",
+    )


### PR DESCRIPTION
[buildifier](https://github.com/bazelbuild/buildtools/tree/4.2.3/buildifier) is a Bazel linter enabled in most other rules within the `github.com/bazelbuild` org. The changes here add the check to CI and address all existing defects by simply running `buildifier -lint=fix -mode=fix -warnings=all -r ./` and adding `buildifier: disable=` directives for things that would require manual changes since those are most likely to cause a change in behavior for users.