### PR TITLE
Use Label constructor for verify_archive_test macro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,12 @@ local_repository(
     path = "tests/mappings/external_repo",
 )
 
+# Used to test invoking tar rules (such as verify_archive_test) in an external repo
+local_repository(
+    name = "tar_tests_external_repo",
+    path = "tests/tar/external_repo",
+)
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/pkg/verify_archive.bzl
+++ b/pkg/verify_archive.bzl
@@ -122,7 +122,7 @@ def verify_archive_test(name, target,
         data = [target],
         python_version = "PY3",
         deps = [
-            "//pkg:verify_archive_test_lib",
+            Label("//pkg:verify_archive_test_lib"),
             "@bazel_tools//tools/python/runfiles",
         ],
     )

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -283,7 +283,13 @@ verify_archive_test(
     must_not_contain_regex = [
         "^five.is.right.out",
     ],
-    max_size = 2,
+
+test_suite(
+    name = "verify_archive_test_suite",
+    tests = [
+        ":repackaging_long_filename_test",
+        "@tar_tests_external_repo//pkg:external_archive_test",
+    ],
 )
 
 pkg_tar(

--- a/tests/tar/external_repo/WORKSPACE
+++ b/tests/tar/external_repo/WORKSPACE
@@ -1,0 +1,15 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "test_external_verify")

--- a/tests/tar/external_repo/pkg/BUILD
+++ b/tests/tar/external_repo/pkg/BUILD
@@ -1,0 +1,29 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@//pkg:tar.bzl", "pkg_tar")
+load("@//pkg:verify_archive.bzl", "verify_archive_test")
+
+pkg_tar(
+    name = "external_archive",
+    srcs = ["file.txt"],
+)
+
+verify_archive_test(
+    name = "external_archive_test",
+    max_size = 1,
+    min_size = 1,
+    must_contain = ["file.txt"],
+    target = ":external_archive",
+)

--- a/tests/tar/external_repo/pkg/file.txt
+++ b/tests/tar/external_repo/pkg/file.txt
@@ -1,0 +1,1 @@
+Test file!


### PR DESCRIPTION
Fixes #704 

One of the `deps` within the `verify_archive_test` macro depends on a label, which would be incorrectly evaluated in a caller's `BUILD` file to be a non-external package.

This change wraps the label in a `Label()` call to ensure it's referenced properly in the `rules_pkg` context.

I added a new external repository to make a test since it didn't quite seem appropriate to put it in the mapping repository, though I can certainly do so if desired.