### PR TITLE
improve the docs table of contents

### DIFF
--- a/doc_build/toc.md.tpl
+++ b/doc_build/toc.md.tpl
@@ -9,20 +9,20 @@
 
   <h2>Packaging Rules</h2>
   <ul>
-    <li><a href="#pkg_deb">pkg_deb</a></li>
-    <li><a href="#pkg_tar">pkg_tar</a></li>
-    <li><a href="#pkg_rpm">pkg_rpm</a></li>
-    <li><a href="#pkg_zip">pkg_zip</a></li>
+    <li><a href="#pkg_deb">//pkg:deb.bzl%pkg_deb</a></li>
+    <li><a href="#pkg_rpm">//pkg:rpm.bzl%pkg_rpm</a></li>
+    <li><a href="#pkg_tar">//pkg:tar.bzl%pkg_tar</a></li>
+    <li><a href="#pkg_zip">//pkg:zip.bzl%pkg_zip</a></li>
   </ul>
 
   <h2>File Tree Creation Rules</h2>
   <ul>
-    <li><a href="#filter_directory">filter_directory</a></li>
-    <li><a href="#pkg_filegroup">pkg_filegroup</a></li>
-    <li><a href="#pkg_files">pkg_files</a></li>
-    <li><a href="#pkg_mkdirs">pkg_mkdirs</a></li>
-    <li><a href="#pkg_mklink">pkg_mklink</a></li>
-    <li><a href="#pkg_attributes">pkg_attributes</a></li>
-    <li><a href="#strip_prefix.files_only">strip_prefix</a></li>
+    <li><a href="#filter_directory">//pkg:mappings.bzl%filter_directory</a></li>
+    <li><a href="#pkg_filegroup">//pkg:mappings.bzl%pkg_filegroup</a></li>
+    <li><a href="#pkg_files">//pkg:mappings.bzl%pkg_files</a></li>
+    <li><a href="#pkg_mkdirs">//pkg:mappings.bzl%pkg_mkdirs</a></li>
+    <li><a href="#pkg_mklink">//pkg:mappings.bzl%pkg_mklink</a></li>
+    <li><a href="#pkg_attributes">//pkg:mappings.bzl%pkg_attributes</a></li>
+    <li><a href="#strip_prefix.files_only">//pkg:mappings.bzl%strip_prefix</a></li>
   </ul>
 </div>

--- a/docs/0.6.0/reference.md
+++ b/docs/0.6.0/reference.md
@@ -9,23 +9,24 @@
 
   <h2>Packaging Rules</h2>
   <ul>
-    <li><a href="#pkg_deb">pkg_deb</a></li>
-    <li><a href="#pkg_tar">pkg_tar</a></li>
-    <li><a href="#pkg_rpm">pkg_rpm</a></li>
-    <li><a href="#pkg_zip">pkg_zip</a></li>
+    <li><a href="#pkg_deb">//pkg:deb.bzl%pkg_deb</a></li>
+    <li><a href="#pkg_rpm">//pkg:rpm.bzl%pkg_rpm</a></li>
+    <li><a href="#pkg_tar">//pkg:pkg.bzl%pkg_tar</a></li>
+    <li><a href="#pkg_zip">//pkg:zip.bzl%pkg_zip</a></li>
   </ul>
 
   <h2>File Tree Creation Rules</h2>
   <ul>
-    <li><a href="#filter_directory">filter_directory</a></li>
-    <li><a href="#pkg_filegroup">pkg_filegroup</a></li>
-    <li><a href="#pkg_files">pkg_files</a></li>
-    <li><a href="#pkg_mkdirs">pkg_mkdirs</a></li>
-    <li><a href="#pkg_mklink">pkg_mklink</a></li>
-    <li><a href="#pkg_attributes">pkg_attributes</a></li>
-    <li><a href="#strip_prefix.files_only">strip_prefix</a></li>
+    <li><a href="#filter_directory">//pkg:mappings.bzl%filter_directory</a></li>
+    <li><a href="#pkg_filegroup">//pkg:mappings.bzl%pkg_filegroup</a></li>
+    <li><a href="#pkg_files">//pkg:mappings.bzl%pkg_files</a></li>
+    <li><a href="#pkg_mkdirs">//pkg:mappings.bzl%pkg_mkdirs</a></li>
+    <li><a href="#pkg_mklink">//pkg:mappings.bzl%pkg_mklink</a></li>
+    <li><a href="#pkg_attributes">//pkg:mappings.bzl%pkg_attributes</a></li>
+    <li><a href="#strip_prefix.files_only">//pkg:mappings.bzl%strip_prefix</a></li>
   </ul>
 </div>
+
 <a name="common"></a>
 
 ### Common Attributes

--- a/docs/latest.md
+++ b/docs/latest.md
@@ -9,21 +9,21 @@
 
   <h2>Packaging Rules</h2>
   <ul>
-    <li><a href="#pkg_deb">pkg_deb</a></li>
-    <li><a href="#pkg_tar">pkg_tar</a></li>
-    <li><a href="#pkg_rpm">pkg_rpm</a></li>
-    <li><a href="#pkg_zip">pkg_zip</a></li>
+    <li><a href="#pkg_deb">//pkg:deb.bzl%pkg_deb</a></li>
+    <li><a href="#pkg_rpm">//pkg:rpm.bzl%pkg_rpm</a></li>
+    <li><a href="#pkg_tar">//pkg:tar.bzl%pkg_tar</a></li>
+    <li><a href="#pkg_zip">//pkg:zip.bzl%pkg_zip</a></li>
   </ul>
 
   <h2>File Tree Creation Rules</h2>
   <ul>
-    <li><a href="#filter_directory">filter_directory</a></li>
-    <li><a href="#pkg_filegroup">pkg_filegroup</a></li>
-    <li><a href="#pkg_files">pkg_files</a></li>
-    <li><a href="#pkg_mkdirs">pkg_mkdirs</a></li>
-    <li><a href="#pkg_mklink">pkg_mklink</a></li>
-    <li><a href="#pkg_attributes">pkg_attributes</a></li>
-    <li><a href="#strip_prefix.files_only">strip_prefix</a></li>
+    <li><a href="#filter_directory">//pkg:mappings.bzl%filter_directory</a></li>
+    <li><a href="#pkg_filegroup">//pkg:mappings.bzl%pkg_filegroup</a></li>
+    <li><a href="#pkg_files">//pkg:mappings.bzl%pkg_files</a></li>
+    <li><a href="#pkg_mkdirs">//pkg:mappings.bzl%pkg_mkdirs</a></li>
+    <li><a href="#pkg_mklink">//pkg:mappings.bzl%pkg_mklink</a></li>
+    <li><a href="#pkg_attributes">//pkg:mappings.bzl%pkg_attributes</a></li>
+    <li><a href="#strip_prefix.files_only">//pkg:mappings.bzl%strip_prefix</a></li>
   </ul>
 </div>
 <a name="common"></a>


### PR DESCRIPTION
Make the docs table of contents more useful by including the .bzl files where the rules are defined. E.g.  //pkg:zip.bzl%pkg_zip.   Without that, you just have to know.

It would be nice if stardoc had support for adding the bzl path out of the box.
https://github.com/bazelbuild/stardoc/issues/120