### PR TITLE
Restore RPM tests in CI; minor cleanup

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -20,10 +20,8 @@ default_tests: &default_tests
     - "//pkg/..."
     - "//tests/..."
     - "//toolchains/..."
-    - "-//pkg/legacy/tests/rpm/..."
-    - "-//tests/rpm/..."
 
-# rpmbuild(8) is not available on most platforms
+# rpmbuild(8) is not available or installed on most platforms
 skip_rpm: &skip_rpm
   - "-//tests/rpm/..."
   - "-//pkg/legacy/tests/rpm/..."
@@ -33,7 +31,6 @@ win_tests: &win_tests
     - "//pkg/..."
     - "//tests/..."
     - "//toolchains/..."
-    - "-//pkg/legacy/tests/rpm/..."
     - "-//tests:make_rpm_test"
     - "-//tests:package_naming_aggregate_test"
     - "-//tests:path_test"
@@ -41,10 +38,6 @@ win_tests: &win_tests
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"
     - "-//tests/mappings/filter_directory/..."
-    # rpmbuild is not available on windows
-    - "-//tests/rpm/..."
-    - "-//tests/install/..."
-
 #
 # Commmon features by platform
 # 
@@ -52,6 +45,7 @@ ubuntu1804: &ubuntu
   platform: ubuntu1804
   <<: *common
   <<: *default_tests
+  <<: *skip_rpm
   build_targets:
     - "//distro:distro"
     - "//distro:relnotes"
@@ -66,11 +60,14 @@ macos: &macos
   platform: macos
   <<: *common
   <<: *default_tests
+  <<: *skip_rpm
 
 windows: &windows
   platform: windows
   <<: *common
   <<: *win_tests
+  # rpmbuild is not available on windows
+  <<: *skip_rpm
 
 #
 # Finally, the cross product of bazel releases X platforms

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -23,8 +23,9 @@ default_tests: &default_tests
 
 # rpmbuild(8) is not available or installed on most platforms
 skip_rpm: &skip_rpm
-  - "-//tests/rpm/..."
-  - "-//pkg/legacy/tests/rpm/..."
+  test_targets:
+    - "-//tests/rpm/..."
+    - "-//pkg/legacy/tests/rpm/..."
 
 win_tests: &win_tests
   test_targets:
@@ -38,6 +39,7 @@ win_tests: &win_tests
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"
     - "-//tests/mappings/filter_directory/..."
+
 #
 # Commmon features by platform
 # 

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -14,28 +14,39 @@ rolling: &rolling
 #
 # Groups of tests, by platform
 #
-default_tests: &default_tests
-  - "//distro/..."
-  - "//pkg/..."
-  - "//tests/..."
-  - "//toolchains/..."
 
 # rpmbuild(8) is not available or installed on most platforms
-skip_rpm_tests: &skip_rpm_tests
-  - "-//tests/rpm/..."
-  - "-//pkg/legacy/tests/rpm/..."
+default_tests: &default_tests
+  test_targets:
+    - "//distro/..."
+    - "//pkg/..."
+    - "//tests/..."
+    - "//toolchains/..."
+    - "-//tests/rpm/..."
+    - "-//pkg/legacy/tests/rpm/..."
+
+default_tests_with_rpm: &default_tests_with_rpm
+  test_targets:
+    - "//distro/..."
+    - "//pkg/..."
+    - "//tests/..."
+    - "//toolchains/..."
 
 win_tests: &win_tests
-  - "//pkg/..."
-  - "//tests/..."
-  - "//toolchains/..."
-  - "-//tests:make_rpm_test"
-  - "-//tests:package_naming_aggregate_test"
-  - "-//tests:path_test"
-  # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
-  # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
-  - "-//tests/mappings:utf8_manifest_test"
-  - "-//tests/mappings/filter_directory/..."
+  test_targets:
+    - "//pkg/..."
+    - "//tests/..."
+    - "//toolchains/..."
+    - "-//tests:make_rpm_test"
+    - "-//tests:package_naming_aggregate_test"
+    - "-//tests:path_test"
+    # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
+    # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
+    - "-//tests/mappings:utf8_manifest_test"
+    - "-//tests/mappings/filter_directory/..."
+    # rpmbuild(8) is not supported on Windows
+    - "-//tests/rpm/..."
+    - "-//pkg/legacy/tests/rpm/..."
 
 #
 # Commmon features by platform
@@ -43,9 +54,7 @@ win_tests: &win_tests
 ubuntu1804: &ubuntu
   platform: ubuntu1804
   <<: *common
-  test_targets:
-    <<: *default_tests
-    <<: *skip_rpm_tests
+  <<: *default_tests
   build_targets:
     - "//distro:distro"
     - "//distro:relnotes"
