### PR TITLE
Add a test for picking up globs in a filegroup.

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -39,6 +39,11 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "glob_for_texts",
+    srcs = glob(["**/*.txt"]),
+)
+
 py_test(
     name = "archive_test",
     srcs = [

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -147,3 +147,14 @@ manifest_golden_test(
     expected = ":executable_test_expected",
     target = "executable_manifest",
 )
+
+write_content_manifest(
+    name = "glob_for_texts_manifest",
+    srcs = ["//tests:glob_for_texts"],
+)
+
+manifest_golden_test(
+    name = "glob_for_texts_manifest_test",
+    expected = "glob_for_texts_manifest.golden",
+    target = "glob_for_texts_manifest",
+)

--- a/tests/mappings/glob_for_texts_manifest.golden
+++ b/tests/mappings/glob_for_texts_manifest.golden
@@ -1,0 +1,6 @@
+[
+[0, "file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "tests/testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "", null, null],
+[0, "hello.txt", "tests/testdata/hello.txt", "", null, null],
+[0, "loremipsum.txt", "tests/testdata/loremipsum.txt", "", null, null],
+[0, "test_tar_package_dir_file.txt", "tests/testdata/test_tar_package_dir_file.txt", "", null, null]
+]


### PR DESCRIPTION
No new feature, I just want the test to make sure we don't backslide on this.