### PR TITLE
Fix imports when --experimental_python_import_all_repositories=false

### DIFF
--- a/distro/packaging_test.py
+++ b/distro/packaging_test.py
@@ -19,7 +19,7 @@ import subprocess
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
-from pkg.releasing import release_tools
+from rules_pkg.pkg.releasing import release_tools
 from distro import release_version
 
 _VERBOSE = True
@@ -31,7 +31,7 @@ class PackagingTest(unittest.TestCase):
   def setUp(self):
     self.data_files = runfiles.Create()
     self.source_repo = 'rules_pkg'
-    self.dest_repo = 'not_named_rules_pkg'
+    self.dest_repo = 'rules_pkg'
     self.version = release_version.RELEASE_VERSION
 
   def testBuild(self):

--- a/distro/testdata/BUILD.tpl
+++ b/distro/testdata/BUILD.tpl
@@ -1,4 +1,4 @@
-load("@not_named_rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 pkg_tar(
     name = "dummy_tar",

--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 from string import Template
 
-from pkg.private import helpers
+from rules_pkg.pkg.private import helpers
 
 
 # Setup to safely create a temporary directory and clean it up when done.

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -28,7 +28,7 @@ if sys.version_info < (3, 7):
 else:
   OrderedDict = dict
 
-from pkg.private import helpers
+from rules_pkg.pkg.private import helpers
 
 # list of debian fields : (name, mandatory, wrap[, default])
 # see http://www.debian.org/doc/debian-policy/ch-controlfields.html

--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -19,11 +19,11 @@ import os
 import tarfile
 import tempfile
 
-from pkg.private import archive
-from pkg.private import helpers
-from pkg.private import build_info
-from pkg.private import manifest
-from pkg.private.tar import tar_writer
+from rules_pkg.pkg.private import archive
+from rules_pkg.pkg.private import helpers
+from rules_pkg.pkg.private import build_info
+from rules_pkg.pkg.private import manifest
+from rules_pkg.pkg.private.tar import tar_writer
 
 
 def normpath(path):

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -19,9 +19,9 @@ import json
 import os
 import zipfile
 
-from pkg.private import build_info
-from pkg.private import helpers
-from pkg.private import manifest
+from rules_pkg.pkg.private import build_info
+from rules_pkg.pkg.private import helpers
+from rules_pkg.pkg.private import manifest
 
 ZIP_EPOCH = 315532800
 

--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -20,7 +20,7 @@ import os
 import string
 import textwrap
 
-from pkg.releasing import release_tools
+from rules_pkg.pkg.releasing import release_tools
 
 
 def print_notes(org, repo, version, tarball_path, mirror_host=None,

--- a/tests/archive_test.py
+++ b/tests/archive_test.py
@@ -16,7 +16,7 @@
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
-from pkg.private import archive
+from rules_pkg.pkg.private import archive
 
 
 class SimpleArReaderTest(unittest.TestCase):

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -23,7 +23,7 @@ import tarfile
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
-from pkg.private import archive
+from rules_pkg.pkg.private import archive
 
 
 class DebInspect(object):

--- a/tests/helpers_test.py
+++ b/tests/helpers_test.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 
-from pkg.private import helpers
+from rules_pkg.pkg.private import helpers
 
 
 class GetFlagValueTestCase(unittest.TestCase):

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -22,7 +22,7 @@ import stat
 import subprocess
 
 from rules_python.python.runfiles import runfiles
-from pkg.private import manifest
+from rules_pkg.pkg.private import manifest
 
 
 class PkgInstallTest(unittest.TestCase):

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -17,7 +17,7 @@ import tarfile
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
-from pkg.private.tar import tar_writer
+from rules_pkg.pkg.private.tar import tar_writer
 
 PORTABLE_MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
 

--- a/tests/tar/tar_writer_test.py
+++ b/tests/tar/tar_writer_test.py
@@ -18,7 +18,7 @@ import tarfile
 import unittest
 
 from bazel_tools.tools.python.runfiles import runfiles
-from pkg.private.tar import tar_writer
+from rules_pkg.pkg.private.tar import tar_writer
 from tests.tar import compressor
 
 


### PR DESCRIPTION
This fixes breakage for users of this repository when `--experimental_python_import_all_repositories=false` is set, which the Bazel team would like to do in https://github.com/bazelbuild/bazel/issues/2636.

Without this change, users get the error:
```
  File "/home/april/.cache/bazel/_bazel_april/4d8027e6d32eeb7619bc14d5897e6dd1/sandbox/linux-sandbox/34/execroot/blah/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/tar/build_tar.runfiles/rules_pkg/pkg/private/tar/build_tar.py", line 22, in <module>
    from pkg.private import archive
ModuleNotFoundError: No module named 'pkg'
```

Because imports can always be done with the absolute workspace name, changing these imports still works fine for tests in this repository and for users who have `--experimental_python_import_all_repositories=true`.

I am not clear on the intention of `not_named_rules_pkg` in the tests and what the implications are of me changing that to `rules_pkg`. It was important to change because otherwise the source files would all need to import `not_named_rules_pkg.blah.blah` which of course would be nonsense.

There is some error in the build rules for `//tests/rpm:analysis_tests_conflicting_inputs_base` that occurs at head, but otherwise all tests appear to pass with this change.