### PR TITLE
Make the .bzl files available as input to a bzl_library

### DIFF
--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -115,21 +115,10 @@ bzl_library(
     name = "rules_pkg_lib",
     srcs = [
         "//:version.bzl",
-        "//pkg:mappings.bzl",
-        "//pkg:package_variables.bzl",
-        "//pkg:path.bzl",
-        "//pkg:providers.bzl",
-        "//pkg:rpm.bzl",
-        "//pkg:rpm_pfg.bzl",
-        "//pkg/legacy:rpm.bzl",
-        "//pkg/private:pkg_files.bzl",
-        "//pkg/private:util.bzl",
-        "//pkg/private/deb:deb.bzl",
-        "//pkg/private/tar:tar.bzl",
-        "//pkg/private/zip:zip.bzl",
+        "//pkg:bzl_srcs",
         "@bazel_skylib//lib:paths",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
 )
 
 py_binary(

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -14,6 +14,7 @@
 
 # -*- coding: utf-8 -*-
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_pkg//pkg/private:make_starlark_library.bzl", "starlark_library")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -42,7 +43,23 @@ filegroup(
         "//pkg/legacy:standard_package",
         "//pkg/rpm:standard_package",
     ],
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
+)
+
+starlark_library(
+    name = "bzl_srcs",
+    srcs = [
+        ":standard_package",
+        "//pkg/private:standard_package",
+        "//pkg/private/deb:standard_package",
+        "//pkg/private/tar:standard_package",
+        "//pkg/private/zip:standard_package",
+        "//pkg/releasing:standard_package",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 # Used by pkg_rpm in rpm.bzl.
@@ -57,8 +74,8 @@ py_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/private:archive",
         "//pkg:make_rpm_lib",
+        "//pkg/private:archive",
     ],
 )
 

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -53,6 +53,7 @@ starlark_library(
     name = "bzl_srcs",
     srcs = [
         ":standard_package",
+        "//pkg:pkg.bzl",
         "//pkg/private:standard_package",
         "//pkg/private/deb:standard_package",
         "//pkg/private/tar:standard_package",

--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -29,7 +29,10 @@ filegroup(
         "*.bzl",
         "*.py",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
 )
 
 exports_files(
@@ -39,6 +42,7 @@ exports_files(
     visibility = [
         "//distro:__pkg__",
         "//doc_build:__pkg__",
+        "//pkg:__pkg__",
     ],
 )
 

--- a/pkg/private/deb/BUILD
+++ b/pkg/private/deb/BUILD
@@ -28,7 +28,10 @@ filegroup(
         "*.bzl",
         "*.py",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
 )
 
 exports_files(
@@ -38,6 +41,7 @@ exports_files(
     visibility = [
         "//distro:__pkg__",
         "//doc_build:__pkg__",
+        "//pkg:__pkg__",
     ],
 )
 

--- a/pkg/private/make_starlark_library.bzl
+++ b/pkg/private/make_starlark_library.bzl
@@ -14,7 +14,7 @@ def _make_starlark_library(ctx):
         else:
             for file in src[DefaultInfo].files.to_list():
                 if file.path.endswith(".bzl"):
-                    print(file.path)
+                    # print(file.path)
                     direct.append(file)
     all_files = depset(direct, transitive = transitive)
     return [

--- a/pkg/private/make_starlark_library.bzl
+++ b/pkg/private/make_starlark_library.bzl
@@ -1,0 +1,35 @@
+"""Turn a label_list of mixed sources and bzl_library's into a bzl_library.
+
+The sources can be anything. Only the ones that end in ".bzl" will be added.
+"""
+
+load("@bazel_skylib//:bzl_library.bzl", "StarlarkLibraryInfo")
+
+def _make_starlark_library(ctx):
+    direct = []
+    transitive = []
+    for src in ctx.attr.srcs:
+        if StarlarkLibraryInfo in src:
+            transitive.append(src[StarlarkLibraryInfo])
+        else:
+            for file in src[DefaultInfo].files.to_list():
+                if file.path.endswith(".bzl"):
+                    print(file.path)
+                    direct.append(file)
+    all_files = depset(direct, transitive = transitive)
+    return [
+        DefaultInfo(files = all_files, runfiles = ctx.runfiles(transitive_files = all_files)),
+        StarlarkLibraryInfo(srcs = direct, transitive_srcs = all_files),
+    ]
+
+starlark_library = rule(
+    implementation = _make_starlark_library,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "Any mix of source files. Only .bzl files will be used.",
+            allow_files = True,
+            cfg = "exec",
+            mandatory = True,
+        ),
+    },
+)

--- a/pkg/private/tar/BUILD
+++ b/pkg/private/tar/BUILD
@@ -28,7 +28,10 @@ filegroup(
         "*.bzl",
         "*.py",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
 )
 
 exports_files(

--- a/pkg/private/zip/BUILD
+++ b/pkg/private/zip/BUILD
@@ -28,7 +28,10 @@ filegroup(
         "*.bzl",
         "*.py",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
 )
 
 exports_files(
@@ -38,6 +41,7 @@ exports_files(
     visibility = [
         "//distro:__pkg__",
         "//doc_build:__pkg__",
+        "//pkg:__pkg__",
     ],
 )
 

--- a/pkg/releasing/BUILD
+++ b/pkg/releasing/BUILD
@@ -24,7 +24,10 @@ filegroup(
         "*.bzl",
         "*.py",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//pkg:__pkg__",
+    ],
 )
 
 py_library(


### PR DESCRIPTION
Make the .bzl files available as input to a bzl_library, without having to resort to the invasivness of a shadow tree of just the .bzl files without the other distributable files.

Fixed #565 