### PR TITLE
pkg_tar, pkg_zip: improve support for long paths on Windows

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -252,7 +252,15 @@ class TarFile(object):
       for dir in dirs:
         to_write[dest_dir + dir] = None
       for file in sorted(files):
-        to_write[dest_dir + file] = root + '/' + file
+        content_path = os.path.abspath(os.path.join(root, file))
+        if os.name == "nt":
+          # "To specify an extended-length path, use the `\\?\` prefix. For
+          # example, `\\?\D:\very long path`."[1]
+          #
+          # [1]: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+          to_write[dest_dir + file] = "\\\\?\\" + content_path
+        else:
+          to_write[dest_dir + file] = content_path
 
     for path in sorted(to_write.keys()):
       content_path = to_write[path]

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -193,14 +193,15 @@ class ZipWriter(object):
         dest_dir = dest
       to_write[dest_dir] = None
       for file in files:
+        content_path = os.path.abspath(os.path.join(root, file))
         if os.name == "nt":
           # "To specify an extended-length path, use the `\\?\` prefix. For
           # example, `\\?\D:\very long path`."[1]
           #
           # [1]: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-          to_write[dest_dir + file] = "\\\\?\\" + os.path.abspath(os.path.join(root, file))
+          to_write[dest_dir + file] = "\\\\?\\" + content_path
         else:
-          to_write[dest_dir + file] = root + '/' + file
+          to_write[dest_dir + file] = content_path
 
     for path in sorted(to_write.keys()):
       content_path = to_write[path]

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -193,7 +193,14 @@ class ZipWriter(object):
         dest_dir = dest
       to_write[dest_dir] = None
       for file in files:
-        to_write[dest_dir + file] = root + '/' + file
+        if os.name == "nt":
+          # "To specify an extended-length path, use the `\\?\` prefix. For
+          # example, `\\?\D:\very long path`."[1]
+          #
+          # [1]: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+          to_write[dest_dir + file] = "\\\\?\\" + os.path.abspath(os.path.join(root, file))
+        else:
+          to_write[dest_dir + file] = root + '/' + file
 
     for path in sorted(to_write.keys()):
       content_path = to_write[path]


### PR DESCRIPTION
This commit updates `pkg_zip` to, when running on Windows, convert zip files' input paths to extended-length paths by (1) making them absolute and then (2) prepending with `\\?\`.