### PR TITLE
Bazel 6.0: Fix config_setting visibility failure on bazel CI

### DIFF
--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -55,9 +55,8 @@ exports_files(
 config_setting(
     name = "private_stamp_detect",
     values = {"stamp": "1"},
-    # Depended on by //src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:bootstrap_autocode in @bazelbuild/bazel.
-    # That's a pkg_tar which calls the pkg_tar macro in rules_pkg/pkg/private/tar/tar.bzl which sets the select().
-    # When --incompatible_config_setting_private_default_visibility is set, that fails unless this is public.
+    # When --incompatible_config_setting_private_default_visibility is set, this fails unless this is public.
+    # TODO: refactor to clear up confusion that this is a "private" target with public access.
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/private/BUILD
+++ b/pkg/private/BUILD
@@ -55,6 +55,10 @@ exports_files(
 config_setting(
     name = "private_stamp_detect",
     values = {"stamp": "1"},
+    # Depended on by //src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec:bootstrap_autocode in @bazelbuild/bazel.
+    # That's a pkg_tar which calls the pkg_tar macro in rules_pkg/pkg/private/tar/tar.bzl which sets the select().
+    # When --incompatible_config_setting_private_default_visibility is set, that fails unless this is public.
+    visibility = ["//visibility:public"],
 )
 
 py_library(


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/12933.

Repro: `$ USE_BAZEL_VERSION=a05276fea75d47370b363125a074c38cb2badc74 bazelisk build  --nobuild --incompatible_config_setting_private_default_visibility  //src/main/java/...`

Discovered in failing Bazel CI with `--incompatible_config_setting_private_default_visibility` flipped:

https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1297#0183cee1-349a-45c1-91ff-df2d2f1720a6
