### PR TITLE
Move the designated place for pkg_tar to be //pkg:tar.bzl.

### DIFF
--- a/deb_packages/examples/deb_packages_base/BUILD
+++ b/deb_packages/examples/deb_packages_base/BUILD
@@ -22,7 +22,7 @@ genrule(
 
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_file")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@bazel_tools//tools/build_defs/pkg:tar.bzl", "pkg_tar")
 load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 

--- a/distro/BUILD
+++ b/distro/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//:version.bzl", "version")
-load("//pkg:pkg.bzl", "pkg_tar")
+load("//pkg:tar.bzl", "pkg_tar")
 load("//pkg/releasing:defs.bzl", "print_rel_notes")
 load("//pkg/releasing:git.bzl", "git_changelog")
 load("@rules_python//python:defs.bzl", "py_test")

--- a/distro/testdata/BUILD.tpl
+++ b/distro/testdata/BUILD.tpl
@@ -1,4 +1,4 @@
-load("@not_named_rules_pkg//pkg:pkg.bzl", "pkg_tar")
+load("@not_named_rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 pkg_tar(
     name = "dummy_tar",

--- a/distro/testdata/BUILD.tpl
+++ b/distro/testdata/BUILD.tpl
@@ -3,7 +3,7 @@ load("@not_named_rules_pkg//pkg:tar.bzl", "pkg_tar")
 pkg_tar(
     name = "dummy_tar",
     srcs = [
-      ":BUILD",
+        ":BUILD",
     ],
     extension = "tar.gz",
     owner = "0.0",

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -29,7 +29,7 @@ ORDER = [
     ("common",         None),
     ("pkg_deb",        "//pkg/private/deb:deb.bzl"),
     ("pkg_deb_impl",   "//pkg/private/deb:deb.bzl"),
-    ("pkg_rpm",        "//pkg:tar.bzl"),
+    ("pkg_rpm",        "//pkg:rpm_pfg.bzl"),
     ("pkg_tar",        "//pkg:pkg.bzl"),
     ("pkg_tar_impl",   "//pkg:pkg.bzl"),
     ("pkg_zip",        "//pkg/private/zip:zip.bzl"),

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -29,7 +29,7 @@ ORDER = [
     ("common",         None),
     ("pkg_deb",        "//pkg/private/deb:deb.bzl"),
     ("pkg_deb_impl",   "//pkg/private/deb:deb.bzl"),
-    ("pkg_rpm",        "//pkg:rpm_pfg.bzl"),
+    ("pkg_rpm",        "//pkg:tar.bzl"),
     ("pkg_tar",        "//pkg:pkg.bzl"),
     ("pkg_tar_impl",   "//pkg:pkg.bzl"),
     ("pkg_zip",        "//pkg/private/zip:zip.bzl"),

--- a/docs/latest.md
+++ b/docs/latest.md
@@ -310,7 +310,7 @@ pkg_tar_impl(<a href="#pkg_tar_impl-name">name</a>, <a href="#pkg_tar_impl-build
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="pkg_tar_impl-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="pkg_tar_impl-build_tar"></a>build_tar |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //pkg/private:build_tar |
+| <a id="pkg_tar_impl-build_tar"></a>build_tar |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | //pkg/private/tar:build_tar |
 | <a id="pkg_tar_impl-compressor"></a>compressor |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="pkg_tar_impl-compressor_args"></a>compressor_args |  -   | String | optional | "" |
 | <a id="pkg_tar_impl-deps"></a>deps |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |

--- a/examples/naming_package_files/BUILD
+++ b/examples/naming_package_files/BUILD
@@ -26,21 +26,19 @@ config_setting(
 )
 
 VERSION = "1"
+
 REVISION = "2"
 
 # Exposes the value of the compilation mode to the package naming.
 basic_naming(
     name = "my_naming_vars",
 
-    # Explicit values to use in all package names
-    version = VERSION,
-    revision = REVISION,
-
     # We make the product name a variable rather than put it in every rule.
     # This technique can be useful if you need to create packages in many
     # different formats but have not decided on the final naming yet. You
     # can use a placeholder and change it on one location.
     product_name = "RulesPkgExamples",
+    revision = REVISION,
 
     # Use a config_setting flag to specify part of the package name.
     # In this example, we define the config_setting based on a command line
@@ -51,6 +49,9 @@ basic_naming(
         ":special_build": "-IsSpecial",
         "//conditions:default": "",
     }),
+
+    # Explicit values to use in all package names
+    version = VERSION,
 )
 
 # Try building with various flag combinations to explore.
@@ -74,8 +75,8 @@ pkg_tar(
     srcs = [
         ":BUILD",
     ],
-    package_file_name = "example2-{product_name}-{target_cpu}-{compilation_mode}{special_build}.tar",
     package_dir = "example1/{product_name}/{target_cpu}/{compilation_mode}{special_build}",
+    package_file_name = "example2-{product_name}-{target_cpu}-{compilation_mode}{special_build}.tar",
     package_variables = ":my_naming_vars",
 )
 

--- a/examples/naming_package_files/BUILD
+++ b/examples/naming_package_files/BUILD
@@ -15,8 +15,8 @@
 
 licenses(["notice"])
 
-load("@rules_pkg//:deb.bzl", "pkg_deb")
-load("@rules_pkg//:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load(":package_upload.bzl", "debian_upload")
 load(":my_package_name.bzl", "basic_naming", "name_part_from_command_line", "names_from_toolchains")
 

--- a/examples/naming_package_files/BUILD
+++ b/examples/naming_package_files/BUILD
@@ -15,7 +15,8 @@
 
 licenses(["notice"])
 
-load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+load("@rules_pkg//:deb.bzl", "pkg_deb")
+load("@rules_pkg//:tar.bzl", "pkg_tar")
 load(":package_upload.bzl", "debian_upload")
 load(":my_package_name.bzl", "basic_naming", "name_part_from_command_line", "names_from_toolchains")
 

--- a/examples/naming_package_files/WORKSPACE
+++ b/examples/naming_package_files/WORKSPACE
@@ -21,10 +21,7 @@ local_repository(
     path = "../..",
 )
 
-http_archive
-
-
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 

--- a/examples/naming_package_files/my_package_name.bzl
+++ b/examples/naming_package_files/my_package_name.bzl
@@ -14,7 +14,7 @@
 
 """Example rules to show package naming techniques."""
 
-load("@rules_pkg//:providers.bzl", "PackageVariablesInfo")
+load("@rules_pkg//pkg:providers.bzl", "PackageVariablesInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 
 def _basic_naming_impl(ctx):

--- a/examples/naming_package_files/package_upload.bzl
+++ b/examples/naming_package_files/package_upload.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Example of how we can use PackageArtifactInfo to find an output name."""
 
-load("@rules_pkg//:providers.bzl", "PackageArtifactInfo")
+load("@rules_pkg//pkg:providers.bzl", "PackageArtifactInfo")
 
 def _debian_upload_impl(ctx):
     # Find out the basename of the deb file we created.

--- a/examples/prebuilt_rpmbuild/BUILD
+++ b/examples/prebuilt_rpmbuild/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-load("@rules_pkg//:rpm.bzl", "pkg_rpm")
+load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 
 pkg_rpm(
     name = "test-rpm",

--- a/examples/prebuilt_rpmbuild/WORKSPACE
+++ b/examples/prebuilt_rpmbuild/WORKSPACE
@@ -19,7 +19,7 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 

--- a/examples/rich_structure/BUILD
+++ b/examples/rich_structure/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
-load("@rules_pkg//:tar.bzl", "pkg_tar")
-load("@rules_pkg//:zip.bzl", "pkg_zip")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 
 # This is the top level BUILD for a hypothetical project Foo.  It has a client,
 # a server, docs, and runtime directories needed by the server.

--- a/examples/rich_structure/BUILD
+++ b/examples/rich_structure/BUILD
@@ -29,10 +29,10 @@ pkg_files(
     srcs = [
         "//docs",
     ],
-    # Required, but why?: see #354
-    strip_prefix = strip_prefix.from_pkg(),
     # Where it should be in the final package
     prefix = "usr/share/doc/foo",
+    # Required, but why?: see #354
+    strip_prefix = strip_prefix.from_pkg(),
 )
 
 pkg_filegroup(
@@ -43,7 +43,6 @@ pkg_filegroup(
     ],
     prefix = "/usr/share",
 )
-
 
 pkg_tar(
     name = "foo_tar",

--- a/examples/rich_structure/BUILD
+++ b/examples/rich_structure/BUILD
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs", "strip_prefix")
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
+load("@rules_pkg//:tar.bzl", "pkg_tar")
+load("@rules_pkg//:zip.bzl", "pkg_zip")
 
 # This is the top level BUILD for a hypothetical project Foo.  It has a client,
 # a server, docs, and runtime directories needed by the server.

--- a/examples/rich_structure/WORKSPACE
+++ b/examples/rich_structure/WORKSPACE
@@ -21,6 +21,6 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()

--- a/examples/rich_structure/resources/l10n/BUILD
+++ b/examples/rich_structure/resources/l10n/BUILD
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "strip_prefix")
-load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "strip_prefix")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("//:foo_defs.bzl", "shared_object_path_selector")
 
 # There are localized message catalogs for all the components.

--- a/examples/rich_structure/src/client/BUILD
+++ b/examples/rich_structure/src/client/BUILD
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//:foo_defs.bzl", "shared_object_path_selector")
 
 cc_library(

--- a/examples/rich_structure/src/server/BUILD
+++ b/examples/rich_structure/src/server/BUILD
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_pkg//:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mkdirs")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//:foo_defs.bzl", "shared_object_path_selector")
 
 cc_library(

--- a/examples/time_stamping/BUILD
+++ b/examples/time_stamping/BUILD
@@ -15,7 +15,7 @@
 
 licenses(["notice"])
 
-load("@rules_pkg//:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 pkg_tar(
     name = "never_stamped",

--- a/examples/time_stamping/WORKSPACE
+++ b/examples/time_stamping/WORKSPACE
@@ -19,6 +19,6 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()

--- a/examples/where_is_my_output/BUILD
+++ b/examples/where_is_my_output/BUILD
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # Build a trivial .deb package to show how to find the output files.
 
-load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
+load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 genrule(
     name = "generate_files",

--- a/examples/where_is_my_output/WORKSPACE
+++ b/examples/where_is_my_output/WORKSPACE
@@ -21,6 +21,6 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()

--- a/examples/where_is_my_output/show_all_outputs.bzl
+++ b/examples/where_is_my_output/show_all_outputs.bzl
@@ -16,7 +16,7 @@
 # Extract the paths to the various outputs of pkg_deb
 #
 # Usage:
-#   bazel cquery //:deb --output=starlark --starlark:file=show_all_outputs.bzl
+#   bazel cquery //pkg:deb --output=starlark --starlark:file=show_all_outputs.bzl
 #
 
 def format(target):

--- a/pkg.bzl
+++ b/pkg.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//pkg:deb.bzl", _pkg_deb = "pkg_deb")
-load("//pkg:pkg.bzl", _pkg_tar = "pkg_tar")
+load("//pkg:tar.bzl", _pkg_tar = "pkg_tar")
 load("//pkg:zip.bzl", _pkg_zip = "pkg_zip")
 
 pkg_deb = _pkg_deb

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -40,7 +40,7 @@ find_system_rpmbuild(name = "rules_pkg_rpmbuild")
 This example is a simplification of the debian packaging of Bazel:
 
 ```python
-load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
 
 pkg_tar(

--- a/pkg/tar.bzl
+++ b/pkg/tar.bzl
@@ -1,4 +1,4 @@
-# Copyright 2021 The Bazel Authors. All rights reserved.
+# Copyright 2022 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,31 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# -*- coding: utf-8 -*-
+"""Forwarder for pkg_tar."""
 
-licenses(["notice"])
+load("//pkg:pkg.bzl", _pkg_tar = "pkg_tar")
 
-load("@rules_pkg//:tar.bzl", "pkg_tar")
-
-pkg_tar(
-    name = "never_stamped",
-    srcs = [
-        ":BUILD",
-    ],
-)
-
-pkg_tar(
-    name = "always_stamped",
-    srcs = [
-        ":BUILD",
-    ],
-    stamp = 1,
-)
-
-pkg_tar(
-    name = "controlled_by_stamp_option",
-    srcs = [
-        ":BUILD",
-    ],
-    stamp = -1,
-)
+pkg_tar = _pkg_tar

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -19,7 +19,7 @@ load(":my_package_name.bzl", "my_package_naming")
 load(":path_test.bzl", "path_tests")
 load("//pkg:deb.bzl", "pkg_deb")
 load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
-load("//pkg:pkg.bzl", "pkg_tar")
+load("//pkg:tar.bzl", "pkg_tar")
 load("//pkg:zip.bzl", "pkg_zip")
 
 licenses(["notice"])

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -18,8 +18,8 @@
 load("@rules_python//python:defs.bzl", "py_test")
 load(":deb_tests.bzl", "package_naming_test")
 load("//pkg:mappings.bzl", "pkg_mklink")
-load("//pkg:pkg.bzl", "pkg_tar")
 load("//pkg:deb.bzl", "pkg_deb")
+load("//pkg:tar.bzl", "pkg_tar")
 load("//tests:my_package_name.bzl", "my_package_naming")
 
 genrule(


### PR DESCRIPTION
This does not move pkg_tar from pkg.bzl to pkg/private/tar.bzl yet. I am waiting on that for other PRs to pkg.bzl to be merged.  This PR moves the examples and tests to the desired style now rather than later.