### PR TITLE
Fix pkg_deb changelog flag getter

### DIFF
--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -371,7 +371,7 @@ def main():
       '--conffile', action='append',
       help='List of conffiles (prefix item with @ to provide a path)')
   parser.add_argument(
-      "--changelog",
+      '--changelog',
       help='The changelog file (prefix item with @ to provide a path).')
   AddControlFlags(parser)
   options = parser.parse_args()
@@ -387,7 +387,7 @@ def main():
       templates=helpers.GetFlagValue(options.templates, False),
       triggers=helpers.GetFlagValue(options.triggers, False),
       conffiles=GetFlagValues(options.conffile),
-      changelog=GetFlagValues(options.changelog),
+      changelog=helpers.GetFlagValue(options.changelog, False),
       package=options.package,
       version=helpers.GetFlagValue(options.version),
       description=helpers.GetFlagValue(options.description),


### PR DESCRIPTION
The `pkg_deb` changelog file getter fails with the `FileNotFoundError`. We should be using `helpers.GetFlagValue()` instead of `GetFlagValues` to read the file content:

```
Traceback (most recent call last):
  File "/home/tomasz.wojno/.cache/bazel/_bazel_tomasz.wojno/add7b8b23cb52c9765c438b938f09330/sandbox/linux-sandbox/34/execroot/repo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/deb/make_deb.runfiles/rules_pkg/pkg/private/deb/make_deb.py", line 408, in <module>
    main()
  File "/home/tomasz.wojno/.cache/bazel/_bazel_tomasz.wojno/add7b8b23cb52c9765c438b938f09330/sandbox/linux-sandbox/34/execroot/repo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/deb/make_deb.runfiles/rules_pkg/pkg/private/deb/make_deb.py", line 376, in main
    changelog=GetFlagValues(options.changelog),
  File "/home/tomasz.wojno/.cache/bazel/_bazel_tomasz.wojno/add7b8b23cb52c9765c438b938f09330/sandbox/linux-sandbox/34/execroot/repo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/deb/make_deb.runfiles/rules_pkg/pkg/private/deb/make_deb.py", line 318, in GetFlagValues
    return [helpers.GetFlagValue(f, False) for f in flagvalues]
  File "/home/tomasz.wojno/.cache/bazel/_bazel_tomasz.wojno/add7b8b23cb52c9765c438b938f09330/sandbox/linux-sandbox/34/execroot/repo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/deb/make_deb.runfiles/rules_pkg/pkg/private/deb/make_deb.py", line 318, in <listcomp>
    return [helpers.GetFlagValue(f, False) for f in flagvalues]
  File "/home/tomasz.wojno/.cache/bazel/_bazel_tomasz.wojno/add7b8b23cb52c9765c438b938f09330/sandbox/linux-sandbox/34/execroot/repo/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_pkg/pkg/private/deb/make_deb.runfiles/rules_pkg/pkg/private/helpers.py", line 80, in GetFlagValue
    with open(flagvalue[1:], 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '' 