### PR TITLE
pkg_rpm: Don't have source_date_epoch apply by default; test modularity cleanup

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -373,7 +373,8 @@ class RpmBuilder(object):
         'LANG': 'C',
         'RPM_BUILD_ROOT': buildroot,
     }
-    if self.source_date_epoch:
+
+    if self.source_date_epoch is not None:
       env['SOURCE_DATE_EPOCH'] = self.source_date_epoch
       args += ["--define", "clamp_mtime_to_source_date_epoch Y"]
 

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -292,10 +292,11 @@ def _pkg_rpm_impl(ctx):
         fail("None of the release or release_file attributes were specified")
 
     # source_date_epoch is an integer, and Bazel (as of 4.2.2) does not allow
-    # you to put "None" as the default for an "int" attribute.
+    # you to put "None" as the default for an "int" attribute.  See also
+    # https://github.com/bazelbuild/bazel/issues/14434.
     #
-    # Since source_date_epoch cannot reasonably be negative, being zero or positive 
-    # treated the same as existing below.
+    # Since source_date_epoch cannot reasonably be negative, being zero or
+    # positive treated the same as existing below.
     if ctx.attr.source_date_epoch_file:
         if ctx.attr.source_date_epoch >= 0:
             fail("Both source_date_epoch and source_date_epoch_file attributes were specified")

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -760,7 +760,7 @@ pkg_rpm = rule(
             subordinate call to `rpmbuild` to facilitate more consistent in-RPM
             file timestamps.
 
-            Negative values (the default) disable this feature
+            Negative values (like the default) disable this feature.
             """,
             default = -1,
         ),

--- a/tests/rpm/pkg_rpm_basic_test.py
+++ b/tests/rpm/pkg_rpm_basic_test.py
@@ -219,10 +219,10 @@ echo postun
         # can just check for something that is non-zero.
         #
         # See also #486.
-        
+
         filedata = rpm_util.read_rpm_filedata(
             self.test_rpm_path,
-            query_tag_map = {
+            query_tag_map={
                 "FILENAMES": "path",
                 "FILEMTIMES": "mtime",
             }
@@ -231,7 +231,7 @@ echo postun
         self.assertNotEqual(
             len(filedata),
             0,
-            "rpm_util.read_rpm_filedata produced no output"
+            "rpm_util.read_rpm_filedata() produced no output"
         )
 
         filedata_shortened = {

--- a/tests/rpm/rpm_util.py
+++ b/tests/rpm/rpm_util.py
@@ -47,13 +47,7 @@ def invoke_rpm_with_queryformat(rpm_file_path, queryformat, rpm_bin_path="rpm"):
     # As a workaround, you should generally know if you're expecting output.
     # Check if the output contains anything not whitespace, or if you're using
     # `read_rpm_filedata`, check if the output dict is nonempty.
-    return subprocess.check_output([
-        rpm_bin_path,
-        "-qp",
-        "--queryformat",
-        queryformat,
-        rpm_file_path,
-    ]).decode("utf-8")
+    return subprocess.check_output([rpm_bin_path, "-qp", "--queryformat", queryformat, rpm_file_path]).decode("utf-8")
 
 
 # TODO(nacl): "rpm_bin_path" should be derived from a toolchain somewhere.

--- a/tests/rpm/rpm_util.py
+++ b/tests/rpm/rpm_util.py
@@ -41,13 +41,19 @@ def invoke_rpm_with_queryformat(rpm_file_path, queryformat, rpm_bin_path="rpm"):
     #   against a package will always "fail" with no explanation.
     #
     # - If you do pass "-p/--package" argument, `rpm -q --queryformat` run
-    #   against a package will always succeed if it can a file, even when there
-    #   is an error.
+    #   against a package will always succeed if it can read a file, even when
+    #   there is an error in some other aspect of the query.
     #
     # As a workaround, you should generally know if you're expecting output.
     # Check if the output contains anything not whitespace, or if you're using
     # `read_rpm_filedata`, check if the output dict is nonempty.
-    return subprocess.check_output([rpm_bin_path, "-qp", "--queryformat", queryformat, rpm_file_path]).decode("utf-8")
+    return subprocess.check_output([
+        rpm_bin_path,
+        "-qp",
+        "--queryformat",
+        queryformat,
+        rpm_file_path,
+    ]).decode("utf-8")
 
 
 # TODO(nacl): "rpm_bin_path" should be derived from a toolchain somewhere.


### PR DESCRIPTION
The logic for `pkg_rpm`'s `source_date_epoch` attribute should apply only when
set.  This change updates the logic so that a negative value for
`source_date_epoch` results in no `--source_date_epoch` being passed to
`make_rpm.py`.  `None` does not seem to be a valid option.

The default is now a negative number, thus disabling this feature unless
explicitly requested.

A regression test was also provided.  While writing it, I noticed a few quirks
in `rpm` that impacted test execution.  These were also addressed, although
perhaps not in the best way.

For more context, see #486.

NOTE: this does not address the similar issue impacting the legacy `pkg_rpm`
rule.  This is mentioned in #488.

Fixes #486