### PR TITLE
Fix a potential TypeException caused by None type

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -27,7 +27,7 @@ from pkg.private.tar import tar_writer
 
 def normpath(path):
   """Normalize a path to the format we need it.
-  
+
   os.path.normpath changes / to \ on windows, but tarfile needs / style paths.
 
   Args:
@@ -256,11 +256,6 @@ class TarFile(object):
 
     for path in sorted(to_write.keys()):
       content_path = to_write[path]
-      # If mode is unspecified, derive the mode from the file's mode.
-      if mode is None:
-        f_mode = 0o755 if os.access(content_path, os.X_OK) else 0o644
-      else:
-        f_mode = mode
       if not content_path:
         # This is an intermediate directory. Bazel has no API to specify modes
         # for this, so the least surprising thing we can do is make it the
@@ -272,6 +267,11 @@ class TarFile(object):
             names=names,
             kind=tarfile.DIRTYPE)
       else:
+        # If mode is unspecified, derive the mode from the file's mode.
+        if mode is None:
+          f_mode = 0o755 if os.access(content_path, os.X_OK) else 0o644
+        else:
+          f_mode = mode
         self.tarfile.add_file(
             path,
             file_content=content_path,
@@ -405,7 +405,7 @@ def main():
 
   # Add objects to the tar file
   with TarFile(
-      options.output, 
+      options.output,
       directory = helpers.GetFlagValue(options.directory),
       compression = options.compression,
       compressor = options.compressor,


### PR DESCRIPTION
`os.access(content_path, os.X_OK)` will raise a TypeException when `content_path` is None.
`f_mode` is only used when `content_path` is neither None nor empty, so I decided to move the assignment into this else-branch.

Thanks @mutongx for reporting this issue.