### PR TITLE
Genericize package manifest system and interface

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -11,9 +11,6 @@ lts: &lts
 rolling: &rolling
   bazel: rolling
 
-bazel5: &bazel5
-  bazel: 5.2.0
-
 #
 # Groups of tests, by platform
 #
@@ -112,7 +109,3 @@ tasks:
     name: lts_windows
     <<: *windows
     <<: *lts
-  bzl5_windows:
-    name: bzl5_windows
-    <<: *windows
-    <<: *bazel5

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -11,6 +11,9 @@ lts: &lts
 rolling: &rolling
   bazel: rolling
 
+bazel5: &bazel5
+  bazel: 5.2.0
+
 #
 # Groups of tests, by platform
 #
@@ -109,3 +112,7 @@ tasks:
     name: lts_windows
     <<: *windows
     <<: *lts
+  bzl5_windows:
+    name: bzl5_windows
+    <<: *windows
+    <<: *bazel5

--- a/pkg/private/manifest.py
+++ b/pkg/private/manifest.py
@@ -15,18 +15,42 @@
 """Common package builder manifest helpers
 """
 
-import collections
+import json
+
 
 # These must be kept in sync with the declarations in private/pkg_files.bzl
-ENTRY_IS_FILE = 0  # Entry is a file: take content from <src>
-ENTRY_IS_LINK = 1  # Entry is a symlink: dest -> <src>
-ENTRY_IS_DIR = 2  # Entry is an owned dir, possibly empty
-ENTRY_IS_TREE = 3  # Entry is a tree artifact: take tree from <src>
-ENTRY_IS_EMPTY_FILE = 4  # Entry is a an empty file
+ENTRY_IS_FILE = "file"  # Entry is a file: take content from <src>
+ENTRY_IS_LINK = "symlink"  # Entry is a symlink: dest -> <src>
+ENTRY_IS_DIR = "dir"  # Entry is an empty dir
+ENTRY_IS_TREE = "tree" # Entry is a tree artifact: take tree from <src>
+ENTRY_IS_EMPTY_FILE = "empty-file"  # Entry is a an empty file
 
-ManifestEntry = collections.namedtuple("ManifestEntry",
-                                       ['entry_type', 'dest', 'src', 'mode', 'user', 'group'])
+class ManifestEntry(object):
+    """Structured wrapper around rules_pkg-produced manifest entries"""
+    type: str
+    dest: str
+    src: str
+    mode: str
+    user: str
+    group: str
+    origin: str = None
 
+    def __init__(self, type, dest, src, mode, user, group, origin = None):
+        self.type = type
+        self.dest = dest
+        self.src = src
+        self.mode = mode
+        self.user = user
+        self.group = group
+        self.origin = origin
+
+    def __repr__(self):
+        return "ManifestEntry<{}>".format(vars(self))
+
+def read_entries_from(fh):
+    """Return a list of ManifestEntry's from `fh`"""
+    raw_entries = json.load(fh)
+    return [ManifestEntry(**entry) for entry in raw_entries]
 
 def entry_type_to_string(et):
     """Entry type stringifier"""

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -514,9 +514,13 @@ def _encode_manifest_entry(dest, df, use_short_path, pretty_print=False):
     else:
         src = None
 
-    # Bazel 6 or newer stringifies local labels with a beginning repository of
-    # "@", which is equivalent to the repository in which the bazel command was
-    # run.
+    # Bazel 6 has a new flag "--incompatible_unambiguous_label_stringification"
+    # (https://github.com/bazelbuild/bazel/issues/15916) that causes labels in
+    # the repository in which Bazel was run to be stringified with a preceding
+    # "@".  In older versions, this flag did not exist.
+    #
+    # Since this causes all sorts of chaos with our tests, be consistent across
+    # all Bazel versions.
     origin_str = str(df.origin)
     if not origin_str.startswith('@'):
         origin_str = '@' + origin_str

