### PR TITLE
Make stamp_test a little less finicky.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -3,8 +3,3 @@
 
 deb_packages/
 examples/
-
-FUTURE/
-i135/
-i434/
-old_tar/

--- a/.bazelignore
+++ b/.bazelignore
@@ -3,3 +3,8 @@
 
 deb_packages/
 examples/
+
+FUTURE/
+i135/
+i434/
+old_tar/

--- a/tests/stamp_test.py
+++ b/tests/stamp_test.py
@@ -36,7 +36,7 @@ class StampTest(unittest.TestCase):
   # CI run and have the test run a few seconds later. Ideally, this would
   # be no greater than the expected total CI run time, but the extra margin
   # does not hurt.
-  ALLOWED_DELTA_FROM_NOW = 10000  # seconds
+  ALLOWED_DELTA_FROM_NOW = 30000  # seconds
 
   def check_mtime(self, mtime, file_path, file_name):
     """Checks that a time stamp is reasonable.
@@ -61,9 +61,12 @@ class StampTest(unittest.TestCase):
     if ((mtime < self.target_mtime - StampTest.ALLOWED_DELTA_FROM_NOW)
         or (mtime > self.target_mtime)):
        self.fail(
-           'Archive %s contains file %s with mtime:%d, expected:%d +/- %d' % (
+           'Archive %s contains file %s with mtime:%d, expected:%d +/- %d.' % (
                file_path, file_name, mtime, self.target_mtime,
-               StampTest.ALLOWED_DELTA_FROM_NOW))
+               StampTest.ALLOWED_DELTA_FROM_NOW) +
+           '  This may be a false positive if your build cache is more than' +
+           ' %s seconds old.  If so, try bazel clean and rerun the test.' %
+           StampTest.ALLOWED_DELTA_FROM_NOW)
 
   def assertTarFilesAreAlmostNew(self, file_name):
     """Assert that tarfile contains files with an mtime of roughly now.


### PR DESCRIPTION
Make //tests:stamp_test a little less finicky.

This addresses most of #489.
- makes the window larger
- improves the warning message

It does not use a fixed stamp value, because that would loose the critical test that we are actually getting a real build date rather than some constant.