### PR TITLE
testing #763

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,0 +1,22 @@
+module(
+    name = "rules_pkg_examples",
+    version = "0.0.0",  # never ships
+    compatibility_level = 1,
+)
+
+local_path_override(
+    module_name = "rules_pkg",
+    path = "..",
+)
+
+bazel_dep(name = "rules_python", version = "0.24.0")
+bazel_dep(name = "rules_cc", version = "0.0.2")
+
+# Find the system rpmbuild if one is available.
+find_rpm = use_extension(
+    "//toolchains/rpm:rpmbuild_configure.bzl",
+    "find_system_rpmbuild_bzlmod",
+    dev_dependency = True
+)
+use_repo(find_rpm, "rules_pkg_rpmbuild")
+register_toolchains("@rules_pkg_rpmbuild//:all", dev_dependency = True)

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,0 +1,17 @@
+workspace(name = "rules_pkg_examples")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "rules_pkg",
+    path = "..",
+)
+
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
+# Find rpmbuild if it exists.
+load("@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild")
+
+find_system_rpmbuild(name = "rules_pkg_rpmbuild")

--- a/examples/rpm/BUILD
+++ b/examples/rpm/BUILD
@@ -1,0 +1,23 @@
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
+
+pkg_filegroup(
+    name = "rpm_filegroup",
+    srcs = [
+        "//rpm/main:exe",
+    ],
+    prefix = "/usr/bin",
+)
+
+pkg_rpm(
+    name = "rpm",
+    package_name = "example",
+    license = "example",
+    summary = "example",
+    version = "1.0.0",
+    release = "1",
+    description = "example",
+    srcs = [
+        ":rpm_filegroup",
+    ],
+)

--- a/examples/rpm/main/BUILD
+++ b/examples/rpm/main/BUILD
@@ -1,0 +1,29 @@
+# Package an executable up for distribution
+#
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "pkg_attributes")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cc"],
+)
+
+py_binary(
+    name = "hello_world_py",
+    main = "hello_world.py",
+    srcs = ["hello_world.py"],
+)
+
+pkg_files(
+    name = "exe",
+    srcs = [
+        ":hello_world",
+        ":hello_world_py",
+    ],
+    visibility = ["//visibility:public"],
+    attributes = pkg_attributes(
+        mode = "0755",
+        user = "root",
+        group = "root",
+    ),
+)

--- a/examples/rpm/main/hello_world.cc
+++ b/examples/rpm/main/hello_world.cc
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  std::cout << "hello world" << std::endl;
+}

--- a/examples/rpm/main/hello_world.py
+++ b/examples/rpm/main/hello_world.py
@@ -1,0 +1,2 @@
+if __name__ == "__main__":
+  print("hello world")

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -45,7 +45,8 @@ spec_filetype = [".spec", ".spec.in", ".spec.tpl"]
 # TODO(nacl, #292): cp -r does not do the right thing with TreeArtifacts
 _INSTALL_FILE_STANZA_FMT = """
 install -d "%{{buildroot}}/$(dirname '{1}')"
-cp '{0}' '%{{buildroot}}/{1}'
+ls -ld '{0}' '%{{_topdir}}/BUILD/{0}'
+cp '%{{_topdir}}/BUILD/{0}' '%{{buildroot}}/{1}'
 """.strip()
 
 # TODO(nacl): __install


### PR DESCRIPTION
@kellyma2

I'm baffled.  I took the example you had and added a python version of the binary.

python alone works fine. C++ fails with a permission denied error, not file not found.

I added some debugging "ls -l"s into the install stanza and the files seem to be in the source.  I can't spend a lot of time on it this week, but it seems that the permission problem is while calling /usr/bin/strip.  It might be that the file is mode o555 rather than o755. But.. how has this been working for others? 