### PR TITLE
update CHANGELOG for r7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Make the .bzl files available as input to a bzl_library (#567)
 - Allow pkg_files.strip_prefix to work on tree artifact without having to use `renames`.
 - Add @rules_license style license declarations (#508)
-- Better looking [documentation)[https://bazelbuild.github.io/rules_pkg/0.7.0/reference.html]
+- Better looking [documentation](https://bazelbuild.github.io/rules_pkg/0.7.0/reference.html)
 - Add `artifact_name` to `print_relnotes` (#541)
 - pkg_{deb,rpm,tar,zip} are now available via individual .bzl files, so you
   only need to load what you actually need.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# Release 0.7.0
+
+## New Features
+- Make the .bzl files available as input to a bzl_library (#567)
+- Allow pkg_files.strip_prefix to work on tree artifact without having to use `renames`.
+- Add @rules_license style license declarations (#508)
+- Better looking [documentation)[https://bazelbuild.github.io/rules_pkg/0.7.0/reference.html]
+- Add `artifact_name` to `print_relnotes` (#541)
+- pkg_{deb,rpm,tar,zip} are now available via individual .bzl files, so you
+  only need to load what you actually need.
+- Add tree artifact support to pkg_zip (#537)
+- symlink support to pkg_zip (#499)
+
+## Potentially breaking changes
+
+- Get rid of the long deprecated archive_name and extension from pkg_zip. (#552)
+  - Make 'out' work in a reasonable way. Fixes #414
+  - Partial fix for #284
+ 
+## Bug fixes:
+
+- Only allow .deb Description to be multiline. (#573)
+  Fixes: https://github.com/bazelbuild/rules_pkg/issues/572
+- Fix pkg_tar to not add the ./ to the prefix of every member. (#554). Closes: #531
+- Stop stripping tree artifact root name in pkg_tar and pkg_zip. (#555). Closes #404
+- Fix RPM source date epoch for rpmbuild 4.17+ (#529)
+
+
+## Contributors
+
+Thanks to: Andrew Psaltis, Gunnar Wagenknecht, and Sven Mueller
+for contributions to this release.
+
+
 # Release 0.6.0
 
 This revision requires Bazel 4.x or greater


### PR DESCRIPTION
I want to do a 0.7.0 release so that we can fix the bazel .deb packaging for their 5.2.

This is actually a good cut point.  Several major features get out and I don't have to rush the runfiles support.