### PR TITLE
feat: expose tar manifest as an output

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -228,6 +228,10 @@ def _pkg_tar_impl(ctx):
             files = depset([output_file]),
             runfiles = ctx.runfiles(files = outputs),
         ),
+        # NB: this is not a committed public API.
+        # The format of this file is subject to change without notice,
+        # or this OutputGroup might be totally removed.
+        # Depend on it at your own risk!
         OutputGroupInfo(
             manifest = [manifest_file], 
         ),

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -228,6 +228,9 @@ def _pkg_tar_impl(ctx):
             files = depset([output_file]),
             runfiles = ctx.runfiles(files = outputs),
         ),
+        OutputGroupInfo(
+            manifest = [manifest_file], 
+        ),
         PackageArtifactInfo(
             label = ctx.label.name,
             file = output_file,


### PR DESCRIPTION
This allows targets to run something like jq over the manifest contents