### PR TITLE
Bump to 0.9.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "rules_pkg",
     version = "0.9.0",  # Must sync with version.bzl.
     repo_name = "rules_pkg",
-    compatibility_level = 2,
+    compatibility_level = 1,
 )
 
 # Do not update to newer versions until you need a specific new feature.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,8 @@
 module(
     name = "rules_pkg",
-    version = "0.8.2",  # Must sync with version.bzl.
+    version = "0.9.0",  # Must sync with version.bzl.
     repo_name = "rules_pkg",
+    compatibility_level = 2,
 )
 
 # Do not update to newer versions until you need a specific new feature.

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_pkg."""
 
-version = "0.8.2"
+version = "0.9.0"


### PR DESCRIPTION
To address https://github.com/bazelbuild/rules_pkg/issues/686, I started to do an 8.2 release. But there are some large internal diffs, so bumping the compat level should change too, and thus the verison.