### PR TITLE
Fix regression in handling tar deps to pkg_tar when there is a file prefix

### DIFF
--- a/distro/packaging_test.py
+++ b/distro/packaging_test.py
@@ -81,7 +81,7 @@ class PackagingTest(unittest.TestCase):
     # TODO(aiuto): Find tar in a disciplined way
     content = subprocess.check_output(
         ['tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
-    self.assertEqual(b'./BUILD\n', content)
+    self.assertEqual(b'BUILD\n', content)
 
 
 if __name__ == '__main__':

--- a/pkg/private/archive.py
+++ b/pkg/private/archive.py
@@ -357,7 +357,7 @@ class TarFileWriter(object):
               rootgid=None,
               numeric=False,
               name_filter=None,
-              root=None):
+              prefix=None):
     """Merge a tar content into the current tar, stripping timestamp.
 
     Args:
@@ -369,16 +369,17 @@ class TarFileWriter(object):
       name_filter: filter out file by names. If not none, this method will be
           called for each file to add, given the name and should return true if
           the file is to be added to the final tar and false otherwise.
-      root: place all content under given root directory, if not None.
+      prefix: prefix to add to all file paths.  This prefix is added to the
+          incoming file path, then the overall root_directory will also be
+          added.
 
     Raises:
       TarFileWriter.Error: if an error happens when uncompressing the tar file.
     """
-    #if root and root[0] not in ['/', '.']:
-    #  # Root prefix should start with a '/', adds it if missing
-    #  root = '/' + root
+    if prefix:
+      prefix = prefix.strip('/') + '/'
     if _DEBUG_VERBOSITY > 1:
-      print('==========================  root is', root)
+      print('==========================  prefix is', prefix)
     intar = tarfile.open(name=tar, mode='r:*')
     for tarinfo in intar:
       if name_filter is None or name_filter(tarinfo.name):
@@ -394,7 +395,10 @@ class TarFileWriter(object):
           tarinfo.uname = ''
           tarinfo.gname = ''
 
-        name = self.add_root_prefix(tarinfo.name)
+        in_name = tarinfo.name
+        if prefix:
+          in_name = prefix + in_name
+        name = self.add_root_prefix(in_name)
         tarinfo.name = name
         self.add_parents(
             name,
@@ -405,11 +409,11 @@ class TarFileWriter(object):
             uname=tarinfo.uname,
             gname=tarinfo.gname)
 
-        if root is not None:
+        if prefix is not None:
           # Relocate internal hardlinks as well to avoid breaking them.
           link = tarinfo.linkname
           if link.startswith('.') and tarinfo.type == tarfile.LNKTYPE:
-            tarinfo.linkname = '.' + root + link.lstrip('.')
+            tarinfo.linkname = '.' + prefix + link.lstrip('.')
 
         # Remove path pax header to ensure that the proposed name is going
         # to be used. Without this, files with long names will not be

--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -56,7 +56,6 @@ class TarFile(object):
         self.output,
         self.compression,
         self.compressor,
-        root_directory = self.directory,
         default_mtime=self.default_mtime)
     return self
 
@@ -162,10 +161,7 @@ class TarFile(object):
     Args:
       tar: the tar file to add
     """
-    root = None
-    if self.directory and self.directory != '/':
-      root = self.directory
-    self.tarfile.add_tar(tar, numeric=True, root=root)
+    self.tarfile.add_tar(tar, numeric=True, prefix=self.directory)
 
   def add_link(self, symlink, destination, mode=None, ids=None, names=None):
     """Add a symbolic link pointing to `destination`.


### PR DESCRIPTION
If you did
```
pkg_tar(..., package_dir = 'foo', deps=...)
```
The output paths would begin with foo/foo/...