### PR TITLE
pkg_tar should not prefix tree artifacts with ./

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -232,6 +232,9 @@ class TarFile(object):
 
     # Again, we expect /-style paths.
     dest = normpath(dest)
+    # normpath may be ".", and dest paths should not start with "./"
+    dest = '' if dest == '.' else dest + '/'
+
     if ids is None:
       ids = (0, 0)
     if names is None:
@@ -246,9 +249,9 @@ class TarFile(object):
       dirs = sorted(dirs)
       rel_path_from_top = root[len(tree_top):].lstrip('/')
       if rel_path_from_top:
-        dest_dir = dest + '/' + rel_path_from_top + '/'
+        dest_dir = dest + rel_path_from_top + '/'
       else:
-        dest_dir = dest + '/'
+        dest_dir = dest
       for dir in dirs:
         to_write[dest_dir + dir] = None
       for file in sorted(files):

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -356,6 +356,7 @@ py_test(
         ":test-tar-tree-artifact",
         ":test-tar-tree-artifact-noroot",
         ":test-tar-with-runfiles",
+        ":test-tree-input-with-strip-prefix",
         "//tests:testdata/tar_test.tar",
         "//tests:testdata/tar_test.tar.bz2",
         "//tests:testdata/tar_test.tar.gz",
@@ -470,4 +471,22 @@ pkg_tar(
     deps = [
         ":relative_links_tar",
     ],
+)
+
+directory(
+    name = "generate_tree_with_prefix",
+    contents = "hello there",
+    filenames = [
+        "a/a",
+        "a/b",
+    ],
+    outdir = "tree_prefix_to_strip",
+)
+
+pkg_tar(
+    name = "test-tree-input-with-strip-prefix",
+    srcs = [
+        ":generate_tree_with_prefix",
+    ],
+    strip_prefix = "tree_prefix_to_strip",
 )

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -258,6 +258,14 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test_tar_leading_dotslash.tar', content)
 
+  def test_tar_with_tree_artifact_and_strip_prefix(self):
+    content = [
+      {'name': 'a', 'isdir': True},
+      {'name': 'a/a'},
+      {'name': 'a/b'},
+    ]
+    self.assertTarFileContent('test-tree-input-with-strip-prefix.tar', content)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fixes #676

It was enlightening to note that `build_zip` doesn't have the same problem! `build_zip`'s `add_tree` has a key special case that previously we didn't have in `build_tar`:
https://github.com/bazelbuild/rules_pkg/blob/main/pkg/private/zip/build_zip.py#L178-L194