### PR TITLE
update version to 8.1 to sync with bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_pkg",
-    version = "0.7.1",  # Must sync with version.bzl.
+    version = "0.8.1",  # Must sync with version.bzl.
     repo_name = "rules_pkg",
 )
 

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_pkg."""
 
-version = "0.8.0"
+version = "0.8.1"


### PR DESCRIPTION
The 0.8.0 release was out of sync in MODULE.bzlmod. 
The only way to reasonably fix that is do a new release.