### PR TITLE
[pkg_deb] Fix multiline fields in changes file

### DIFF
--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -139,7 +139,7 @@ def MakeDebianControlField(name: str, value: str, is_multiline:bool=False) -> st
           '\\n is not allowed in simple control fields (%s)' % value)
 
   lines = value.split('\n')
-  result = name + ': ' +lines[0].strip() + '\n'
+  result = (name + ': ' +lines[0].strip()).strip() + '\n'
   for line in lines[1:]:
     if not line.startswith(' '):
       result += ' '
@@ -298,13 +298,16 @@ def CreateChanges(output,
           is_multiline=True),
       MakeDebianControlField(
           'Files', '\n ' + ' '.join(
-              [checksums['md5'], debsize, section, priority, deb_basename])),
+              [checksums['md5'], debsize, section, priority, deb_basename]),
+              is_multiline=True),
       MakeDebianControlField(
           'Checksums-Sha1',
-          '\n ' + ' '.join([checksums['sha1'], debsize, deb_basename])),
+          '\n ' + ' '.join([checksums['sha1'], debsize, deb_basename]),
+          is_multiline=True),
       MakeDebianControlField(
           'Checksums-Sha256',
-          '\n ' + ' '.join([checksums['sha256'], debsize, deb_basename]))
+          '\n ' + ' '.join([checksums['sha256'], debsize, deb_basename]),
+          is_multiline=True)
   ])
   with open(output, 'wb') as changes_fh:
     changes_fh.write(changesdata.encode('utf-8'))

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -14,6 +14,7 @@
 """A simple cross-platform helper to create a debian package."""
 
 import argparse
+from enum import Enum
 import gzip
 import hashlib
 import io
@@ -29,6 +30,8 @@ else:
   OrderedDict = dict
 
 from pkg.private import helpers
+
+Multiline = Enum('Multiline', ['NO', 'YES', 'YES_ADD_NEWLINE'])
 
 # list of debian fields : (name, mandatory, is_multiline[, default])
 # see http://www.debian.org/doc/debian-policy/ch-controlfields.html
