### PR TITLE
[RPM] Fix handling paths containing whitespaces

### DIFF
--- a/pkg/rpm/augment_rpm_files_install.py
+++ b/pkg/rpm/augment_rpm_files_install.py
@@ -22,10 +22,14 @@ import os
 import sys
 import json
 
-# NOTE: Keep this in sync with the same variable in rpm.bzl
+# NOTE: Keep those two in sync with the same variables in rpm_pfg.bzl
 _INSTALL_FILE_STANZA_FMT = """
-install -d %{{buildroot}}/$(dirname {1})
-cp {0} %{{buildroot}}/{1}
+install -d "%{{buildroot}}/$(dirname '{1}')"
+cp '{0}' '%{{buildroot}}/{1}'
+""".strip()
+
+_FILE_MODE_STANZA_FMT = """
+{0} "{1}"
 """.strip()
 
 # Cheapo arg parsing.  Currently this script is single-purpose.
@@ -69,9 +73,7 @@ with open(dir_data_path, 'r') as fh:
                     os.path.join(root, f),
                     full_dest
                 ))
-                dir_files_segments.append(
-                    d["tags"] + " " + full_dest
-                )
+                dir_files_segments.append(_FILE_MODE_STANZA_FMT.format(d["tags"], full_dest))
 
 with open(existing_install_script_path, 'r') as fh:
     existing_install_script = fh.read()


### PR DESCRIPTION
## What

Fixes #732:
- Added quotes around paths to avoid string splitting when the path contains whitespaces
- Added file attribute string template
- Added `.strip()` calls around string templates to avoid extra blank lines

## Verification

```
$ rpm -qlpviR bazel-bin/test/test-0.0.0-0..rpm
Name        : test
Version     : 0.0.0
Release     : 0
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 7
License     : license
Signature   : (none)
Source RPM  : test-0.0.0-0.src.rpm
Build Date  : Wed Aug 16 07:55:34 2023
Build Host  : tomasz-dev
Summary     : summary
Description :
description
pre,interp: /bin/sh
post,interp: /bin/sh
preun,interp: /bin/sh
postun,interp: /bin/sh
rpmlib: rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib: rpmlib(FileDigests) <= 4.6.0-1
rpmlib: rpmlib(PayloadFilesHavePrefix) <= 4.0-1
drwxr-xr-x    2 root     root                        0 Aug 16 07:55 /dire ctory
-rw-r--r--    1 root     root                        0 Aug 16 07:55 /foo bar
-rw-r--r--    1 root     root                        0 Aug 16 07:55 /foobar
lrwxrwxrwx    1 root     root                        7 Aug 16 07:55 /sym link -> /foobar
```
