### PR TITLE
Substitute package variables in `pkg_zip#package_dir`.

### DIFF
--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -19,7 +19,11 @@ load(
     "PackageArtifactInfo",
     "PackageVariablesInfo",
 )
-load("//pkg/private:util.bzl", "setup_output_files")
+load(
+    "//pkg/private:util.bzl",
+    "setup_output_files",
+    "substitute_package_variables",
+)
 load(
     "//pkg/private:pkg_files.bzl",
     "add_label_list",
@@ -33,7 +37,7 @@ def _pkg_zip_impl(ctx):
 
     args = ctx.actions.args()
     args.add("-o", output_file.path)
-    args.add("-d", ctx.attr.package_dir)
+    args.add("-d", substitute_package_variables(ctx, ctx.attr.package_dir))
     args.add("-t", ctx.attr.timestamp)
     args.add("-m", ctx.attr.mode)
     inputs = []

--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -15,6 +15,7 @@
 
 load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs", "pkg_mklink")
 load("//pkg:zip.bzl", "pkg_zip")
+load("//tests:my_package_name.bzl", "my_package_naming")
 load("//tests/util:defs.bzl", "directory", "fake_artifact")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
@@ -209,6 +210,21 @@ filegroup(
     "/abc/def/",
 ])]
 
+my_package_naming(
+    name = "my_package_variables",
+    label = "some_value",
+)
+
+pkg_zip(
+    name = "test_zip_package_dir_substitution",
+    srcs = [
+        "//tests:testdata/hello.txt",
+        "//tests:testdata/loremipsum.txt",
+    ],
+    package_dir = "/level1/{label}/level3",
+    package_variables = ":my_package_variables",
+)
+
 py_test(
     name = "zip_test",
     srcs = [
@@ -222,6 +238,7 @@ py_test(
         ":test_zip_basic.zip",
         ":test_zip_empty.zip",
         ":test_zip_package_dir0.zip",
+        ":test_zip_package_dir_substitution.zip",
         ":test_zip_permissions.zip",
         ":test_zip_timestamp.zip",
         ":test_zip_tree.zip",

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -59,6 +59,12 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
         {"filename": "abc/def/loremipsum.txt", "crc": LOREM_CRC},
     ])
 
+  def test_package_dir_substitution(self):
+    self.assertZipFileContent("test_zip_package_dir_substitution.zip", [
+        {"filename": "level1/some_value/level3/hello.txt", "crc": HELLO_CRC},
+        {"filename": "level1/some_value/level3/loremipsum.txt", "crc": LOREM_CRC},
+    ])
+
   def test_zip_strip_prefix_empty(self):
     self.assertZipFileContent("test-zip-strip_prefix-empty.zip", [
         {"filename": "loremipsum.txt", "crc": LOREM_CRC},


### PR DESCRIPTION
This change adds logic and tests for substituting values from `pkg_zip#package_variables` into `pkg_zip#package_dir`. This behavior largely matches `pkg_tar` (`pkg_zip` does not have an equivalent to `pkg_tar#package_dir_file`, but they are otherwise the same).