### PR TITLE
Properly format the deb Description field, fix format of changes file.

### DIFF
--- a/pkg/private/deb/BUILD
+++ b/pkg/private/deb/BUILD
@@ -16,7 +16,7 @@
 All interfaces are subject to change at any time.
 """
 
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -50,6 +50,16 @@ py_binary(
     srcs = ["make_deb.py"],
     python_version = "PY3",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/private:helpers",
+    ],
+)
+
+py_library(
+    name = "make_deb_lib",
+    srcs = ["make_deb.py"],
+    srcs_version = "PY3",
+    visibility = ["//tests/deb:__pkg__"],
     deps = [
         "//pkg/private:helpers",
     ],

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -76,7 +76,7 @@ pkg_deb(
         "dep1",
         "dep2",
     ],
-    description = "toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é",
+    description = "toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\n more",
     distribution = "trusty",
     maintainer = "soméone@somewhere.com",
     package = "fizzbuzz",
@@ -86,7 +86,7 @@ pkg_deb(
     templates = "templates",
     triggers = "deb_triggers",
     urgency = "low",
-    version = "test",
+    version = "4.5.6",
 )
 
 py_test(
@@ -108,6 +108,18 @@ py_test(
 
 package_naming_test(
     name = "naming_test",
-    expected_name = "fizzbuzz_test_all.deb",
+    expected_name = "fizzbuzz_4.5.6_all.deb",
     target_under_test = ":test_deb",
+)
+
+py_test(
+    name = "control_field_test",
+    size = "small",
+    srcs = [
+        "control_field_test.py",
+    ],
+    python_version = "PY3",
+    deps = [
+        "//pkg/private/deb:make_deb_lib",
+    ],
 )

--- a/tests/deb/control_field_test.py
+++ b/tests/deb/control_field_test.py
@@ -34,12 +34,16 @@ class MakeControlFieldTest(unittest.TestCase):
     self.assertEqual(
         'Package: fizzbuzz\n',
         make_deb.MakeDebianControlField('Package', 'fizzbuzz'))
+
+  def test_simple_strip(self):
     self.assertEqual(
         'Package: fizzbuzz\n',
         make_deb.MakeDebianControlField('Package', ' fizzbuzz'))
     self.assertEqual(
         'Package: fizzbuzz\n',
         make_deb.MakeDebianControlField('Package', ' fizzbuzz '))
+
+  def test_simple_no_newline(self):
     with self.assertRaises(ValueError):
       make_deb.MakeDebianControlField('Package', ' fizz\nbuzz ')
 
@@ -53,15 +57,18 @@ class MakeControlFieldTest(unittest.TestCase):
         'Description: fizz\n buzz\n',
         make_deb.MakeDebianControlField(
             'Description', 'fizz\n buzz\n', is_multiline=True))
+
+  def test_multiline_add_required_space(self):
     self.assertEqual(
         'Description: fizz\n buzz\n',
         make_deb.MakeDebianControlField(
             'Description', 'fizz\nbuzz', is_multiline=True))
+
+  def test_multiline_add_trailing_newline(self):
     self.assertEqual(
         'Description: fizz\n buzz\n baz\n',
         make_deb.MakeDebianControlField(
             'Description', 'fizz\n buzz\n baz', is_multiline=True))
- 
 
 
 if __name__ == '__main__':

--- a/tests/deb/control_field_test.py
+++ b/tests/deb/control_field_test.py
@@ -1,0 +1,68 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -*- coding: utf-8 -*-
+"""Testing for archive."""
+
+import codecs
+from io import BytesIO
+import os
+import sys
+import tarfile
+import unittest
+
+from pkg.private.deb import make_deb
+
+class MakeControlFieldTest(unittest.TestCase):
+  """Tests for MakeControlField.
+
+  https://www.debian.org/doc/debian-policy/ch-controlfields.html#syntax-of-control-files
+  """
+
+  def test_simple(self):
+    self.assertEqual(
+        'Package: fizzbuzz\n',
+        make_deb.MakeDebianControlField('Package', 'fizzbuzz'))
+    self.assertEqual(
+        'Package: fizzbuzz\n',
+        make_deb.MakeDebianControlField('Package', ' fizzbuzz'))
+    self.assertEqual(
+        'Package: fizzbuzz\n',
+        make_deb.MakeDebianControlField('Package', ' fizzbuzz '))
+    with self.assertRaises(ValueError):
+      make_deb.MakeDebianControlField('Package', ' fizz\nbuzz ')
+
+
+  def test_multiline(self):
+    self.assertEqual(
+        'Description: fizzbuzz\n',
+        make_deb.MakeDebianControlField(
+            'Description', 'fizzbuzz', is_multiline=True))
+    self.assertEqual(
+        'Description: fizz\n buzz\n',
+        make_deb.MakeDebianControlField(
+            'Description', 'fizz\n buzz\n', is_multiline=True))
+    self.assertEqual(
+        'Description: fizz\n buzz\n',
+        make_deb.MakeDebianControlField(
+            'Description', 'fizz\nbuzz', is_multiline=True))
+    self.assertEqual(
+        'Description: fizz\n buzz\n baz\n',
+        make_deb.MakeDebianControlField(
+            'Description', 'fizz\n buzz\n baz', is_multiline=True))
+ 
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -223,16 +223,25 @@ class PkgDebTest(unittest.TestCase):
         if content.find(field) < 0:
           self.fail('Missing template field: <%s> in <%s>' % (field, content))
 
+      # From the spec:
+      #   In a .changes file, the Description field contains a summary of the
+      #   descriptions for the packages being uploaded. For this case, the first
+      #   line of the field value (the part on the same line as Description:) is
+      #   always empty. It is a multiline field, with one line per package. Each
+      #   line is indented by one space and contains the name of a binary package,
+      #   a space, a hyphen (-), a space, and the short description line from that
+      #   package.
       d_expect = 'Description:\n fizzbuzz - toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\n'
       d_start = content.find(d_expect)
       if d_start < 0:
         self.fail(
             'Could not find expected description (%s) in\n=====%s=====' %
             (d_expect, content))
+      # Check that the next line is the start of a new description, rather than
+      # a continuation.
       self.assertTrue(
           content[d_start + len(d_expect)].isupper(),
           'Description has unexpected characters at end (%s)' % content)
-
 
 
 if __name__ == '__main__':

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -63,7 +63,7 @@ class PkgDebTest(unittest.TestCase):
     super(PkgDebTest, self).setUp()
     self.runfiles = runfiles.Create()
     # Note: Rlocation requires forward slashes. os.path.join() will not work.
-    self.deb_path = self.runfiles.Rlocation('rules_pkg/tests/deb/fizzbuzz_test_all.deb')
+    self.deb_path = self.runfiles.Rlocation('rules_pkg/tests/deb/fizzbuzz_4.5.6_all.deb')
     self.deb_file = DebInspect(self.deb_path)
 
   def assert_control_content(self, expected, match_order=False):
@@ -163,7 +163,7 @@ class PkgDebTest(unittest.TestCase):
     # pass on Windows Until we rewrite how description is passed
     if sys.platform != 'win32':
       fields.extend([
-	  'Description: toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é',
+	  'Description: toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\n more\n',
 	  'Maintainer: soméone@somewhere.com',
       ])
     for field in fields:
@@ -214,7 +214,7 @@ class PkgDebTest(unittest.TestCase):
 
   def test_changes(self):
     changes_path = self.runfiles.Rlocation(
-        'rules_pkg/tests/deb/fizzbuzz_test_all.changes')
+        'rules_pkg/tests/deb/fizzbuzz_4.5.6_all.changes')
     with open(changes_path, 'r', encoding='utf-8') as f:
       content = f.read()
       for field in (
@@ -222,6 +222,17 @@ class PkgDebTest(unittest.TestCase):
           'Distribution: trusty'):
         if content.find(field) < 0:
           self.fail('Missing template field: <%s> in <%s>' % (field, content))
+
+      d_expect = 'Description:\n fizzbuzz - toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é\n'
+      d_start = content.find(d_expect)
+      if d_start < 0:
+        self.fail(
+            'Could not find expected description (%s) in\n=====%s=====' %
+            (d_expect, content))
+      self.assertTrue(
+          content[d_start + len(d_expect)].isupper(),
+          'Description has unexpected characters at end (%s)' % content)
+
 
 
 if __name__ == '__main__':

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -225,7 +225,7 @@ class PkgDebTest(unittest.TestCase):
 
       # TODO(https://github.com/bazelbuild/rules_pkg/issues/214): This can not
       # pass on Windows until we rewrite how description is passed.
-      if sys.platform -= 'win32':
+      if sys.platform == 'win32':
         return
 
       # From the spec:

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -223,6 +223,11 @@ class PkgDebTest(unittest.TestCase):
         if content.find(field) < 0:
           self.fail('Missing template field: <%s> in <%s>' % (field, content))
 
+      # TODO(https://github.com/bazelbuild/rules_pkg/issues/214): This can not
+      # pass on Windows until we rewrite how description is passed.
+      if sys.platform -= 'win32':
+        return
+
       # From the spec:
       #   In a .changes file, the Description field contains a summary of the
       #   descriptions for the packages being uploaded. For this case, the first


### PR DESCRIPTION
A combination of fixes and then tests for the behavior:
- Stop text wrapping the description. The "displayer" should do the wrapping.
- Create the changes "Description" field in the correct format.
- Do not allow newline in single line fields.
- Add leading space to continuation lines in multiline fields.

https://www.debian.org/doc/debian-policy/ch-controlfields.html

Fixes: #522