### PR TITLE
pkg_tar remap_paths works for TreeArtifacts (#450)

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -140,14 +140,15 @@ def _pkg_tar_impl(ctx):
             # Add in the files of srcs which are not pkg_* types
             for f in src_files:
                 d_path = dest_path(f, data_path, data_path_without_prefix)
+
+                # Note: This extra remap is the bottleneck preventing this
+                # large block from being a utility method as shown below.
+                # Should we disallow mixing pkg_files in srcs with remap?
+                # I am fine with that if it makes the code more readable.
+                dest = _remap(remap_paths, d_path)
                 if f.is_directory:
-                    add_tree_artifact(content_map, d_path, f, src.label)
+                    add_tree_artifact(content_map, dest, f, src.label)
                 else:
-                    # Note: This extra remap is the bottleneck preventing this
-                    # large block from being a utility method as shown below.
-                    # Should we disallow mixing pkg_files in srcs with remap?
-                    # I am fine with that if it makes the code more readable.
-                    dest = _remap(remap_paths, d_path)
                     add_single_file(content_map, dest, f, src.label)
 
     # TODO(aiuto): I want the code to look like this, but we don't have lambdas.

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -360,6 +360,7 @@ py_test(
         ":test-pkg-tar-with-attributes",
         ":test-pkg-tar-from-pkg-files-with-attributes",
         ":test-tree-input-with-strip-prefix",
+        ":test-remap-paths-tree-artifact",
         "//tests:testdata/tar_test.tar",
         "//tests:testdata/tar_test.tar.bz2",
         "//tests:testdata/tar_test.tar.gz",
@@ -523,4 +524,25 @@ pkg_tar(
         ":generate_tree_with_prefix",
     ],
     strip_prefix = "tree_prefix_to_strip",
+)
+
+
+directory(
+    name = "tree_artifact_to_rename",
+    contents = "hello there",
+    filenames = [
+        "a",
+        "rename_me/should_not_rename"
+    ],
+    outdir = "rename_me",
+)
+
+pkg_tar(
+    name = "test-remap-paths-tree-artifact",
+    remap_paths = {
+        "/rename_me": "a_new_name",
+    },
+    srcs = [
+        ":tree_artifact_to_rename",
+    ],
 )

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -283,6 +283,15 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test-tree-input-with-strip-prefix.tar', content)
 
+  def test_remap_paths_tree_artifact(self):
+    content = [
+      {'name': 'a_new_name', 'isdir': True},
+      {'name': 'a_new_name/a'},
+      {'name': 'a_new_name/rename_me', 'isdir': True},
+      {'name': 'a_new_name/rename_me/should_not_rename'},
+    ]
+    self.assertTarFileContent('test-remap-paths-tree-artifact.tar', content)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
I understand that `remap_paths` is a hack that will eventually be deprecated, but this change brings it's behavior in line with the behavior of the `pkg_tar` from the built-in `bazel_tools`. We are working towards removing our usages of `remap_paths`, but would like that removal work to not block our upgrade to Bazel 6.