@@ -118,7 +121,7 @@ def AddArFileEntry(fileobj, filename,
     fileobj.write(b'\n')  # 2-byte alignment padding
 
 
-def MakeDebianControlField(name: str, value: str, is_multiline:bool=False) -> str:
+def MakeDebianControlField(name: str, value: str, multiline:Multiline=Multiline.NO) -> str:
   """Add a field to a debian control file.
 
   https://www.debian.org/doc/debian-policy/ch-controlfields.html#syntax-of-control-files
@@ -132,15 +135,20 @@ def MakeDebianControlField(name: str, value: str, is_multiline:bool=False) -> st
   if isinstance(value, list):
     value = u', '.join(value)
   value = value.rstrip()
-  if not is_multiline:
+  if multiline == Multiline.NO:
     value = value.strip()
     if '\n' in value:
       raise ValueError(
           '\\n is not allowed in simple control fields (%s)' % value)
 
   lines = value.split('\n')
-  result = (name + ': ' +lines[0].strip()).strip() + '\n'
-  for line in lines[1:]:
+  i = 0
+  if multiline != Multiline.YES_ADD_NEWLINE:
+    result = name + ': ' + lines[i].strip() + '\n'
+    i = 1
+  else:
+    result = name + ':\n'
+  for line in lines[i:]:
     if not line.startswith(' '):
       result += ' '
     result += line
@@ -155,10 +163,10 @@ def CreateDebControl(extrafiles=None, **kwargs):
   for values in DEBIAN_FIELDS:
     fieldname = values[0]
     mandatory = values[1]
-    is_multiline = values[2]
+    multiline = Multiline.YES if values[2] else Multiline.NO
     key = fieldname[0].lower() + fieldname[1:].replace('-', '')
     if mandatory or (key in kwargs and kwargs[key]):
-      controlfile += MakeDebianControlField(fieldname, kwargs[key], is_multiline)
+      controlfile += MakeDebianControlField(fieldname, kwargs[key], multiline)
   # Create the control.tar file
   tar = io.BytesIO()
   with gzip.GzipFile('control.tar.gz', mode='w', fileobj=tar, mtime=0) as gz:
@@ -290,24 +298,27 @@ def CreateChanges(output,
       MakeDebianControlField('Maintainer', maintainer),
       MakeDebianControlField('Changed-By', maintainer),
       # The description in the changes file is strange
-      'Description:\n %s - %s\n' % (package, description.split('\n')[0]),
+      MakeDebianControlField('Description', (
+          '%s - %s\n') % (
+              package, description.split('\n')[0]),
+          multiline=Multiline.YES_ADD_NEWLINE),
       MakeDebianControlField('Changes', (
-          '\n %s (%s) %s; urgency=%s'
+          '%s (%s) %s; urgency=%s'
           '\n Changes are tracked in revision control.') % (
               package, version, distribution, urgency),
-          is_multiline=True),
+          multiline=Multiline.YES_ADD_NEWLINE),
       MakeDebianControlField(
-          'Files', '\n ' + ' '.join(
+          'Files', ' '.join(
               [checksums['md5'], debsize, section, priority, deb_basename]),
-              is_multiline=True),
+              multiline=Multiline.YES_ADD_NEWLINE),
       MakeDebianControlField(
           'Checksums-Sha1',
-          '\n ' + ' '.join([checksums['sha1'], debsize, deb_basename]),
-          is_multiline=True),
+          ' '.join([checksums['sha1'], debsize, deb_basename]),
+          multiline=Multiline.YES_ADD_NEWLINE),
       MakeDebianControlField(
           'Checksums-Sha256',
-          '\n ' + ' '.join([checksums['sha256'], debsize, deb_basename]),
-          is_multiline=True)
+          ' '.join([checksums['sha256'], debsize, deb_basename]),
+          multiline=Multiline.YES_ADD_NEWLINE)
   ])
   with open(output, 'wb') as changes_fh:
     changes_fh.write(changesdata.encode('utf-8'))

--- a/tests/deb/control_field_test.py
+++ b/tests/deb/control_field_test.py
@@ -52,23 +52,31 @@ class MakeControlFieldTest(unittest.TestCase):
     self.assertEqual(
         'Description: fizzbuzz\n',
         make_deb.MakeDebianControlField(
-            'Description', 'fizzbuzz', is_multiline=True))
+            'Description', 'fizzbuzz', multiline=make_deb.Multiline.YES))
     self.assertEqual(
         'Description: fizz\n buzz\n',
         make_deb.MakeDebianControlField(
-            'Description', 'fizz\n buzz\n', is_multiline=True))
+            'Description', 'fizz\n buzz\n', multiline=make_deb.Multiline.YES))
+    self.assertEqual(
+        'Description:\n fizz\n buzz\n',
+        make_deb.MakeDebianControlField(
+            'Description', ' fizz\n buzz\n', multiline=make_deb.Multiline.YES_ADD_NEWLINE))
 
   def test_multiline_add_required_space(self):
     self.assertEqual(
         'Description: fizz\n buzz\n',
         make_deb.MakeDebianControlField(
-            'Description', 'fizz\nbuzz', is_multiline=True))
+            'Description', 'fizz\nbuzz', multiline=make_deb.Multiline.YES))
+    self.assertEqual(
+        'Description:\n fizz\n buzz\n',
+        make_deb.MakeDebianControlField(
+            'Description', 'fizz\nbuzz\n', multiline=make_deb.Multiline.YES_ADD_NEWLINE))
 
   def test_multiline_add_trailing_newline(self):
     self.assertEqual(
         'Description: fizz\n buzz\n baz\n',
         make_deb.MakeDebianControlField(
-            'Description', 'fizz\n buzz\n baz', is_multiline=True))
+            'Description', 'fizz\n buzz\n baz', multiline=make_deb.Multiline.YES))
 
 
 if __name__ == '__main__':

--- a/tests/deb/pkg_deb_test.py
+++ b/tests/deb/pkg_deb_test.py
@@ -249,6 +249,32 @@ class PkgDebTest(unittest.TestCase):
           content[d_start + len(d_expect)].isupper(),
           'Description has unexpected characters at end (%s)' % content)
 
+      self.maxDiff = None
+      expect = '''Format: 1\.8
+Date: Thu Jan  1 \d{2}:00:00 1970
+Source: fizzbuzz
+Binary: fizzbuzz
+Architecture: all
+Version: 4\.5\.6
+Distribution: trusty
+Urgency: low
+Maintainer: soméone@somewhere.com
+Changed-By: soméone@somewhere.com
+Description:
+ fizzbuzz - toto ®, Й, ק ,م, ๗, あ, 叶, 葉, 말, ü and é
+Changes:
+ fizzbuzz \(4\.5\.6\) trusty; urgency=low
+ Changes are tracked in revision control\.
+Files:
+ [a-f0-9]{32} \d{4} contrib/devel optional fizzbuzz_4\.5\.6_all\.deb
+Checksums-Sha1:
+ [a-f0-9]{40} \d{4} fizzbuzz_4\.5\.6_all\.deb
+Checksums-Sha256:
+ [a-f0-9]{64} \d{4} fizzbuzz_4\.5\.6_all\.deb
+'''
+
+      self.assertRegex(content, expect)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fix broken `.changes` file reported in https://github.com/bazelbuild/rules_pkg/issues/632 
As per documentation https://www.debian.org/doc/debian-policy/ch-controlfields.html#debian-changes-files-changes
Files and checksum fields always start with an empty line.
Fix this by marking the fields as `is_multiline=True`. Also remove the trailing whitespace after a single line includes just the field key. Added a test that checks for an exact match to generated `.changes` file.

fixes https://github.com/bazelbuild/rules_pkg/issues/632 
fixes https://github.com/bazelbuild/rules_pkg/issues/659