### PR TITLE
Allow pkg_tar to have a package_dir == './'

### DIFF
--- a/distro/packaging_test.py
+++ b/distro/packaging_test.py
@@ -81,7 +81,7 @@ class PackagingTest(unittest.TestCase):
     # TODO(aiuto): Find tar in a disciplined way
     content = subprocess.check_output(
         ['tar', 'tzf', 'bazel-bin/dummy_tar.tar.gz'])
-    self.assertEqual(b'BUILD\n', content)
+    self.assertEqual(b'etc/\netc/BUILD\n', content)
 
 
 if __name__ == '__main__':

--- a/distro/testdata/BUILD.tpl
+++ b/distro/testdata/BUILD.tpl
@@ -7,7 +7,7 @@ pkg_tar(
     ],
     extension = "tar.gz",
     owner = "0.0",
-    package_dir = ".",
+    package_dir = "etc",
     tags = [
         "manual",
     ],

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -281,6 +281,27 @@ pkg_tar(
     package_dir = "a_tree",
 )
 
+fake_artifact(
+    name = "a_program",
+    files = ["//tests:testdata/executable.sh"],
+    runfiles = ["BUILD"],
+)
+
+pkg_tar(
+    name = "test-tar-with-runfiles",
+    srcs = [
+        ":a_program",
+    ],
+    include_runfiles = True,
+)
+
+pkg_tar(
+    name = "test_tar_leading_dotslash",
+    srcs = [
+        "//tests:loremipsum_txt",
+    ],
+    package_dir = ".",
+)
 
 py_test(
     name = "pkg_tar_test",
@@ -298,6 +319,7 @@ py_test(
         ":test-tar-strip_prefix-etc.tar",
         ":test-tar-strip_prefix-none.tar",
         ":test-tar-strip_prefix-substring.tar",
+        ":test_tar_leading_dotslash",
         ":test_tar_package_dir_substitution.tar",
         ":test-tar-long-filename",
         ":test-tar-repackaging-long-filename.tar",
@@ -358,20 +380,6 @@ pkg_tar(
         "//tests:testdata/loremipsum.txt",
     ],
     extension = ".bz2",
-)
-
-fake_artifact(
-    name = "a_program",
-    files = ["//tests:testdata/executable.sh"],
-    runfiles = ["BUILD"],
-)
-
-pkg_tar(
-    name = "test-tar-with-runfiles",
-    srcs = [
-        ":a_program",
-    ],
-    include_runfiles = True,
 )
 
 py_test(

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -241,6 +241,12 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test-tar-with-runfiles.tar', content)
 
+  def test_tar_leading_dotslash(self):
+    content = [
+      {'name': './loremipsum.txt'},
+    ]
+    self.assertTarFileContent('test_tar_leading_dotslash.tar', content)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
We still never create a lone '.' as a directory in the archive. That is
intentional

There are a few parts to this:

- Remove the root_directory logic from tar_writer. It was a needless feature
  inherited from an ancient implementation. It was not used by anything except
  the tests.
- Stop re-normalizing paths in tar_writer. It should do what it is asked.  The
  implication is that all the test which accounted for test data which which
  contained tar files with paths like './a', will now keep the './'.
- Add a test to show prefix_dir == './' does work.

RELNOTES: pkg_tar no longer prefixes paths with './'.

Fixes #50