### PR TITLE
Require python3 for executable scripts

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/releasing/git_changelog_private.py
+++ b/pkg/releasing/git_changelog_private.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/releasing/print_rel_notes.py
+++ b/pkg/releasing/print_rel_notes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/releasing/release_tools_test.py
+++ b/pkg/releasing/release_tools_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/verify_archive_test_main.py.tpl
+++ b/pkg/verify_archive_test_main.py.tpl
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2023 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Otherwise, on old Linux systems where python == python2, we try to use python2 and fail: https://buildkite.com/bazel/bazel-skylib/builds/2768#0189d6bc-463d-4c32-ad02-46ed3c01da5d