### PR TITLE
pkg_deb: allow data.tar.zst

### DIFF
--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -16,7 +16,7 @@
 load("//pkg:providers.bzl", "PackageVariablesInfo")
 load("//pkg/private:util.bzl", "setup_output_files")
 
-_tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.bz2", "tar.xz"]
+_tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.bz2", "tar.xz", "tar.zst"]
 
 def _pkg_deb_impl(ctx):
     """The implementation for the pkg_deb rule."""

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -237,7 +237,7 @@ def CreateDeb(output,
       ext = 'tar.bz2'
     else:
       ext = '.'.join(ext)
-      if ext not in ['tar.bz2', 'tar.gz', 'tar.xz', 'tar.lzma']:
+      if ext not in ['tar.bz2', 'tar.gz', 'tar.xz', 'tar.lzma', 'tar.zst']:
         ext = 'tar'
     data_size = os.stat(data).st_size
     with open(data, 'rb') as datafile:


### PR DESCRIPTION
dpkg has officially supported zstandard compression for the data tarball since version 1.21.18, and despite shipping with dpkg version 1.21.1, most .deb packages for Ubuntu 22.04 are also in zst format.

While this PR does not do anything to make it easier to create zstd-compressed tarballs, it does make it possible to use them when creating .deb packages.

Closes #759