### PR TITLE
Refactor archive.py to make adding parent directories easier to understand

### DIFF
--- a/pkg/private/archive.py
+++ b/pkg/private/archive.py
@@ -316,8 +316,6 @@ class TarFileWriter(object):
     if name == '.':
       return
     name = self.add_root_prefix(name)
-    if kind == tarfile.DIRTYPE and name in self.directories:
-      return
     if name in self.members:
       return
 


### PR DESCRIPTION
This is a precursor PR to cleaning up the use of './' in pkg_tar and
pkg_deb. The followups may require more changes to the tar writer,
and doing this refactor first will make anything downstream easier to
reason about.

The core of this change is to change adding the parent tree from
a recursive call of add_file to an iterative one building up a
path from root to tail. The recursion had difficult to understand
termination conditions, with checks sprinkled in a few places.
The refactoring makes the concept clearer.

#531