### PR TITLE
compute_data_path should add the workspace_root

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,3 +65,12 @@ local_repository(
     name = "mappings_test_external_repo",
     path = "tests/mappings/external_repo",
 )
+
+# This repository is used to test pkg_tar rule itself.
+local_repository(
+    name = "rules_pkg_test_workspace",
+    path = ".",
+    repo_mapping = {
+        "@rules_pkg": "@",
+    },
+)

--- a/pkg/path.bzl
+++ b/pkg/path.bzl
@@ -68,7 +68,10 @@ def compute_data_path(ctx, data_path):
       ctx: rule implementation ctx.
       data_path: path to a file, relative to the package of the rule ctx.
     """
-    build_dir = ctx.label.package
+    build_dir = ctx.label.workspace_root
+    if ctx.label.workspace_root and ctx.label.package:
+        build_dir += "/"
+    build_dir += ctx.label.package
     if data_path:
         # Strip ./ from the beginning if specified.
         # There is no way to handle .// correctly (no function that would make

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -420,6 +420,15 @@ pkg_tar(
 )
 
 pkg_tar(
+    name = "test-tar-strip_prefix-external_workspace",
+    srcs = [
+         "BUILD",
+    ],
+    strip_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
     name = "test-tar-files_dict",
     files = {
         ":etc/nsswitch.conf": "not-etc/mapped-filename.conf",
@@ -493,6 +502,7 @@ py_test(
         ":test-tar-strip_prefix-etc.tar",
         ":test-tar-strip_prefix-none.tar",
         ":test-tar-strip_prefix-substring.tar",
+        "@rules_pkg_test_workspace//tests:test-tar-strip_prefix-external_workspace",
         ":test_tar_package_dir_substitution.tar",
         ":test-tar-long-filename",
         ":test-tar-repackaging-long-filename.tar",

--- a/tests/pkg_tar_test.py
+++ b/tests/pkg_tar_test.py
@@ -39,7 +39,10 @@ class PkgTarTest(unittest.TestCase):
     """
     # NOTE: This is portable to Windows. os.path.join('rules_pkg', 'tests',
     # filename) is not.
-    file_path = runfiles.Create().Rlocation('rules_pkg/tests/' + file_name)
+    if file_name[0] == '/':
+      file_path = runfiles.Create().Rlocation(file_name[1:])
+    else:
+      file_path = runfiles.Create().Rlocation('rules_pkg/tests/' + file_name)
     with tarfile.open(file_path, 'r:*') as f:
       i = 0
       for info in f:
@@ -93,6 +96,14 @@ class PkgTarTest(unittest.TestCase):
         {'name': './etc/nsswitch.conf'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-substring.tar', content)
+
+  def test_strip_prefix_external_workspace(self):
+    content = [
+        {'name': '.', 'isdir': True},
+        {'name': './BUILD'},
+    ]
+    self.assertTarFileContent('/rules_pkg_test_workspace/tests/test-tar-strip_prefix-external_workspace.tar', content)
+
 
   def test_strip_prefix_dot(self):
     content = [


### PR DESCRIPTION
pkg_tar rule will produce a tarbal with files
named exteranl/workspace_name/path_to_file
even if `strip_prefix = "."` currently. This commit
fixes it.