### PR TITLE
Support for setting executable bits.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,15 @@ bazel_skylib_workspace()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_archive(
+    name = "platforms",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+    ],
+    sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+)
+
 # Find rpmbuild if it exists.
 load("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild")
 

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -277,8 +277,6 @@ def add_label_list(
             default_group = default_group,
         ):
             # Add in the files of srcs which are not pkg_* types
-            # We can 
-
             add_from_default_info(
                 content_map,
                 file_deps,
@@ -318,7 +316,6 @@ def add_from_default_info(
 
     # Auto-detect the executable so we can set its mode.
     the_executable = get_my_executable(src)
-    file_deps.append(src[DefaultInfo].files)
     all_files = src[DefaultInfo].files.to_list()
     for f in all_files:
         d_path = dest_path(f, data_path, data_path_without_prefix)
@@ -357,22 +354,21 @@ def get_my_executable(src):
     Returns:
       File or None.
     """
-    the_executable = None  # The file which is the actual executable.
-    if DefaultInfo in src:
-        di = src[DefaultInfo]
-        # XXX print(ctx.label, dir(di))
-        if hasattr(di, "files_to_run"):
-            ftr = di.files_to_run
-            # The docs lead you to believe that you could look at
-            # files_to_run.executable, but that is filled out even for
-            # source files.
-            # XXX print(dir(ftr))
-            if hasattr(ftr, "runfiles_manifest"):
-                # XXX print(ftr.executable, ftr.runfiles_manifest)
-                if ftr.runfiles_manifest:
-                    # XX print("Got an manifest executable", ftr.executable)
-                    the_executable = ftr.executable
-    return the_executable
+    if not DefaultInfo in src:
+        return None
+    di = src[DefaultInfo]
+    if not hasattr(di, "files_to_run"):
+        return None
+    ftr = di.files_to_run
+    # The docs lead you to believe that you could look at
+    # files_to_run.executable, but that is filled out even for source
+    # files.
+    if not hasattr(ftr, "runfiles_manifest"):
+        return None
+    if ftr.runfiles_manifest:
+        # DEBUG print("Got an manifest executable", ftr.executable)
+        return ftr.executable
+    return None
 
 
 def add_single_file(content_map, dest_path, src, origin, mode = None, user = None, group = None):

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -31,6 +31,13 @@ licenses(["notice"])
 
 exports_files(glob(["testdata/**"]))
 
+#XXXXconfig_setting(
+#    name = "windows",
+#    constraint_values = ["@platforms//os:windows"],
+#    visibility = ["//visibility:public"],
+#)
+
+
 filegroup(
     name = "loremipsum_txt",
     srcs = [

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -22,7 +22,10 @@ load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs")
 load("//pkg:tar.bzl", "pkg_tar")
 load("//pkg:zip.bzl", "pkg_zip")
 
-package(default_applicable_licenses = ["//:license"])
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = ["//tests:__subpackages__"],
+)
 
 licenses(["notice"])
 
@@ -64,6 +67,11 @@ py_test(
     data = ["//pkg:path.bzl"],
     python_version = "PY3",
     srcs_version = "PY3",
+)
+
+cc_binary(
+  name = "an_executable",
+  srcs = ["foo.cc"],
 )
 
 py_test(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -31,13 +31,6 @@ licenses(["notice"])
 
 exports_files(glob(["testdata/**"]))
 
-#XXXXconfig_setting(
-#    name = "windows",
-#    constraint_values = ["@platforms//os:windows"],
-#    visibility = ["//visibility:public"],
-#)
-
-
 filegroup(
     name = "loremipsum_txt",
     srcs = [

--- a/tests/foo.cc
+++ b/tests/foo.cc
@@ -1,0 +1,1 @@
+int main(int argc, char* argv[]) { return 0; }

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -134,8 +134,17 @@ write_content_manifest(
     ],
 )
 
+alias(
+   name = "executable_test_expected",
+   actual = select({
+      "@platforms//os:windows": "executable.manifest.windows.golden",
+      "//conditions:default": "executable.manifest.golden",
+   }),
+)
+
 manifest_golden_test(
     name = "executable_test",
+    #expected = ":executable_test_expected",
     expected = "executable.manifest.golden",
     target = "executable_manifest",
 )

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -144,7 +144,6 @@ alias(
 
 manifest_golden_test(
     name = "executable_test",
-    #expected = ":executable_test_expected",
-    expected = "executable.manifest.golden",
+    expected = ":executable_test_expected",
     target = "executable_manifest",
 )

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -125,3 +125,17 @@ manifest_golden_test(
     expected = "utf8_manifest.golden",
     target = "utf8",
 )
+
+# Test handling of executable files
+write_content_manifest(
+    name = "executable_manifest",
+    srcs = [
+        "//tests:an_executable",
+    ],
+)
+
+manifest_golden_test(
+    name = "executable_test",
+    expected = "executable.manifest.golden",
+    target = "executable_manifest",
+)

--- a/tests/mappings/executable.manifest.golden
+++ b/tests/mappings/executable.manifest.golden
@@ -1,0 +1,3 @@
+[
+[0, "an_executable", "tests/an_executable", "0755", null, null]
+]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -1,0 +1,4 @@
+[
+[0, "an_executable", "tests/an_executable", "0755", null, null]
+[0, "an_executable.exe", "tests/an_executable.exe", "0755", null, null]
+]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -1,4 +1,3 @@
 [
-[0, "an_executable", "tests/an_executable", "0755", null, null],
 [0, "an_executable.exe", "tests/an_executable.exe", "0755", null, null]
 ]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -1,4 +1,4 @@
 [
-[0, "an_executable", "tests/an_executable", "0755", null, null]
+[0, "an_executable", "tests/an_executable", "0755", null, null],
 [0, "an_executable.exe", "tests/an_executable.exe", "0755", null, null]
 ]

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -30,12 +30,12 @@ class ContentManifestTest(unittest.TestCase):
         expected: The path to the content we expect.
         got: The path to the content we got.
     """
-    e_file = ContentManifestTest.run_files.Rlocation(
-        'rules_pkg/tests/mappings/' + expected)
-    with open(e_file, mode='rb') as e_fp:
+    #e_file = ContentManifestTest.run_files.Rlocation(
+    #    'rules_pkg/tests/mappings/' + expected)
+    with open(expected, mode='rb') as e_fp:
       expected = json.load(e_fp)
-    g_file = ContentManifestTest.run_files.Rlocation(
-        'rules_pkg/tests/mappings/' + got)
-    with open(g_file, mode='rb') as g_fp:
+    #g_file = ContentManifestTest.run_files.Rlocation(
+    #    'rules_pkg/tests/mappings/' + got)
+    with open(got, mode='rb') as g_fp:
       got = json.load(g_fp)
     self.assertEqual(expected, got)

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -30,12 +30,12 @@ class ContentManifestTest(unittest.TestCase):
         expected: The path to the content we expect.
         got: The path to the content we got.
     """
-    #e_file = ContentManifestTest.run_files.Rlocation(
-    #    'rules_pkg/tests/mappings/' + expected)
-    with open(expected, mode='rb') as e_fp:
+    e_file = ContentManifestTest.run_files.Rlocation(
+        'rules_pkg/' + expected)
+    with open(e_file, mode='rb') as e_fp:
       expected = json.load(e_fp)
-    #g_file = ContentManifestTest.run_files.Rlocation(
-    #    'rules_pkg/tests/mappings/' + got)
-    with open(got, mode='rb') as g_fp:
+    g_file = ContentManifestTest.run_files.Rlocation(
+        'rules_pkg/' + got)
+    with open(g_file, mode='rb') as g_fp:
       got = json.load(g_fp)
     self.assertEqual(expected, got)

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -30,12 +30,10 @@ class ContentManifestTest(unittest.TestCase):
         expected: The path to the content we expect.
         got: The path to the content we got.
     """
-    e_file = ContentManifestTest.run_files.Rlocation(
-        'rules_pkg/' + expected)
+    e_file = ContentManifestTest.run_files.Rlocation('rules_pkg/' + expected)
     with open(e_file, mode='rb') as e_fp:
       expected = json.load(e_fp)
-    g_file = ContentManifestTest.run_files.Rlocation(
-        'rules_pkg/' + got)
+    g_file = ContentManifestTest.run_files.Rlocation('rules_pkg/' + got)
     with open(g_file, mode='rb') as g_fp:
       got = json.load(g_fp)
     self.assertEqual(expected, got)

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -946,8 +946,8 @@ def _gen_manifest_test_main_impl(ctx):
         template = ctx.file._template,
         output = ctx.outputs.out,
         substitutions = {
-            "${EXPECTED}": ctx.files.expected[0].path,
-            "${TARGET}": ctx.files.target[0].path,
+            "${EXPECTED}": ctx.files.expected[0].short_path,
+            "${TARGET}": ctx.files.target[0].short_path,
             "${TEST_NAME}": ctx.attr.test_name,
         },
     )
@@ -991,6 +991,7 @@ def manifest_golden_test(name, target, expected):
         name = name,
         srcs = [":" + name + ".py"],
         data = [
+            ":" + target,
             ":" + target + ".manifest",
             expected,
         ],

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -946,8 +946,8 @@ def _gen_manifest_test_main_impl(ctx):
         template = ctx.file._template,
         output = ctx.outputs.out,
         substitutions = {
-            "${EXPECTED}": ctx.attr.expected,
-            "${TARGET}": ctx.attr.target,
+            "${EXPECTED}": ctx.files.expected[0].path,
+            "${TARGET}": ctx.files.target[0].path,
             "${TEST_NAME}": ctx.attr.test_name,
         },
     )
