### PR TITLE
Added support for the built-in tags attribute so that tags can be set on pkg rules

### DIFF
--- a/pkg/pkg.bzl
+++ b/pkg/pkg.bzl
@@ -32,7 +32,12 @@ load(
     "process_src",
     "write_manifest",
 )
-load("//pkg/private:util.bzl", "setup_output_files", "substitute_package_variables")
+load(
+    "//pkg/private:util.bzl",
+    "setup_output_files",
+    "substitute_package_variables",
+    "compute_execution_requirements",
+)
 load("//pkg/private/deb:deb.bzl", _pkg_deb = "pkg_deb")
 load("//pkg/private/zip:zip.bzl", _pkg_zip = "pkg_zip")
 
@@ -228,6 +233,7 @@ def _pkg_tar_impl(ctx):
     files.append(arg_file)
     ctx.actions.write(arg_file, "\n".join(args))
 
+
     ctx.actions.run(
         mnemonic = "PackageTar",
         progress_message = "Writing: %s" % output_file.path,
@@ -243,6 +249,7 @@ def _pkg_tar_impl(ctx):
             "PYTHONUTF8": "1",
         },
         use_default_shell_env = True,
+        execution_requirements = compute_execution_requirements(ctx),
     )
     return [
         DefaultInfo(

--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -14,7 +14,7 @@
 """Rule for creating Debian packages."""
 
 load("//pkg:providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
-load("//pkg/private:util.bzl", "setup_output_files")
+load("//pkg/private:util.bzl", "setup_output_files", "compute_execution_requirements")
 
 _tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.bz2", "tar.xz"]
 
@@ -154,6 +154,7 @@ def _pkg_deb_impl(ctx):
             "PYTHONIOENCODING": "UTF-8",
             "PYTHONUTF8": "1",
         },
+        execution_requirements = compute_execution_requirements(ctx)
     )
     output_groups = {
         "out": [ctx.outputs.out],

--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -87,3 +87,12 @@ def substitute_package_variables(ctx, attribute_value):
 
     package_variables = ctx.attr.package_variables[PackageVariablesInfo]
     return attribute_value.format(**package_variables.values)
+
+def compute_execution_requirements(ctx):
+    if not ctx.attr.tags:
+        return None
+
+    return {
+        tag: "1"
+        for tag in ctx.attr.tags
+    }

--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -19,7 +19,7 @@ load(
     "PackageArtifactInfo",
     "PackageVariablesInfo",
 )
-load("//pkg/private:util.bzl", "setup_output_files")
+load("//pkg/private:util.bzl", "setup_output_files", "compute_execution_requirements")
 load(
     "//pkg/private:pkg_files.bzl",
     "add_single_file",
@@ -96,6 +96,7 @@ def _pkg_zip_impl(ctx):
             "PYTHONUTF8": "1",
         },
         use_default_shell_env = True,
+        execution_requirements = compute_execution_requirements(ctx),
     )
     return [
         DefaultInfo(


### PR DESCRIPTION
Fixes #504 

I'd like to set tags, specifically `no-remote-cache`, on my use of the `pkg_tar` rule. This is a built-in rule from Bazel, but it seems it needs to be connected to the associated action in the custom rule. I've created a small utility to generate execution requirements based on `ctx.attr.tags` if it is present, which allows the attribute to be set on a rule.

I've added this for all `pkg_*` rules, please let me know if you have any feedback.