### PR TITLE
Remove PackageArtifactsInfo.

### DIFF
--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Rule for creating Debian packages."""
 
-load("//pkg:providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
+load("//pkg:providers.bzl", "PackageVariablesInfo")
 load("//pkg/private:util.bzl", "setup_output_files")
 
 _tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.bz2", "tar.xz"]
@@ -171,11 +171,6 @@ def _pkg_deb_impl(ctx):
         DefaultInfo(
             files = depset([output_file]),
             runfiles = ctx.runfiles(files = outputs),
-        ),
-        PackageArtifactInfo(
-            label = ctx.label.name,
-            file = output_file,
-            file_name = output_name,
         ),
     ]
 
@@ -361,7 +356,6 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
             allow_files = True,
         ),
     },
-    provides = [PackageArtifactInfo],
 )
 
 def pkg_deb(name, out = None, **kwargs):

--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -177,6 +177,18 @@ def _pkg_deb_impl(ctx):
 # A rule for creating a deb file, see README.md
 pkg_deb_impl = rule(
     implementation = _pkg_deb_impl,
+    doc = """
+    Create a Debian package.
+
+    This rule produces 2 artifacts: a .deb and a .changes file. The DefaultInfo will
+    include both. If you need downstream rule to specificially depend on only the .deb or
+    .changes file then you can use `filegroup` to select distinct output groups.
+
+    **OutputGroupInfo**
+    - `out` the Debian package or a symlink to the actual package.
+    - `deb` the package with any precise file name created with `package_file_name`.
+    - `changes` the .changes file.
+    """,
     attrs = {
         # @unsorted-dict-items
         "data": attr.label(

--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -34,7 +34,6 @@ Concepts and terms:
 load("//pkg:path.bzl", "compute_data_path", "dest_path")
 load(
     "//pkg:providers.bzl",
-    "PackageArtifactInfo",
     "PackageDirsInfo",
     "PackageFilegroupInfo",
     "PackageFilesInfo",

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -14,7 +14,7 @@
 """Rules for making .tar files."""
 
 load("//pkg:path.bzl", "compute_data_path", "dest_path")
-load("//pkg:providers.bzl", "PackageArtifactInfo", "PackageVariablesInfo")
+load("//pkg:providers.bzl", "PackageVariablesInfo")
 load(
     "//pkg/private:pkg_files.bzl",
     "add_directory",
@@ -238,11 +238,6 @@ def _pkg_tar_impl(ctx):
         OutputGroupInfo(
             manifest = [manifest_file], 
         ),
-        PackageArtifactInfo(
-            label = ctx.label.name,
-            file = output_file,
-            file_name = output_name,
-        ),
     ]
 
 # A rule for creating a tar file, see README.md
@@ -305,7 +300,6 @@ The name may contain variables, same as [package_file_name](#package_file_name)"
             allow_files = True,
         ),
     },
-    provides = [PackageArtifactInfo],
 )
 
 def pkg_tar(name, **kwargs):

--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -29,10 +29,7 @@ def setup_output_files(ctx, package_file_name = None, default_output_file = None
     Callers should:
        - write to `output_file`
        - add `outputs` to their returned `DefaultInfo(files)` provider
-       - return a `PackageArtifactInfo` provider of the form:
-            label: `ctx.label.name`
-            file: `output_file`
-            file_name: `output_name`
+       - Possibly add a distingiushing element to OutputGroups
 
     Args:
       ctx: rule context

--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -29,7 +29,7 @@ def setup_output_files(ctx, package_file_name = None, default_output_file = None
     Callers should:
        - write to `output_file`
        - add `outputs` to their returned `DefaultInfo(files)` provider
-       - Possibly add a distingiushing element to OutputGroups
+       - Possibly add a distinguishing element to OutputGroups
 
     Args:
       ctx: rule context

--- a/pkg/private/zip/zip.bzl
+++ b/pkg/private/zip/zip.bzl
@@ -16,7 +16,6 @@
 load("//pkg:path.bzl", "compute_data_path", "dest_path")
 load(
     "//pkg:providers.bzl",
-    "PackageArtifactInfo",
     "PackageVariablesInfo",
 )
 load(
@@ -82,11 +81,6 @@ def _pkg_zip_impl(ctx):
         DefaultInfo(
             files = depset([output_file]),
             runfiles = ctx.runfiles(files = outputs),
-        ),
-        PackageArtifactInfo(
-            label = ctx.label.name,
-            file = output_file,
-            file_name = output_name,
         ),
     ]
 
@@ -160,7 +154,6 @@ The list of compressions is the same as Python's ZipFile: https://docs.python.or
             allow_files = True,
         ),
     },
-    provides = [PackageArtifactInfo],
 )
 
 def pkg_zip(name, out = None, **kwargs):

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -709,6 +709,14 @@ pkg_rpm = rule(
 
     Is the equivalent to `%config(missingok, noreplace)` in the `%files` list.
 
+    This rule produces 2 artifacts: an .rpm and a .changes file. The DefaultInfo will
+    include both. If you need downstream rule to specificially depend on only the .rpm or
+    .changes file then you can use `filegroup` to select distinct output groups.
+
+    **OutputGroupInfo**
+    - `out` the RPM or a symlink to the actual package.
+    - `rpm` the package with any precise file name created with `package_file_name`.
+    - `changes` the .changes file.
     """,
     # @unsorted-dict-items
     attrs = {

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -27,7 +27,6 @@ find_system_rpmbuild(name="rules_pkg_rpmbuild")
 
 load(
     "//pkg:providers.bzl",
-    "PackageArtifactInfo",
     "PackageDirsInfo",
     "PackageFilegroupInfo",
     "PackageFilesInfo",
@@ -678,11 +677,6 @@ def _pkg_rpm_impl(ctx):
         DefaultInfo(
             files = depset(outputs),
         ),
-        PackageArtifactInfo(
-            file = output_file,
-            file_name = output_name,
-            label = ctx.label.name,
-        ),
     ]
 
 # Define the rule.
@@ -1022,6 +1016,5 @@ pkg_rpm = rule(
     },
     executable = False,
     implementation = _pkg_rpm_impl,
-    provides = [PackageArtifactInfo],
     toolchains = ["@rules_pkg//toolchains/rpm:rpmbuild_toolchain_type"],
 )


### PR DESCRIPTION
Fixes #396

RELNOTES:
No rules return a PackageArtifactsInfo provider.
Rules which return multiple files (such as a .rpm and a .changes) now exclusively distinguish them through OutputGroupInfo.