### PR TITLE
silence a spurious buildifier warning

### DIFF
--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -*- coding: utf-8 -*-
+"""Tests for pkg_tar."""
 
+# buildifier: disable=bzl-visibility
 load("//pkg/private/tar:tar.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_tar")
 load("//tests:my_package_name.bzl", "my_package_naming")
 load("//tests/util:defs.bzl", "directory", "fake_artifact")


### PR DESCRIPTION
It complains that I can not import pkg/private/tar/tar.bzl from the tests.
True, it is good to warn people about importing someone else's private packages, but the tests are explicitly not collocated with the rules, so there it is.