### PR TITLE
add tests for tree artifact zip

### DIFF
--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -71,6 +71,11 @@ copy_file(
 )
 
 pkg_zip(
+    name = "test_zip_tree",
+    srcs = [":generate_tree"],
+)
+
+pkg_zip(
     name = "test_zip_empty",
     srcs = [],
 )
@@ -184,6 +189,7 @@ py_test(
     ],
     data = [
         "test_zip_empty.zip",
+        "test_zip_tree.zip",
         "test_zip_basic.zip",
         "test_zip_package_dir0.zip",
         "test_zip_timestamp.zip",

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -112,6 +112,15 @@ class ZipContentsCase(ZipTest):
         {"filename": "abc/def/loremipsum.txt", "crc": LOREM_CRC},
     ])
 
+  def test_zip_tree(self):
+      self.assertZipFileContent("test_zip_tree.zip", [
+          {"filename": "b/e"},
+          {"filename": "b/c/d"},
+          {"filename": "b/d"},
+          {"filename": "a/a"},
+          {"filename": "a/b/c"},
+      ])
+
   def test_zip_strip_prefix_empty(self):
     self.assertZipFileContent("test-zip-strip_prefix-empty.zip", [
         {"filename": "loremipsum.txt", "crc": LOREM_CRC},


### PR DESCRIPTION
tests are, as yet, failing due to the feature not being implemented yet