### PR TITLE
Explicitly set the tar format to GNU.

### DIFF
--- a/pkg/private/tar/tar_writer.py
+++ b/pkg/private/tar/tar_writer.py
@@ -97,7 +97,8 @@ class TarFileWriter(object):
       self.fileobj = self.compressor_proc.stdin
     self.name = name
 
-    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
+    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj,
+                            format=tarfile.GNU_FORMAT) 
     self.members = set()
     self.directories = set()
     # Preseed the added directory list with things we should not add. If we


### PR DESCRIPTION
This means that:
1. you'll get the same format no matter what version of Python you have.
   At Python 3.8 the default changed from GNU to PAX.
2. The default will be suitable for building Debian packages containing
   long file names.

A followup PR may add the capability to allow PAX tar writing, but I
do not know the urgency of that at this time, so that is a future
feature request.

Fixes #216