### PR TITLE
Use Gzip compress level 6

### DIFF
--- a/pkg/private/tar/tar_writer.py
+++ b/pkg/private/tar/tar_writer.py
@@ -87,7 +87,7 @@ class TarFileWriter(object):
         # The Tarfile class doesn't allow us to specify gzip's mtime attribute.
         # Instead, we manually reimplement gzopen from tarfile.py and set mtime.
         self.fileobj = gzip.GzipFile(
-            filename=name, mode='w', compresslevel=9, mtime=self.default_mtime)
+            filename=name, mode='w', compresslevel=6, mtime=self.default_mtime)
     self.compressor_proc = None
     if self.compressor_cmd:
       mode = 'w|'


### PR DESCRIPTION
Much faster and comparable quality to level 9

In the example below, level 9 (max) compression is 2% smaller and 50% slower compared to level 6. This is why most gzip implementations default to level 6. 

---

**BUILD.bazel**

```bzl
load("@rules_pkg//pkg:tar.bzl", "pkg_tar")

pkg_tar(
    name = "tar",
    extension = "tar.gz",
    srcs = ["@src//:src"],
)
```

**WORKSPACE.bazel**

```bzl
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

local_repository(
    name = "rules_pkg",
    path = "../rules_pkg",
)

load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

rules_pkg_dependencies()

http_archive(
    build_file_content = """
filegroup(
    name = "src",
    srcs = glob(["**/*"]),
    visibility = ["//visibility:public"],
)
""".strip(),
    name = "src",
    url = "https://github.com/torvalds/linux/archive/c1a515d3c0270628df8ae5f5118ba859b85464a2.zip",
    sha256 = "33e032d6022e19c1b07ff122848b34f2f9e54e3202adb6f14da344b21f01b11a",
)
```

Level 6: 183MB, 36s

Level 9: 179MB, 54s

---

(FYI, as a note for anyone caring about performance, using an external gzip binary cut the time by a further 6s.)