### PR TITLE
Allow graceful fallback for compression types in pkg_zip.

### DIFF
--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -24,13 +24,16 @@ from pkg.private import build_info
 from pkg.private import manifest
 
 try:
+  import bz2  # pylint: disable=g-import-not-at-top, unused-import
+  HAS_BZIP2 = True
+except ImportError:
+  HAS_BZIP2 = False
+
+try:
   import lzma  # pylint: disable=g-import-not-at-top, unused-import
   HAS_LZMA = True
 except ImportError:
   HAS_LZMA = False
-
-COMPRESSIONS = ('stored', 'deflated', 'bzip2', 'lzma') if HAS_LZMA else ('stored', 'deflated', 'bzip2')
-
 
 ZIP_EPOCH = 315532800
 
@@ -104,10 +107,16 @@ class ZipWriter(object):
     compressions = {
       'deflated': zipfile.ZIP_DEFLATED,
       'bzip2': zipfile.ZIP_BZIP2,
-      'stored': zipfile.ZIP_STORED,
+      'stored': zipfile.ZIP_STORED
     }
+    if HAS_BZIP2:
+      compressions['bzip2'] = zipfile.ZIP_BZIP2
+    else:
+      compressions['bzip2'] = zipfile.ZIP_DEFLATED
     if HAS_LZMA:
       compressions['lzma'] = zipfile.ZIP_LZMA
+    else:
+      compressions['lzma'] = compressions['bzip2']
     self.compression_type = compressions[compression_type]
     self.compression_level = compression_level
     self.zip_file = zipfile.ZipFile(self.output_path, mode='w', compression=self.compression_type)

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -89,6 +89,23 @@ def parse_date(ts):
   return (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second)
 
 
+def _get_compression(requested_compression):
+  compressions = {
+    'deflated': zipfile.ZIP_DEFLATED,
+    'bzip2': zipfile.ZIP_BZIP2,
+    'stored': zipfile.ZIP_STORED
+  }
+  if HAS_BZIP2:
+    compressions['bzip2'] = zipfile.ZIP_BZIP2
+  else:
+    compressions['bzip2'] = zipfile.ZIP_DEFLATED
+  if HAS_LZMA:
+    compressions['lzma'] = zipfile.ZIP_LZMA
+  else:
+    compressions['lzma'] = compressions['bzip2']
+  return compressions[requested_compression]
+
+
 class ZipWriter(object):
 
   def __init__(self, output_path: str, time_stamp: int, default_mode: int, compression_type: str, compression_level: int):
@@ -104,20 +121,7 @@ class ZipWriter(object):
     self.output_path = output_path
     self.time_stamp = time_stamp
     self.default_mode = default_mode
-    compressions = {
-      'deflated': zipfile.ZIP_DEFLATED,
-      'bzip2': zipfile.ZIP_BZIP2,
-      'stored': zipfile.ZIP_STORED
-    }
-    if HAS_BZIP2:
-      compressions['bzip2'] = zipfile.ZIP_BZIP2
-    else:
-      compressions['bzip2'] = zipfile.ZIP_DEFLATED
-    if HAS_LZMA:
-      compressions['lzma'] = zipfile.ZIP_LZMA
-    else:
-      compressions['lzma'] = compressions['bzip2']
-    self.compression_type = compressions[compression_type]
+    self.compression_type = _get_compression(compression_type)
     self.compression_level = compression_level
     self.zip_file = zipfile.ZipFile(self.output_path, mode='w', compression=self.compression_type)
 

--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -23,6 +23,15 @@ import zipfile
 from pkg.private import build_info
 from pkg.private import manifest
 
+try:
+  import lzma  # pylint: disable=g-import-not-at-top, unused-import
+  HAS_LZMA = True
+except ImportError:
+  HAS_LZMA = False
+
+COMPRESSIONS = ('stored', 'deflated', 'bzip2', 'lzma') if HAS_LZMA else ('stored', 'deflated', 'bzip2')
+
+
 ZIP_EPOCH = 315532800
 
 # Unix dir bit and Windows dir bit. Magic from zip spec
@@ -93,11 +102,12 @@ class ZipWriter(object):
     self.time_stamp = time_stamp
     self.default_mode = default_mode
     compressions = {
-      "deflated": zipfile.ZIP_DEFLATED,
-      "lzma": zipfile.ZIP_LZMA,
-      "bzip2": zipfile.ZIP_BZIP2,
-      "stored": zipfile.ZIP_STORED
+      'deflated': zipfile.ZIP_DEFLATED,
+      'bzip2': zipfile.ZIP_BZIP2,
+      'stored': zipfile.ZIP_STORED,
     }
+    if HAS_LZMA:
+      compressions['lzma'] = zipfile.ZIP_LZMA
     self.compression_type = compressions[compression_type]
     self.compression_level = compression_level
     self.zip_file = zipfile.ZipFile(self.output_path, mode='w', compression=self.compression_type)


### PR DESCRIPTION
If they python you have does not support lzma, fall back to bz2.
If no bz2, fall back to deflate.

Possible alternates:
- print a warning
- fail hard
- fail hard unless you also set `allow_fallback=True`
- make `compression` a list of acceptable values, falling back from first to last.


