### PR TITLE
Fix use of name parameter to pkg_tar

### DIFF
--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -320,7 +320,7 @@ def pkg_tar(name, **kwargs):
     if "srcs" not in kwargs:
         if "files" in kwargs:
             if not hasattr(kwargs["files"], "items"):
-                label = "%s//%s:%s" % (native.repository_name(), native.package_name(), kwargs["name"])
+                label = "%s//%s:%s" % (native.repository_name(), native.package_name(), name)
 
                 # buildifier: disable=print
                 print("%s: you provided a non dictionary to the pkg_tar `files` attribute. " % (label,) +


### PR DESCRIPTION
The legacy branch of pkg_tar attempts to fetch the name parameter using kwargs. As name is an explicit parameter, this results in a build error. The PR changes this branch to use 'name' instead.