### PR TITLE
Allow $(var) substitution in filenames

### DIFF
--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -78,12 +78,12 @@ def substitute_package_variables(ctx, attribute_value):
 
     if type(attribute_value) != "string":
         fail("attempt to substitute package_variables in the attribute value %s which is not a string" % attribute_value)
+    vars = dict(ctx.var)
+    if ctx.attr.package_variables:
+        package_variables = ctx.attr.package_variables[PackageVariablesInfo]
+        vars.update(package_variables.values)
 
-    if not ctx.attr.package_variables:
-        # Nothing to substitute. Return the attribute value as is.
-        if attribute_value.find("{") >= 0:
-            fail("package_variables is required when using '{' in attribute value %s" % attribute_value)
-        return attribute_value
-
-    package_variables = ctx.attr.package_variables[PackageVariablesInfo]
-    return attribute_value.format(**package_variables.values)
+    # Map $(var) to {x} and then use format for substitution.
+    # This is brittle and I hate it. We should have template substitution
+    # in the Starlark runtime.
+    return attribute_value.replace("$(", "{").replace(")", "}").format(**vars)

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -134,7 +134,8 @@ pkg_deb(
     maintainer = "soméone@somewhere.com",
     package = "fizzbuzz",
     version = "7",
-    # A bogus concept we are just testing the substitution capability.
+    # This does not make sense for architecture, but for testing, compilation
+    # mode is more stable thatn cpu.
     architecture = "$(COMPILATION_MODE)",
 )
 

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -123,3 +123,24 @@ py_test(
         "//pkg/private/deb:make_deb_lib",
     ],
 )
+
+# Test case for expanding $(var) constructions and for using ctx.var directly
+pkg_deb(
+    name = "deb_using_ctxvar",
+    config = "config",
+    data = ":tar_input",
+    description = "Compiled with $(COMPILATION_MODE)",
+    #distribution = "trusty",
+    maintainer = "soméone@somewhere.com",
+    package = "fizzbuzz",
+    version = "7",
+    # A bogus concept we are just testing the substitution capability.
+    architecture = "$(COMPILATION_MODE)",
+)
+
+package_naming_test(
+    name = "expand_from_ctx_var",
+    # Heads up. If the default compilation mode ever changes this will break.
+    expected_name = "fizzbuzz_7_fastbuild.deb",
+    target_under_test = ":deb_using_ctxvar",
+)


### PR DESCRIPTION
Allow $(var) substitution in filenames and include everything in ctx.var in the substitution dictionary.

Fixes #520