--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Rules for manipulation of various packaging."""
+"""Zip archive creation rule and associated logic."""
 
 load("//pkg:path.bzl", "compute_data_path", "dest_path")
 load(

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import itertools
-import json
 import os
 import unittest
 import stat
@@ -33,11 +32,11 @@ class PkgInstallTest(unittest.TestCase):
         manifest_file = cls.runfiles.Rlocation("rules_pkg/tests/install/test_installer_install_script-install-manifest.json")
 
         with open(manifest_file, 'r') as fh:
-            manifest_data_raw = json.load(fh)
+            manifest_entries = manifest.read_entries_from(fh)
             cls.manifest_data = {}
-            for entry in manifest_data_raw:
-                entry_struct = manifest.ManifestEntry(*entry)
-                cls.manifest_data[entry_struct.dest] = entry_struct
+
+            for entry in manifest_entries:
+                cls.manifest_data[entry.dest] = entry
         cls.installdir = os.path.join(os.getenv("TEST_TMPDIR"), "installdir")
         env = {}
         env.update(cls.runfiles.EnvVars())
@@ -62,10 +61,10 @@ class PkgInstallTest(unittest.TestCase):
 
     def assertEntryTypeMatches(self, entry, actual_path):
         actual_entry_type = self.entity_type_at_path(actual_path)
-        self.assertEqual(actual_entry_type, entry.entry_type,
+        self.assertEqual(actual_entry_type, entry.type,
                         "Entity {} should be a {}, but was actually {}".format(
                             entry.dest,
-                            manifest.entry_type_to_string(entry.entry_type),
+                            manifest.entry_type_to_string(entry.type),
                             manifest.entry_type_to_string(actual_entry_type),
                         ))
 
@@ -94,7 +93,7 @@ class PkgInstallTest(unittest.TestCase):
         #
         # Owned directories are created explicitly with the pkg_mkdirs rule.
         for dest, data in self.manifest_data.items():
-            if data.entry_type == manifest.ENTRY_IS_DIR:
+            if data.type == manifest.ENTRY_IS_DIR:
                 owned_dirs.add(dest)
 
             # TODO(nacl): The initial stage of the accumulation returns an empty string,

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -84,8 +84,6 @@ pkg_files(
     ],
 )
 
-# TODO: this seems to write the JSON in a particular order; regardless of input
-# order.  Investigate when opportune, or make the test order-agnostic.
 write_content_manifest(
     name = "all",
     srcs = [

--- a/tests/mappings/all.manifest.golden
+++ b/tests/mappings/all.manifest.golden
@@ -1,6 +1,7 @@
 [
-[0, "BUILD","tests/mappings/BUILD","",null,null],
-[2, "foodir",null,"711","foo","bar"],
-[0, "mappings_test.bzl","tests/mappings/mappings_test.bzl","0644",null,null],
-[3, "treeartifact","tests/mappings/treeartifact","0644",null,null]
+    {"type": "file", "dest": "BUILD", "src": "tests/mappings/BUILD", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:BUILD"},
+    {"type": "dir", "dest": "foodir", "src": null, "mode": "711", "user": "foo", "group": "bar", "origin": "@//tests/mappings:dirs"},
+
+    {"type": "file", "dest": "mappings_test.bzl", "src": "tests/mappings/mappings_test.bzl", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:files"},
+    {"type": "tree", "dest": "treeartifact", "src": "tests/mappings/treeartifact", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:directory-with-contents"}
 ]

--- a/tests/mappings/executable.manifest.golden
+++ b/tests/mappings/executable.manifest.golden
@@ -1,5 +1,5 @@
 [
-[0,"an_executable.runfiles/tests/BUILD","tests/BUILD","",null,null],
-[0,"an_executable.runfiles/tests/an_executable","tests/an_executable","0755",null,null],
-[0,"an_executable","tests/an_executable","0755",null,null]
+    {"type": "file", "dest": "an_executable.runfiles/tests/BUILD", "src": "tests/BUILD", "mode": "", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable.runfiles/tests/an_executable", "src": "tests/an_executable", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable", "src": "tests/an_executable", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"}
 ]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -1,5 +1,5 @@
 [
-[0,"an_executable.exe.runfiles/tests/an_executable.exe","tests/an_executable.exe","0755",null,null],
-[0,"an_executable.exe.runfiles/tests/BUILD","tests/BUILD","",null,null],
-[0,"an_executable.exe","tests/an_executable.exe","0755",null,null]
+    {"type": "file", "dest": "an_executable.runfiles/tests/BUILD", "src": "tests/BUILD", "mode": "", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable.runfiles/tests/an_executable.exe", "src": "tests/an_executable.exe", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable.exe", "src": "tests/an_executable.exe", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"}
 ]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -1,5 +1,5 @@
 [
-    {"type": "file", "dest": "an_executable.runfiles/tests/BUILD", "src": "tests/BUILD", "mode": "", "user": null, "group": null, "origin": "@//tests:an_executable"},
-    {"type": "file", "dest": "an_executable.runfiles/tests/an_executable.exe", "src": "tests/an_executable.exe", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable.exe.runfiles/tests/BUILD", "src": "tests/BUILD", "mode": "", "user": null, "group": null, "origin": "@//tests:an_executable"},
+    {"type": "file", "dest": "an_executable.exe.runfiles/tests/an_executable.exe", "src": "tests/an_executable.exe", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"},
     {"type": "file", "dest": "an_executable.exe", "src": "tests/an_executable.exe", "mode": "0755", "user": null, "group": null, "origin": "@//tests:an_executable"}
 ]

--- a/tests/mappings/glob_for_texts_manifest.golden
+++ b/tests/mappings/glob_for_texts_manifest.golden
@@ -1,6 +1,6 @@
 [
-[0, "file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "tests/testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "", null, null],
-[0, "hello.txt", "tests/testdata/hello.txt", "", null, null],
-[0, "loremipsum.txt", "tests/testdata/loremipsum.txt", "", null, null],
-[0, "test_tar_package_dir_file.txt", "tests/testdata/test_tar_package_dir_file.txt", "", null, null]
+    {"type": "file", "dest": "file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "src": "tests/testdata/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt", "mode": "", "user": null, "group": null, "origin": "@//tests:glob_for_texts"},
+    {"type": "file", "dest": "hello.txt", "src": "tests/testdata/hello.txt", "mode": "", "user": null, "group": null, "origin": "@//tests:glob_for_texts"},
+    {"type": "file", "dest": "loremipsum.txt", "src": "tests/testdata/loremipsum.txt", "mode": "", "user": null, "group": null, "origin": "@//tests:glob_for_texts"},
+    {"type": "file", "dest": "test_tar_package_dir_file.txt", "src": "tests/testdata/test_tar_package_dir_file.txt", "mode": "", "user": null, "group": null, "origin": "@//tests:glob_for_texts"}
 ]

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -33,9 +33,9 @@ class ContentManifestTest(unittest.TestCase):
     e_file = ContentManifestTest.run_files.Rlocation('rules_pkg/' + expected)
     with open(e_file, mode='rb') as e_fp:
       expected = json.load(e_fp)
-    expected_dict = {x[1]: x for x in expected}
+    expected_dict = {x["dest"]: x for x in expected}
     g_file = ContentManifestTest.run_files.Rlocation('rules_pkg/' + got)
     with open(g_file, mode='rb') as g_fp:
       got = json.load(g_fp)
-    got_dict = {x[1]: x for x in got}
+    got_dict = {x["dest"]: x for x in got}
     self.assertEqual(expected_dict, got_dict)

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -23,9 +23,6 @@ class ContentManifestTest(unittest.TestCase):
 
   run_files = runfiles.Create()
 
-  # Debug
-  maxDiff = None
-
   def assertManifestsMatch(self, expected, got):
     """Check two manifest files for equality.
 

