### PR TITLE
fix working dir on integration tests

### DIFF
--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -7,7 +7,6 @@ rolling: &rolling
 
 common: &common
   platform: ubuntu1804
-  working_directory: /workdir
   build_targets:
   - "distro:*"
 

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -7,6 +7,7 @@ rolling: &rolling
 
 common: &common
   platform: ubuntu1804
+  working_directory: ..
   build_targets:
   - "distro:*"
 


### PR DESCRIPTION
The old spec was just wrong. bazelci must have updated the framework, and now errors out on it.