### PR TITLE
Fix pkg_tar to not add the ./ to the prefix of every member.

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -70,7 +70,6 @@ def _pkg_tar_impl(ctx):
 
     # Start building the arguments.
     args = ctx.actions.args()
-    args.add("--root_directory", ctx.attr.package_base)
     args.add("--output", output_file.path)
     args.add("--mode", ctx.attr.mode)
     args.add("--owner", ctx.attr.owner)
@@ -245,8 +244,9 @@ pkg_tar_impl = rule(
     implementation = _pkg_tar_impl,
     attrs = {
         "strip_prefix": attr.string(),
-        "package_base": attr.string(default = "./"),
-        "package_dir": attr.string(),
+        "package_dir": attr.string(
+            doc = """Prefix to be prepend to all paths written."""
+        ),
         "package_dir_file": attr.label(allow_single_file = True),
         "deps": attr.label_list(allow_files = tar_filetype),
         "srcs": attr.label_list(allow_files = True),

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -133,17 +133,17 @@ class PkgDebTest(unittest.TestCase):
   def test_expected_files(self):
     # Check the set of 'test-tar-basic-*' smoke test.
     expected = [
-        {'name': './etc', 'isdir': True,
+        {'name': 'etc', 'isdir': True,
          'uid': 24, 'gid': 42, 'uname': 'foobar', 'gname': 'fizzbuzz'},
-        {'name': './etc/nsswitch.conf',
+        {'name': 'etc/nsswitch.conf',
          'mode': 0o644,
          'uid': 24, 'gid': 42, 'uname': 'foobar', 'gname': 'fizzbuzz'
          },
-        {'name': './usr', 'isdir': True,
+        {'name': 'usr', 'isdir': True,
          'uid': 42, 'gid': 24, 'uname': 'fizzbuzz', 'gname': 'foobar'},
-        {'name': './usr/bin', 'isdir': True},
-        {'name': './usr/bin/java', 'linkname': '/path/to/bin/java'},
-        {'name': './usr/fizzbuzz',
+        {'name': 'usr/bin', 'isdir': True},
+        {'name': 'usr/bin/java', 'linkname': '/path/to/bin/java'},
+        {'name': 'usr/fizzbuzz',
          'mode': 0o755,
          'uid': 42, 'gid': 24, 'uname': 'fizzbuzz', 'gname': 'foobar'},
     ]

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -40,10 +40,11 @@ class PkgTarTest(unittest.TestCase):
     # NOTE: This is portable to Windows. os.path.join('rules_pkg', 'tests',
     # filename) is not.
     file_path = runfiles.Create().Rlocation('rules_pkg/tests/tar/' + file_name)
+    got = []
     with tarfile.open(file_path, 'r:*') as f:
       i = 0
       for info in f:
-        print('============got', info.name)
+        got.append(info.name)
         error_msg = 'Extraneous file at end of archive %s: %s' % (
             file_path,
             info.name
@@ -66,65 +67,66 @@ class PkgTarTest(unittest.TestCase):
             print(error_msg)
         i += 1
       if i < len(content):
-        self.fail('Missing file %s in archive %s' % (content[i], file_path))
+        self.fail('Missing file %s in archive %s of [%s]' % (
+            content[i], file_path, ',\n    '.join(got)))
 
   def test_strip_prefix_empty(self):
     content = [
-        {'name': './nsswitch.conf'},
+        {'name': 'nsswitch.conf'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-empty.tar', content)
 
   def test_strip_prefix_none(self):
     content = [
-        {'name': './nsswitch.conf'},
+        {'name': 'nsswitch.conf'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-none.tar', content)
 
   def test_strip_prefix_etc(self):
     content = [
-        {'name': './nsswitch.conf'},
+        {'name': 'nsswitch.conf'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-etc.tar', content)
 
   def test_strip_prefix_substring(self):
     content = [
-        {'name': './etc', 'isdir': True},
-        {'name': './etc/nsswitch.conf'},
+        {'name': 'etc', 'isdir': True},
+        {'name': 'etc/nsswitch.conf'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-substring.tar', content)
 
   def test_strip_prefix_dot(self):
     content = [
-        {'name': './etc'},
-        {'name': './etc/nsswitch.conf'},
-        {'name': './external'},
-        {'name': './external/bazel_tools'},
-        {'name': './external/bazel_tools/tools'},
-        {'name': './external/bazel_tools/tools/python'},
-        {'name': './external/bazel_tools/tools/python/runfiles'},
-        {'name': './external/bazel_tools/tools/python/runfiles/runfiles.py'},
+        {'name': 'etc'},
+        {'name': 'etc/nsswitch.conf'},
+        {'name': 'external'},
+        {'name': 'external/bazel_tools'},
+        {'name': 'external/bazel_tools/tools'},
+        {'name': 'external/bazel_tools/tools/python'},
+        {'name': 'external/bazel_tools/tools/python/runfiles'},
+        {'name': 'external/bazel_tools/tools/python/runfiles/runfiles.py'},
     ]
     self.assertTarFileContent('test-tar-strip_prefix-dot.tar', content)
 
   def test_strip_files_dict(self):
     content = [
-        {'name': './not-etc'},
-        {'name': './not-etc/mapped-filename.conf'},
+        {'name': 'not-etc'},
+        {'name': 'not-etc/mapped-filename.conf'},
     ]
     self.assertTarFileContent('test-tar-files_dict.tar', content)
 
   def test_empty_files(self):
     content = [
-        {'name': './a', 'size': 0, 'uid': 0},
-        {'name': './b', 'size': 0, 'uid': 0, 'mtime': PORTABLE_MTIME},
+        {'name': 'a', 'size': 0, 'uid': 0},
+        {'name': 'b', 'size': 0, 'uid': 0, 'mtime': PORTABLE_MTIME},
     ]
     self.assertTarFileContent('test-tar-empty_files.tar', content)
 
   def test_empty_dirs(self):
     content = [
-        {'name': './pmt', 'isdir': True, 'size': 0, 'uid': 0,
+        {'name': 'pmt', 'isdir': True, 'size': 0, 'uid': 0,
          'mtime': PORTABLE_MTIME},
-        {'name': './tmp', 'isdir': True, 'size': 0, 'uid': 0,
+        {'name': 'tmp', 'isdir': True, 'size': 0, 'uid': 0,
          'mtime': PORTABLE_MTIME},
     ]
     self.assertTarFileContent('test-tar-empty_dirs.tar', content)
@@ -132,24 +134,24 @@ class PkgTarTest(unittest.TestCase):
   def test_mtime(self):
     # Note strange mtime. It is specified in the BUILD file.
     content = [
-        {'name': './nsswitch.conf', 'mtime': 946684740},
+        {'name': 'nsswitch.conf', 'mtime': 946684740},
     ]
     self.assertTarFileContent('test-tar-mtime.tar', content)
 
   def test_basic(self):
     # Check the set of 'test-tar-basic-*' smoke test.
     content = [
-        {'name': './etc',
+        {'name': 'etc',
          'uid': 24, 'gid': 42, 'uname': 'tata', 'gname': 'titi'},
-        {'name': './etc/nsswitch.conf',
+        {'name': 'etc/nsswitch.conf',
          'mode': 0o644,
          'uid': 24, 'gid': 42, 'uname': 'tata', 'gname': 'titi'
          },
-        {'name': './usr',
+        {'name': 'usr',
          'uid': 42, 'gid': 24, 'uname': 'titi', 'gname': 'tata'},
-        {'name': './usr/bin'},
-        {'name': './usr/bin/java', 'linkname': '/path/to/bin/java'},
-        {'name': './usr/titi',
+        {'name': 'usr/bin'},
+        {'name': 'usr/bin/java', 'linkname': '/path/to/bin/java'},
+        {'name': 'usr/titi',
          'mode': 0o755,
          'uid': 42, 'gid': 24, 'uname': 'titi', 'gname': 'tata'},
     ]
@@ -160,13 +162,13 @@ class PkgTarTest(unittest.TestCase):
 
   def test_file_inclusion(self):
     content = [
-        {'name': './etc', 'uid': 24, 'gid': 42},
-        {'name': './etc/nsswitch.conf', 'mode': 0o644, 'uid': 24, 'gid': 42},
-        {'name': './usr', 'uid': 42, 'gid': 24},
-        {'name': './usr/bin'},
-        {'name': './usr/bin/java', 'linkname': '/path/to/bin/java'},
-        {'name': './usr/titi', 'mode': 0o755, 'uid': 42, 'gid': 24},
-        {'name': './BUILD'},
+        {'name': 'etc', 'uid': 24, 'gid': 42},
+        {'name': 'etc/nsswitch.conf', 'mode': 0o644, 'uid': 24, 'gid': 42},
+        {'name': 'usr', 'uid': 42, 'gid': 24},
+        {'name': 'usr/bin'},
+        {'name': 'usr/bin/java', 'linkname': '/path/to/bin/java'},
+        {'name': 'usr/titi', 'mode': 0o755, 'uid': 42, 'gid': 24},
+        {'name': 'BUILD'},
     ]
     for ext in [('.' + comp if comp else '') for comp in archive.COMPRESSIONS]:
       with self.subTest(ext=ext):
@@ -175,23 +177,23 @@ class PkgTarTest(unittest.TestCase):
 
   def test_strip_prefix_empty(self):
     content = [
-        {'name': './level1'},
-        {'name': './level1/some_value'},
-        {'name': './level1/some_value/level3'},
-        {'name': './level1/some_value/level3/BUILD'},
+        {'name': 'level1'},
+        {'name': 'level1/some_value'},
+        {'name': 'level1/some_value/level3'},
+        {'name': 'level1/some_value/level3/BUILD'},
     ]
     self.assertTarFileContent('test_tar_package_dir_substitution.tar', content)
 
   def test_tar_with_long_file_name(self):
     content = [
-      {'name': './file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
+      {'name': 'file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
     ]
     self.assertTarFileContent('test-tar-long-filename.tar', content)
 
   def test_repackage_file_with_long_name(self):
     content = [
-      {'name': './can_i_repackage_a_file_with_a_long_name'},
-      {'name': './can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
+      {'name': 'can_i_repackage_a_file_with_a_long_name'},
+      {'name': 'can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt'}
     ]
     self.assertTarFileContent('test-tar-repackaging-long-filename.tar', content)
 
@@ -204,24 +206,24 @@ class PkgTarTest(unittest.TestCase):
     #  "b/e"
 
     content = [
-      {'name': './a_tree', 'isdir': True},
-      {'name': './a_tree/a', 'isdir': True},
-      {'name': './a_tree/a/a'},
-      {'name': './a_tree/a/b', 'isdir': True},
-      {'name': './a_tree/a/b/c'},
-      {'name': './a_tree/b', 'isdir': True},
-      {'name': './a_tree/b/c', 'isdir': True},
-      {'name': './a_tree/b/c/d'},
-      {'name': './a_tree/b/d'},
-      {'name': './a_tree/b/e'},
+      {'name': 'a_tree', 'isdir': True},
+      {'name': 'a_tree/a', 'isdir': True},
+      {'name': 'a_tree/a/a'},
+      {'name': 'a_tree/a/b', 'isdir': True},
+      {'name': 'a_tree/a/b/c'},
+      {'name': 'a_tree/b', 'isdir': True},
+      {'name': 'a_tree/b/c', 'isdir': True},
+      {'name': 'a_tree/b/c/d'},
+      {'name': 'a_tree/b/d'},
+      {'name': 'a_tree/b/e'},
     ]
     self.assertTarFileContent('test-tar-tree-artifact.tar', content)
 
   def test_tar_with_runfiles(self):
     content = [
-      {'name': './BUILD' },
-      {'name': './a_program' },
-      {'name': './executable.sh' },
+      {'name': 'BUILD' },
+      {'name': 'a_program' },
+      {'name': 'executable.sh' },
     ]
     self.assertTarFileContent('test-tar-with-runfiles.tar', content)
 


### PR DESCRIPTION
Fixes: #531

- Remove leading './' from merged tar files. Also applies to pkg_deb.
- Remove package_base from pkg_tar. Closes #549
- Use build_tar --directory as the prefix to add to everything.

Note that the code is intentionaly not testing use cases that try to add "./"
as an explicit root. This might still work, but it is a bad idea, for the
reasons described in #531 . If someone comes up with a real need for
using a leading "./" AND it does not work, they can file a feature
request to support it.