@@ -54,23 +63,17 @@ ubuntu1804: &ubuntu
 centos7: &centos
   platform: centos7
   <<: *common
-  test_targets:
-    <<: *default_tests
+  <<: *default_tests_with_rpm
 
 macos: &macos
   platform: macos
   <<: *common
-  test_targets:
-    <<: *default_tests
-    <<: *skip_rpm_tests
+  <<: *default_tests
 
 windows: &windows
   platform: windows
   <<: *common
-  test_targets:
-    <<: *win_tests
-    # rpmbuild is not available on windows
-    <<: *skip_rpm_tests
+  <<: *win_tests
 
 #
 # Finally, the cross product of bazel releases X platforms

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -15,30 +15,27 @@ rolling: &rolling
 # Groups of tests, by platform
 #
 default_tests: &default_tests
-  test_targets:
-    - "//distro/..."
-    - "//pkg/..."
-    - "//tests/..."
-    - "//toolchains/..."
+  - "//distro/..."
+  - "//pkg/..."
+  - "//tests/..."
+  - "//toolchains/..."
 
 # rpmbuild(8) is not available or installed on most platforms
-skip_rpm: &skip_rpm
-  test_targets:
-    - "-//tests/rpm/..."
-    - "-//pkg/legacy/tests/rpm/..."
+skip_rpm_tests: &skip_rpm_tests
+  - "-//tests/rpm/..."
+  - "-//pkg/legacy/tests/rpm/..."
 
 win_tests: &win_tests
-  test_targets:
-    - "//pkg/..."
-    - "//tests/..."
-    - "//toolchains/..."
-    - "-//tests:make_rpm_test"
-    - "-//tests:package_naming_aggregate_test"
-    - "-//tests:path_test"
-    # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
-    # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
-    - "-//tests/mappings:utf8_manifest_test"
-    - "-//tests/mappings/filter_directory/..."
+  - "//pkg/..."
+  - "//tests/..."
+  - "//toolchains/..."
+  - "-//tests:make_rpm_test"
+  - "-//tests:package_naming_aggregate_test"
+  - "-//tests:path_test"
+  # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
+  # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
+  - "-//tests/mappings:utf8_manifest_test"
+  - "-//tests/mappings/filter_directory/..."
 
 #
 # Commmon features by platform
@@ -46,8 +43,9 @@ win_tests: &win_tests
 ubuntu1804: &ubuntu
   platform: ubuntu1804
   <<: *common
-  <<: *default_tests
-  <<: *skip_rpm
+  test_targets:
+    <<: *default_tests
+    <<: *skip_rpm_tests
   build_targets:
     - "//distro:distro"
     - "//distro:relnotes"
@@ -56,20 +54,23 @@ ubuntu1804: &ubuntu
 centos7: &centos
   platform: centos7
   <<: *common
-  <<: *default_tests
+  test_targets:
+    <<: *default_tests
 
 macos: &macos
   platform: macos
   <<: *common
-  <<: *default_tests
-  <<: *skip_rpm
+  test_targets:
+    <<: *default_tests
+    <<: *skip_rpm_tests
 
 windows: &windows
   platform: windows
   <<: *common
-  <<: *win_tests
-  # rpmbuild is not available on windows
-  <<: *skip_rpm
+  test_targets:
+    <<: *win_tests
+    # rpmbuild is not available on windows
+    <<: *skip_rpm_tests
 
 #
 # Finally, the cross product of bazel releases X platforms

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -37,16 +37,21 @@ win_tests: &win_tests
     - "//pkg/..."
     - "//tests/..."
     - "//toolchains/..."
-    - "-//tests:make_rpm_test"
     - "-//tests:package_naming_aggregate_test"
     - "-//tests:path_test"
     # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"
     - "-//tests/mappings/filter_directory/..."
+    # See #387
+    - "-//tests/install/..."
     # rpmbuild(8) is not supported on Windows
     - "-//tests/rpm/..."
     - "-//pkg/legacy/tests/rpm/..."
+    # RPM-related, but not applicable to Windows given the above.  Also relies
+    # on a Bourne Shell.  On other platforms, this exercises a dummy "rpmbuild",
+    # so it's OK to keep around.
+    - "-//tests:make_rpm_test"
 
 #
 # Commmon features by platform


### PR DESCRIPTION
During this month's public meeting, we discovered that none of the RPM packaging
tests were not being run in CI.  This looks like it was overlooked in 85eabf2.

This change fixes this by adding a new `default_tests_with_rpm` merge key, and using that on the CentOS 7 hosts, which have an `rpmbuild` toolchain.

Other minor cleanup and commentary also added.