### PR TITLE
Add changelog attribute to pkg_deb

### DIFF
--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -107,6 +107,10 @@ def _pkg_deb_impl(ctx):
     else:
         fail("Neither description_file nor description attribute was specified")
 
+    if ctx.attr.changelog:
+        args += ["--changelog=@" + ctx.file.changelog.path]
+        files += [ctx.file.changelog]
+
     # Built using can also be specified by a file or inlined (but is not mandatory)
     if ctx.attr.built_using_file:
         if ctx.attr.built_using:
@@ -214,6 +218,11 @@ pkg_deb_impl = rule(
             doc = """config file used for debconf integration.
             See https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts.""",
             allow_single_file = True,
+        ),
+        "changelog": attr.label(
+            doc = """The package changelog.
+            See https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog.""",
+            allow_single_file = True
         ),
         "description": attr.string(
             doc = """The package description. Must not be used with `description_file`.""",

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -198,6 +198,7 @@ def CreateDeb(output,
               templates=None,
               triggers=None,
               conffiles=None,
+              changelog=None,
               **kwargs):
   """Create a full debian package."""
   extrafiles = OrderedDict()
@@ -217,6 +218,8 @@ def CreateDeb(output,
     extrafiles['triggers'] = (triggers, 0o644)
   if conffiles:
     extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
+  if changelog:
+    extrafiles['changelog'] = (changelog, 0o644)
   control = CreateDebControl(extrafiles=extrafiles, **kwargs)
 
   # Write the final AR archive (the deb package)
@@ -367,6 +370,9 @@ def main():
   parser.add_argument(
       '--conffile', action='append',
       help='List of conffiles (prefix item with @ to provide a path)')
+  parser.add_argument(
+      "--changelog",
+      help='The changelog file (prefix item with @ to provide a path).')
   AddControlFlags(parser)
   options = parser.parse_args()
 
@@ -381,6 +387,7 @@ def main():
       templates=helpers.GetFlagValue(options.templates, False),
       triggers=helpers.GetFlagValue(options.triggers, False),
       conffiles=GetFlagValues(options.conffile),
+      changelog=GetFlagValues(options.changelog),
       package=options.package,
       version=helpers.GetFlagValue(options.version),
       description=helpers.GetFlagValue(options.description),


### PR DESCRIPTION
Allow passing changelog file to `pkg_deb` rule.
This addresses #696 issue.