### PR TITLE
fix(pkg_tar): properly normalize paths for empty files

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -316,11 +316,11 @@ class TarFile(object):
     if entry.type == manifest.ENTRY_IS_LINK:
       self.add_link(entry.dest, entry.src, **attrs)
     elif entry.type == manifest.ENTRY_IS_DIR:
-      self.add_empty_dir(entry.dest, **attrs)
+      self.add_empty_dir(self.normalize_path(entry.dest), **attrs)
     elif entry.type == manifest.ENTRY_IS_TREE:
       self.add_tree(entry.src, entry.dest, **attrs)
     elif entry.type == manifest.ENTRY_IS_EMPTY_FILE:
-      self.add_empty_file(entry.dest, **attrs)
+      self.add_empty_file(self.normalize_path(entry.dest), **attrs)
     else:
       self.add_file(entry.src, entry.dest, **attrs)
 

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -16,7 +16,7 @@
 
 # buildifier: disable=bzl-visibility
 load("//pkg:mappings.bzl", "pkg_attributes")
-load("//pkg:mappings.bzl", "pkg_files", "pkg_mklink", "strip_prefix")
+load("//pkg:mappings.bzl", "pkg_files", "pkg_mkdirs", "pkg_mklink", "strip_prefix")
 load("//pkg:verify_archive.bzl", "verify_archive_test")
 load("//pkg/private/tar:tar.bzl", "SUPPORTED_TAR_COMPRESSIONS", "pkg_tar")
 load("//tests:my_package_name.bzl", "my_package_naming")
@@ -106,10 +106,18 @@ pkg_tar(
     package_variables = ":my_package_variables",
 )
 
+pkg_mkdirs(
+    name = "mydir",
+    dirs = [
+        "mydir",
+    ],
+)
+
 pkg_tar(
     name = "test_tar_package_dir_substitution",
     srcs = [
         ":BUILD",
+        ":mydir",
     ],
     package_dir = "level1/{label}/level3",
     package_variables = ":my_package_variables",

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -195,6 +195,7 @@ class PkgTarTest(unittest.TestCase):
         {'name': 'level1/some_value'},
         {'name': 'level1/some_value/level3'},
         {'name': 'level1/some_value/level3/BUILD'},
+        {'name': 'level1/some_value/level3/mydir'},
     ]
     self.assertTarFileContent('test_tar_package_dir_substitution.tar', content)
 


### PR DESCRIPTION
The directory prefix attribute for a `pkg_tar` was not being honored for empty files or empty directories.

Closes #758