### PR TITLE
docs: add a note in pkg_tar#strip_prefix docs (v.0.8.0) about flattening

### DIFF
--- a/docs/0.8.0/reference.md
+++ b/docs/0.8.0/reference.md
@@ -297,7 +297,7 @@ pkg_tar(<a href="#pkg_tar-name">name</a>, <a href="#pkg_tar-build_tar">build_tar
 | <a id="pkg_tar-remap_paths"></a>remap_paths |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="pkg_tar-srcs"></a>srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="pkg_tar-stamp"></a>stamp |  Enable file time stamping.  Possible values: <li>stamp = 1: Use the time of the build as the modification time of each file in the archive. <li>stamp = 0: Use an "epoch" time for the modification time of each file. This gives good build result caching. <li>stamp = -1: Control the chosen modification time using the --[no]stamp flag. <div class="since"><i>Since 0.5.0</i></div>   | Integer | optional | 0 |
-| <a id="pkg_tar-strip_prefix"></a>strip_prefix |  -   | String | optional | "" |
+| <a id="pkg_tar-strip_prefix"></a>strip_prefix |  (note: strip_prefix = "." will prevent srcs to be flattened) | String | optional | "" |
 | <a id="pkg_tar-symlinks"></a>symlinks |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 

--- a/docs/0.8.0/reference.md
+++ b/docs/0.8.0/reference.md
@@ -297,7 +297,7 @@ pkg_tar(<a href="#pkg_tar-name">name</a>, <a href="#pkg_tar-build_tar">build_tar
 | <a id="pkg_tar-remap_paths"></a>remap_paths |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="pkg_tar-srcs"></a>srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="pkg_tar-stamp"></a>stamp |  Enable file time stamping.  Possible values: <li>stamp = 1: Use the time of the build as the modification time of each file in the archive. <li>stamp = 0: Use an "epoch" time for the modification time of each file. This gives good build result caching. <li>stamp = -1: Control the chosen modification time using the --[no]stamp flag. <div class="since"><i>Since 0.5.0</i></div>   | Integer | optional | 0 |
-| <a id="pkg_tar-strip_prefix"></a>strip_prefix |  (note: strip_prefix = "." will prevent srcs to be flattened) | String | optional | "" |
+| <a id="pkg_tar-strip_prefix"></a>strip_prefix |  (note: Use strip_prefix = "." to strip path to the package but preserve relative paths of sub directories beneath the package.) | String | optional | "" |
 | <a id="pkg_tar-symlinks"></a>symlinks |  -   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -249,7 +249,7 @@ pkg_tar_impl = rule(
     implementation = _pkg_tar_impl,
     attrs = {
         "strip_prefix": attr.string(
-            doc = """(note: strip_prefix = "." will prevent srcs to be flattened)"""
+            doc = """(note: Use strip_prefix = "." to strip path to the package but preserve relative paths of sub directories beneath the package.)"""
         ),
         "package_dir": attr.string(
             doc = """Prefix to be prepend to all paths written."""

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -248,7 +248,9 @@ def _pkg_tar_impl(ctx):
 pkg_tar_impl = rule(
     implementation = _pkg_tar_impl,
     attrs = {
-        "strip_prefix": attr.string(),
+        "strip_prefix": attr.string(
+            doc = """(note: strip_prefix = "." will prevent srcs to be flattened)"""
+        ),
         "package_dir": attr.string(
             doc = """Prefix to be prepend to all paths written."""
         ),


### PR DESCRIPTION
Hey folks, here is a very inconsequential PR which could save some time to new users. 

From the perspective of someone who just started using `rules_pkg`, I was really confused to learn that if I don't want to flatten the files structure I have to use the undocumented `strip_prefix = "."` magic trick. 

While there is an ongoing discussion over https://github.com/bazelbuild/rules_pkg/issues/354 on this precise issue, I feel that it would save a lot a time for new users stumbling across this problem by having a quick note in the existing docs, while the conversation continues over there. 