### PR TITLE
doc: Fixup external manual references

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -913,7 +913,7 @@ pkg_rpm = rule(
 
             Corresponds to the "Conflicts" preamble tag.
 
-            See also: https://rpm.org/user_doc/dependencies.html
+            See also: https://rpm-software-management.github.io/rpm/manual/dependencies.html
             """,
         ),
         "provides": attr.string_list(
@@ -921,7 +921,7 @@ pkg_rpm = rule(
 
             Corresponds to the "Provides" preamble tag.
 
-            See also: https://rpm.org/user_doc/dependencies.html
+            See also: https://rpm-software-management.github.io/rpm/manual/dependencies.html
             """,
         ),
         "requires": attr.string_list(
@@ -929,7 +929,7 @@ pkg_rpm = rule(
 
             Corresponds to the "Requires" preamble tag.
 
-            See also: https://rpm.org/user_doc/dependencies.html
+            See also: https://rpm-software-management.github.io/rpm/manual/dependencies.html
             """,
         ),
         "requires_contextual": attr.string_list_dict(
@@ -964,7 +964,7 @@ pkg_rpm = rule(
             For capabilities that are always required by packages at runtime,
             use the `requires` attribute instead.
 
-            See also: https://rpm.org/user_doc/more_dependencies.html
+            See also: https://rpm-software-management.github.io/rpm/manual/more_dependencies.html
 
             NOTE: `pkg_rpm` does not check if the keys of this dictionary are
             acceptable to `rpm(8)`.


### PR DESCRIPTION
The original links for the RPM manual that were being referred to appear to have moved.  This update the links to point at the correct place.