### PR TITLE
Buff the developer guide a bit.

### DIFF
--- a/developers.md
+++ b/developers.md
@@ -1,28 +1,82 @@
 # rules_pkg - Information for Developers
 
-NOTE: This is a work in progress. It is only an outline at this point.
+NOTE: This is perpetually a work in progress. We will revise it as we need.
 
-TBD: Introduction
+## PR guidelines
 
-## General
+Please discuss proposed major features and structural changes before sending a
+PR. The best way to do that is to
 
--    tests
--    OS portability
--    minimize tests
--    repo structure
-     - more at build time than in the distribution
-     - some features do not work on all platforms
+1.  Create an an issue
+1.  Discuss it in the issue or in rules-pkg-discuss@googlegroups.com
+1.  Bring it up at the monthly engineering meeting. (See #325 for
+    details)[https://github.com/bazelbuild/rules_pkg/issues/325].
 
-## Starlark style
+### A few small PRs are better than one big one.
 
--    using analysis tests
--    docstrings in attributes
+If you need to refactor a lot of code before you can add new behavior, please
+send a refactoring CL first (which should not add or change tests), then send a
+smaller change that implements the new behavior.
 
-## Python style
+## Functionality
 
--    import style as per #399
--    ...
+### General solutions are better than package specific ones.
 
-## Continuous testing
+-   Favor solutions that can be reused for all package formats. We will not
+    accept contributions that add specific features to one package format when
+    they could be incorporated into existing pkg_files and related rules such
+    that they could be used by all formats.
+-   We are moving towards aligning attribute names across rules. If we want
+    backwards compatibility with older versions, do that in the macro wrapper.
 
--    under .bazel_ci
+### Tests
+
+-   All behavioral changes require tests. Even if you are fixing what is most
+    likely a bug, please add a test that would have failed before the fix and
+    passes after.
+-   Aim for minimal tests. Favor unit tests over integration tests. It is better
+    to have many small tests rather than one that checks many conditions.
+-   Continuous testing is defined under `.bazel_ci`.
+
+### Portability
+
+-   All of the code must work on Linux, macos, and Windows. Other OSes are
+    optional, but we do not have CI to ensure it. If you are making changes that
+    require something specifically for portability, your change should include
+    inline comments about why, so a future maintainer does not accidentally
+    revert it.
+-   Some features can not work on all platforms. Favor solutions that allow
+    auto-skipping tests that are platform specific rather than requiring
+    exclusion lists in CI.
+
+### Major features require commitment
+
+We would love to have features like an MSI builder or macos application support.
+Before accepting a PR for something like that, we want to know that your
+organization will commit to maintaining that feature and responding to issues.
+
+## About the code
+
+### Repository structure: run time vs build time
+
+-   pkg/... contains what is needed at run time. Everything else is not `part of
+    the packaged distribution releases.
+-   docs/... is served as github pages. We mostly generate that rather than edit
+    by hand.
+-   distro/... contains the rules to create the distribution package.
+
+### Starlark style
+
+-   We are moving towards fully generated docs. If you touch an attribute, you
+    must update the docstring to explain it.
+-   Add docstrings args defined in macros. We are targeting the future time when
+    stardoc can build unified documentation for the rule and the wrapper.
+-   Actions should not write quoted strings to command lings. If your rule must
+    pass file paths to another program, write the paths to an intermediate file
+    and pass that as an arg to the other program.
+    (See #214)[https://github.com/bazelbuild/rules_pkg/issues/214].
+
+### Python style
+
+-   We use Python 3. We are not trying to support Python 2 at all.
+-   Always import with a full path from the root of the source tree.

--- a/developers.md
+++ b/developers.md
@@ -5,7 +5,7 @@ NOTE: This is perpetually a work in progress. We will revise it as we need.
 ## PR guidelines
 
 Please discuss proposed major features and structural changes before sending a
-PR. The best way to do that is to
+PR. The best way to do that is to do one or more of the following.
 
 1.  Create an an issue
 1.  Discuss it in the issue or in rules-pkg-discuss@googlegroups.com
@@ -15,7 +15,7 @@ PR. The best way to do that is to
 ### A few small PRs are better than one big one.
 
 If you need to refactor a lot of code before you can add new behavior, please
-send a refactoring CL first (which should not add or change tests), then send a
+send a refactoring PR first (which should not add or change tests), then send a
 smaller change that implements the new behavior.
 
 ## Functionality
@@ -24,7 +24,7 @@ smaller change that implements the new behavior.
 
 -   Favor solutions that can be reused for all package formats. We will not
     accept contributions that add specific features to one package format when
-    they could be incorporated into existing pkg_files and related rules such
+    they could be incorporated into existing `pkg_files` and related rules such
     that they could be used by all formats.
 -   We are moving towards aligning attribute names across rules. If we want
     backwards compatibility with older versions, do that in the macro wrapper.
@@ -40,7 +40,7 @@ smaller change that implements the new behavior.
 
 ### Portability
 
--   All of the code must work on Linux, macos, and Windows. Other OSes are
+-   All of the code must work on Linux, macOS, and Windows. Other OSes are
     optional, but we do not have CI to ensure it. If you are making changes that
     require something specifically for portability, your change should include
     inline comments about why, so a future maintainer does not accidentally
@@ -51,7 +51,7 @@ smaller change that implements the new behavior.
 
 ### Major features require commitment
 
-We would love to have features like an MSI builder or macos application support.
+We would love to have features like an MSI builder or macOS application support.
 Before accepting a PR for something like that, we want to know that your
 organization will commit to maintaining that feature and responding to issues.
 
@@ -59,11 +59,20 @@ organization will commit to maintaining that feature and responding to issues.
 
 ### Repository structure: run time vs build time
 
--   pkg/... contains what is needed at run time. Everything else is not `part of
+-   pkg/... contains what is needed at run time. Everything else is not part of
     the packaged distribution releases.
 -   docs/... is served as github pages. We mostly generate that rather than edit
     by hand.
 -   distro/... contains the rules to create the distribution package.
+-   examples/... contains runnable examples  which serve as additional
+    documentation. These are tested in CI.
+-   tests/... contains unit and integration tests. It is a distinct folder so
+    that it is not needed in the distribution runtime.
+-   <root> contains shims for the .bzl files in pkg/*.bzl. They add backwards
+    compatibility to to older releases.
+
+Additionally:
+-   deb_packages/... is defunct and unsupported.
 
 ### Starlark style
 
@@ -71,10 +80,10 @@ organization will commit to maintaining that feature and responding to issues.
     must update the docstring to explain it.
 -   Add docstrings args defined in macros. We are targeting the future time when
     stardoc can build unified documentation for the rule and the wrapper.
--   Actions should not write quoted strings to command lings. If your rule must
+-   Actions should not write quoted strings to command lines. If your rule must
     pass file paths to another program, write the paths to an intermediate file
     and pass that as an arg to the other program.
-    (See #214)[https://github.com/bazelbuild/rules_pkg/issues/214].
+    [See #214](https://github.com/bazelbuild/rules_pkg/issues/214).
 
 ### Python style
 

--- a/developers.md
+++ b/developers.md
@@ -7,7 +7,7 @@ NOTE: This is perpetually a work in progress. We will revise it as we need.
 Please discuss proposed major features and structural changes before sending a
 PR. The best way to do that is to do one or more of the following.
 
-1.  Create an an issue
+1.  Create an issue
 1.  Discuss it in the issue or in rules-pkg-discuss@googlegroups.com
 1.  Bring it up at the monthly engineering meeting. (See #325 for
     details)[https://github.com/bazelbuild/rules_pkg/issues/325].
@@ -84,8 +84,18 @@ Additionally:
     pass file paths to another program, write the paths to an intermediate file
     and pass that as an arg to the other program.
     [See #214](https://github.com/bazelbuild/rules_pkg/issues/214).
+-   Run buildifier on you .bzl files before sending a PR.
 
 ### Python style
 
 -   We use Python 3. We are not trying to support Python 2 at all.
 -   Always import with a full path from the root of the source tree.
+
+### Dependencies
+
+-   No new dependencies on language toolchains. We take a dependency on Python
+    because it is generally available on all OSes.
+-   No new python package dependencies.  Use only what is part of the core
+    distribution.
+-   Other new dependencies are strongly discouraged. The exception is that we
+    may take dependencies on other modules maintained by the Bazel team.


### PR DESCRIPTION
Fill in some more words in the developers guide.

Fixes #214.  More accurately, it moves the intent of #214 into this guide. This feels appropriate because it is not a single problem, but rather a general principal.

My intent is to start moving intangible "guidance" issues into the developers guide and out of the issue list that we keep reviewing.