### PR TITLE
chore: automate publishing releases to BCR

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When the ruleset is released, we want it to be published to the
+Bazel Central Registry automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files to automate the publish step.
+See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for authoritative documentation about these files.

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,5 @@
+# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
+# for guidance about this section:
+fixedReleaser:
+  login: alexeagle
+  email: alex@aspect.dev

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,5 +1,0 @@
-# See https://github.com/bazel-contrib/publish-to-bcr#a-note-on-release-automation
-# for guidance about this section:
-fixedReleaser:
-  login: alexeagle
-  email: alex@aspect.dev

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,7 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_pkg",
+    "maintainers": [],
+    "repository": ["github:bazelbuild/rules_pkg"],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,10 @@
+bcr_test_module:
+  module_path: "examples/naming_package_files"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,10 +1,17 @@
-bcr_test_module:
-  module_path: "examples/naming_package_files"
-  matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
-  tasks:
-    run_tests:
-      name: "Run test module"
-      platform: ${{ platform }}
-      test_targets:
-        - "//..."
+build_targets: &build_targets
+- '@rules_pkg//...'
+# Re-enable those targets when toolchain registration is supported.
+- '-@rules_pkg//toolchains/...'
+- '-@rules_pkg//pkg:make_rpm'
+
+platforms:
+  centos7:
+    build_targets: *build_targets
+  debian10:
+    build_targets: *build_targets
+  macos:
+    build_targets: *build_targets
+  ubuntu2004:
+    build_targets: *build_targets
+  windows:
+    build_targets: *build_targets

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,4 @@
+{
+    "integrity": "**leave this alone**",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_pkg-{TAG}.tar.gz"
+}


### PR DESCRIPTION
This matches the layout that was manually published for prior releases: https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/rules_pkg/

After this is merged, an admin of this repo needs to add the Publish to BCR app like we've done for most other bazelbuild/ rulesets on BCR.