### PR TITLE
Write debian changes Date field in UTC rather than local time

### DIFF
--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -288,7 +288,7 @@ def CreateChanges(output,
 
   changesdata = u''.join([
       MakeDebianControlField('Format', '1.8'),
-      MakeDebianControlField('Date', time.ctime(timestamp)),
+      MakeDebianControlField('Date', time.asctime(time.gmtime(timestamp))),
       MakeDebianControlField('Source', package),
       MakeDebianControlField('Binary', package),
       MakeDebianControlField('Architecture', architecture),


### PR DESCRIPTION
This fixes some subtle problems caused by having CI and developer machines in different time zones.
It's also the right thing.