### PR TITLE
Add 'isexe' check to zip tests.

### DIFF
--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -34,19 +34,19 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
   def test_basic(self):
     if os.name == "nt":
       expect = [
-          {"filename": "an_executable.exe", "attr": 0o755},
+          {"filename": "an_executable.exe", "isexe": True},
           {"filename": "foodir/", "isdir": True, "attr": 0o711},
           {"filename": "hello.txt", "crc": HELLO_CRC},
           {"filename": "loremipsum.txt", "crc": LOREM_CRC},
-          {"filename": "usr/bin/foo", "attr": 0o555, "data": "/usr/local/foo/foo.real"},
+          {"filename": "usr/bin/foo", "isexe": True, "data": "/usr/local/foo/foo.real"},
       ]
     else:
       expect = [
-          {"filename": "an_executable", "attr": 0o755},
+          {"filename": "an_executable", "isexe": True},
           {"filename": "foodir/", "isdir": True, "attr": 0o711},
           {"filename": "hello.txt", "crc": HELLO_CRC},
           {"filename": "loremipsum.txt", "crc": LOREM_CRC},
-          {"filename": "usr/bin/foo", "attr": 0o555, "data": "/usr/local/foo/foo.real"},
+          {"filename": "usr/bin/foo", "isexe": True, "data": "/usr/local/foo/foo.real"},
       ]
 
     self.assertZipFileContent("test_zip_basic.zip", expect)

--- a/tests/zip/zip_test_lib.py
+++ b/tests/zip/zip_test_lib.py
@@ -24,6 +24,7 @@ from bazel_tools.tools.python.runfiles import runfiles
 UNIX_DIR_BIT = 0o40000
 MSDOS_DIR_BIT = 0x10
 UNIX_RWX_BITS = 0o777
+UNIX_RX_BITS = 0o555
 
 # The ZIP epoch date: (1980, 1, 1, 0, 0, 0)
 _ZIP_EPOCH_DT = datetime.datetime(1980, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
@@ -76,6 +77,13 @@ class ZipContentsTestBase(ZipTest):
                            oct(expect_dir_bits))
           self.assertEqual(oct((info.external_attr >> 16) & UNIX_RWX_BITS),
                            oct(expected.get("attr", 0o755)))
-        else:
+        if "isexe" in expected:
+          got_mode = (info.external_attr >> 16) & UNIX_RX_BITS
+          self.assertEqual(oct(got_mode), oct(UNIX_RX_BITS))
+
+        if "attr" in expected:
+          attr = expected.get("attr")
+          if "attr_mask" in expected:
+            attr &= expected.get("attr_mask")
           self.assertEqual(oct((info.external_attr >> 16) & UNIX_RWX_BITS),
-                           oct(expected.get("attr", 0o555)))
+                           oct(attr))


### PR DESCRIPTION
isexe checks that the file is r?xr?xr?x.  That is, it just tests for read and execute, without looking at the write bits. The need is subtle. Some builds are local, and the executables often come back as 0o755, while others are remote, returning an immutable object with mode 0o555.