### PR TITLE
Remove unnecessary `to_list()` calls

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -195,7 +195,6 @@ def _pkg_tar_impl(ctx):
         args.add("--stamp_from", ctx.version_file.path)
         files.append(ctx.version_file)
 
-    file_inputs = depset(transitive = file_deps)
     manifest_file = ctx.actions.declare_file(ctx.label.name + ".manifest")
     files.append(manifest_file)
     write_manifest(ctx, manifest_file, content_map)
@@ -204,10 +203,12 @@ def _pkg_tar_impl(ctx):
     args.set_param_file_format("flag_per_line")
     args.use_param_file("@%s", use_always = False)
 
+    inputs = depset(direct = ctx.files.deps + files, transitive = file_deps)
+
     ctx.actions.run(
         mnemonic = "PackageTar",
         progress_message = "Writing: %s" % output_file.path,
-        inputs = file_inputs.to_list() + ctx.files.deps + files,
+        inputs = inputs,
         tools = [ctx.executable.compressor] if ctx.executable.compressor else [],
         executable = ctx.executable.build_tar,
         arguments = [args],

--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -52,7 +52,6 @@ def _pkg_zip_impl(ctx):
     content_map = {}  # content handled in the manifest
     file_deps = []  # list of Depsets needed by srcs
     add_label_list(ctx, content_map, file_deps, srcs = ctx.attr.srcs)
-    file_inputs = depset(transitive = file_deps)
 
     manifest_file = ctx.actions.declare_file(ctx.label.name + ".manifest")
     inputs.append(manifest_file)
@@ -61,9 +60,11 @@ def _pkg_zip_impl(ctx):
     args.set_param_file_format("multiline")
     args.use_param_file("@%s")
 
+    all_inputs = depset(direct = inputs, transitive = file_deps)
+
     ctx.actions.run(
         mnemonic = "PackageZip",
-        inputs = file_inputs.to_list() + inputs,
+        inputs = all_inputs,
         executable = ctx.executable._build_zip,
         arguments = [args],
         outputs = [output_file],


### PR DESCRIPTION
Avoids flattening depsets during the analysis phase by passing depsets into `ctx.actions.run`'s `input` parameter.