### PR TITLE
pkg_rpm: Specify _topdir for install stanza

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -45,7 +45,7 @@ spec_filetype = [".spec", ".spec.in", ".spec.tpl"]
 # TODO(nacl, #292): cp -r does not do the right thing with TreeArtifacts
 _INSTALL_FILE_STANZA_FMT = """
 install -d "%{{buildroot}}/$(dirname '{1}')"
-cp '{0}' '%{{buildroot}}/{1}'
+cp '%{{_topdir}}/BUILD/{0}' '%{{buildroot}}/{1}'
 """.strip()
 
 # TODO(nacl): __install


### PR DESCRIPTION
If we don't specify the _topdir as part of the install-from path we can't seem to find the correct files to install when using a set of rules like:
```
pkg_filegroup(
    name = "my_filegroup",
    srcs = [
      "//some/label:foo",
    ],
    prefixs = "/usr/bin",
)

pkg_rpm(
    name = "rpm",
    ...
    srcs = [
        ":my_filegroup",
    ],
)
```
Adding `%{{_topdir}/BUILD/` as a prefix to the source path seems to solve this problem.