--- a/tests/mappings/manifest_test_lib.py
+++ b/tests/mappings/manifest_test_lib.py
@@ -23,6 +23,9 @@ class ContentManifestTest(unittest.TestCase):
 
   run_files = runfiles.Create()
 
+  # Debug
+  maxDiff = None
+
   def assertManifestsMatch(self, expected, got):
     """Check two manifest files for equality.
 

--- a/tests/mappings/node_modules_manifest.golden
+++ b/tests/mappings/node_modules_manifest.golden
@@ -1,9 +1,9 @@
 [
-[1,"node_modules/.pnpm/bar@1.0.0/node_modules/bar","STORE/bar","",null,null],
-[1,"node_modules/.pnpm/bar@1.0.0/node_modules/qar","../../qar@2.0.0/node_modules/qar","",null,null],
-[1,"node_modules/.pnpm/foo@1.0.0/node_modules/bar","../../bar@1.0.0/node_modules/bar","",null,null],
-[1,"node_modules/.pnpm/foo@1.0.0/node_modules/foo","STORE/foo","",null,null],
-[1,"node_modules/.pnpm/foo@1.0.0/node_modules/qar","../../qar@2.0.0/node_modules/qar","",null,null],
-[1,"node_modules/.pnpm/qar@2.0.0/node_modules/qar","STORE/qar","",null,null],
-[1,"node_modules/foo",".pnpm/foo@1.0.0/node_modules/foo","",null,null]
+    {"type": "symlink", "dest": "node_modules/.pnpm/bar@1.0.0/node_modules/bar", "src": "STORE/bar", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/.pnpm/bar@1.0.0/node_modules/qar", "src": "../../qar@2.0.0/node_modules/qar", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/.pnpm/foo@1.0.0/node_modules/bar", "src": "../../bar@1.0.0/node_modules/bar", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/.pnpm/foo@1.0.0/node_modules/foo", "src": "STORE/foo", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/.pnpm/foo@1.0.0/node_modules/qar", "src": "../../qar@2.0.0/node_modules/qar", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/.pnpm/qar@2.0.0/node_modules/qar", "src": "STORE/qar", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"},
+    {"type": "symlink", "dest": "node_modules/foo", "src": ".pnpm/foo@1.0.0/node_modules/foo", "mode": "", "user": null, "group": null, "origin": "@//tests/mappings:node_modules"}
 ]

--- a/tests/mappings/utf8_manifest.golden
+++ b/tests/mappings/utf8_manifest.golden
@@ -1,8 +1,8 @@
 [
-[0,"1-a","tests/testdata/utf8/1-a","0644",null,null],
-[0,"2-λ","tests/testdata/utf8/2-λ","0644",null,null],
-[0,"3-世","tests/testdata/utf8/3-世","0644",null,null],
-[0,"BUILD","tests/testdata/utf8/BUILD","0644",null,null],
-[0,"sübdir/2-λ","tests/testdata/utf8/sübdir/2-λ","0644",null,null],
-[0,"sübdir/hello","tests/testdata/utf8/sübdir/hello","0644",null,null]
+    {"type": "file", "dest": "1-a", "src": "tests/testdata/utf8/1-a", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"},
+    {"type": "file", "dest": "2-λ", "src": "tests/testdata/utf8/2-λ", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"},
+    {"type": "file", "dest": "3-世", "src": "tests/testdata/utf8/3-世", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"},
+    {"type": "file", "dest": "BUILD", "src": "tests/testdata/utf8/BUILD", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"},
+    {"type": "file", "dest": "sübdir/2-λ", "src": "tests/testdata/utf8/sübdir/2-λ", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"},
+    {"type": "file", "dest": "sübdir/hello", "src": "tests/testdata/utf8/sübdir/hello", "mode": "0644", "user": null, "group": null, "origin": "@//tests/mappings:utf8_files"}
 ]


### PR DESCRIPTION
The current way that rules_pkg communicates with must packagers is using a manifest file, which is currently a JSON data structure based on a an array of arrays.  While generally readable, it looks strange, as it was to reduce Bazel resource usage (JSON strings in memory).  Further, our Python code is directly bound to this data structure format.

However, if we want to add more or change this, it becomes cumbersome on both the Starlark and Python sides. This change alleviates concerns generally by:

- Converting all manifests to a JSON "object" style, improving readability. Numerous "golden" tests were updated to support this.
- Replace the `collections.namedtuple`-based `ManifestEntry` object with one that is a little more flexible and type-safe.
- Providing a function (`read_entries_from`) that converts a file-like object into a list of `ManifestEntry`s, and replacing all JSON reading in packagers (`tar`, `zip`, `install`) and their tests with this function.  While this is theoretically usable by consumers of rules_pkg, it is not intended to be supported as such.

Other convenience factors or things addressed:

- `ManifestEntry.entry_type` is now just `ManifestEntry.type`
- Bazel 6 now stringifies repository-local labels with a preceding `@`, unlike prior versions.  Adapt to this in the manifest writer.

Future changes will extend this interface to allow for custom attributes to be passed from `pkg_files` and friends, which, among other things, will be necessary to more generically support `pkg_rpm`.

Provides some groundwork for (but doesn't resolve) #385.