### PR TITLE
Add MODULE.bazel file

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -10,6 +10,11 @@ lts: &lts
 
 rolling: &rolling
   bazel: rolling
+  # Enable bzlmod on experimental branches.  Might remove prior to submit.
+  build_flags:
+    - "--experimental_enable_bzlmod"
+  test_flags:
+    - "--experimental_enable_bzlmod"
 
 #
 # Groups of tests, by platform

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,22 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "rules_pkg",
+    version = "0.6.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_python", version = "0.4.0")
+bazel_dep(name = "bazel_skylib", version = "1.0.3")


### PR DESCRIPTION
[bzlmod] is the upcoming package manager for Bazel's external dependencies.

While it's already in the [central registry], it's apparently also helpful to
have such a file in the repository, in case, you need to use overrides.

This change adds such a file, specifically the one from the central repository
with the version bumped.

I can't quite get the tests to work yet; I think there's a bug in how runfiles
trees are created (the rules_python directory for the runfiles lib contains the
version in addition to the name).  This was tested using the latest 5.0 RC; I
currently cannot test at bazel HEAD due to https://github.com/bazelbuild/bazel/issues/14403.

[bzlmod]: https://docs.bazel.build/versions/main/bzlmod.html
[central registry]: https://github.com/bazelbuild/bazel-central-registry