@@ -959,8 +959,8 @@ _gen_manifest_test_main = rule(
     implementation = _gen_manifest_test_main_impl,
     attrs = {
         "out": attr.output(mandatory = True),
-        "expected": attr.string(mandatory = True),
-        "target": attr.string(mandatory = True),
+        "expected": attr.label(mandatory = True, allow_single_file = True),
+        "target": attr.label(mandatory = True, allow_single_file = True),
         "test_name": attr.string(mandatory = True),
         "_template": attr.label(
             default = Label("//tests/mappings:manifest_test_main.py.tpl"),

--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -94,6 +94,7 @@ pkg_zip(
     srcs = [
         ":dirs",
         ":link",
+        "//tests:an_executable",
         "//tests:testdata/hello.txt",
         "//tests:testdata/loremipsum.txt",
     ],
@@ -105,6 +106,7 @@ pkg_zip(
     srcs = [
         ":dirs",
         ":link",
+        "//tests:an_executable",
         "//tests:testdata/hello.txt",
         "//tests:testdata/loremipsum.txt",
     ],
@@ -148,6 +150,7 @@ pkg_zip(
     srcs = [
         ":dirs",
         ":link",
+        "//tests:an_executable",
         "//tests:testdata/hello.txt",
         "//tests:testdata/loremipsum.txt",
     ],

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -32,6 +32,7 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
 
   def test_basic(self):
     self.assertZipFileContent("test_zip_basic.zip", [
+        {"filename": "an_executable", "attr": 0o755},
         {"filename": "foodir/", "isdir": True, "attr": 0o711},
         {"filename": "hello.txt", "crc": HELLO_CRC},
         {"filename": "loremipsum.txt", "crc": LOREM_CRC},

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -14,6 +14,7 @@
 
 import datetime
 import filecmp
+import os
 import unittest
 import zipfile
 
@@ -31,13 +32,24 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
     self.assertZipFileContent("test_zip_empty.zip", [])
 
   def test_basic(self):
-    self.assertZipFileContent("test_zip_basic.zip", [
-        {"filename": "an_executable", "attr": 0o755},
-        {"filename": "foodir/", "isdir": True, "attr": 0o711},
-        {"filename": "hello.txt", "crc": HELLO_CRC},
-        {"filename": "loremipsum.txt", "crc": LOREM_CRC},
-        {"filename": "usr/bin/foo", "attr": 0o555, "data": "/usr/local/foo/foo.real"},
-    ])
+    if os.name == "nt":
+      expect = [
+          {"filename": "an_executable.exe", "attr": 0o755},
+          {"filename": "foodir/", "isdir": True, "attr": 0o711},
+          {"filename": "hello.txt", "crc": HELLO_CRC},
+          {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+          {"filename": "usr/bin/foo", "attr": 0o555, "data": "/usr/local/foo/foo.real"},
+      ]
+    else:
+      expect = [
+          {"filename": "an_executable", "attr": 0o755},
+          {"filename": "foodir/", "isdir": True, "attr": 0o711},
+          {"filename": "hello.txt", "crc": HELLO_CRC},
+          {"filename": "loremipsum.txt", "crc": LOREM_CRC},
+          {"filename": "usr/bin/foo", "attr": 0o555, "data": "/usr/local/foo/foo.real"},
+      ]
+
+    self.assertZipFileContent("test_zip_basic.zip", expect)
 
   def test_timestamp(self):
     self.assertZipFileContent("test_zip_timestamp.zip", [


### PR DESCRIPTION
- mostly fix #96 by finding executables and setting mode==755 on them

This new feature can not detect all executables. Bazel does not have the right capability to make that easy. This seems to get most binaries, except shell. You will have to wrap those in pkg_files to set the mode bits.

This also does a little refactoring of the code for readability.