### PR TITLE
get rid of the long deprecated archive_name and extension from pkg_zip

### DIFF
--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -169,26 +169,10 @@ limited to a granularity of 2 seconds.""",
 )
 
 def pkg_zip(name, **kwargs):
-    """Creates a .zip file. See pkg_zip_impl."""
-    extension = kwargs.pop("extension", None)
-    if extension:
-        # buildifier: disable=print
-        print("'extension' is deprecated. Use 'package_file_name' or 'out' to name the output.")
-    else:
-        extension = "zip"
-    archive_name = kwargs.pop("archive_name", None)
-    if archive_name:
-        if kwargs.get("package_file_name"):
-            fail("You may not set both 'archive_name' and 'package_file_name'.")
-
-        # buildifier: disable=print
-        print("archive_name is deprecated. Use package_file_name instead.")
-        kwargs["package_file_name"] = archive_name + "." + extension
-    else:
-        archive_name = name
+    """Creates a .zip file.  @wraps(pkg_zip_impl)"""
     pkg_zip_impl(
         name = name,
-        out = archive_name + "." + extension,
+        out = name + ".zip",
         private_stamp_detect = select({
             _stamp_condition: True,
             "//conditions:default": False,

--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -77,9 +77,14 @@ pkg_zip(
 
 # The contents of this file should equal test_zip_empty
 pkg_zip(
-    name = "test_zip_empty_different_extension",
-    srcs = [],
-    extension = "otherkindofzip",
+    name = "test_zip_basic_renamed",
+    srcs = [
+        ":dirs",
+        ":link",
+        "//tests:testdata/hello.txt",
+        "//tests:testdata/loremipsum.txt",
+    ],
+    package_file_name = "test_zip_basic_renamed.foo",
 )
 
 pkg_zip(
@@ -185,6 +190,7 @@ py_test(
     data = [
         "test_zip_empty.zip",
         "test_zip_basic.zip",
+        "test_zip_basic_renamed",
         "test_zip_package_dir0.zip",
         "test_zip_timestamp.zip",
         "test_zip_permissions.zip",
@@ -195,7 +201,6 @@ py_test(
 
         # these could be replaced with diff_test() rules (from skylib)
         "test_zip_basic_timestamp_before_epoch.zip",
-        "test_zip_empty_different_extension.otherkindofzip",
         "test_zip_package_dir1.zip",
         "test_zip_package_dir2.zip",
     ],

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -153,8 +153,8 @@ class ZipEquivalency(ZipTest):
 
   def test_extension(self):
     self.assertFilesEqual(
-        "test_zip_empty_different_extension.otherkindofzip",
-        "test_zip_empty.zip",
+        "test_zip_basic_renamed.foo",
+        "test_zip_basic.zip",
     )
 
   def test_package_dir1(self):


### PR DESCRIPTION
It is time.