### PR TITLE
Don't load cc toolchain from rules_cc

### DIFF
--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -4,7 +4,7 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
+  centos7_java11_devtoolset10:
     platform: centos7
     <<: *common
   ubuntu1804:

--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -4,8 +4,8 @@ common: &common
   - "..."
 
 tasks:
-  centos7_java11_devtoolset10:
-    platform: centos7
+  centos7:
+    platform: centos7_java11_devtoolset10
     <<: *common
   ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/examples_rich_structure.yml
+++ b/.bazelci/examples_rich_structure.yml
@@ -4,7 +4,7 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
+  centos7_java11_devtoolset10:
     platform: centos7
     <<: *common
   ubuntu1804:

--- a/.bazelci/examples_rich_structure.yml
+++ b/.bazelci/examples_rich_structure.yml
@@ -4,8 +4,8 @@ common: &common
   - "..."
 
 tasks:
-  centos7_java11_devtoolset10:
-    platform: centos7
+  centos7:
+    platform: centos7_java11_devtoolset10
     <<: *common
   ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/examples_stamping.yml
+++ b/.bazelci/examples_stamping.yml
@@ -5,7 +5,7 @@ common: &common
 
 tasks:
   centos7:
-    platform: centos7
+    platform: centos7_java11_devtoolset10
     <<: *common
   ubuntu1804:
     platform: ubuntu1804

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -66,7 +66,7 @@ ubuntu1804: &ubuntu
     - "//distro:relnotes"
     - "//doc_build:*"
 
-centos7: &centos
+centos7_java11_devtoolset10: &centos
   platform: centos7
   <<: *common
   <<: *default_tests_with_rpm

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -66,8 +66,8 @@ ubuntu1804: &ubuntu
     - "//distro:relnotes"
     - "//doc_build:*"
 
-centos7_java11_devtoolset10: &centos
-  platform: centos7
+centos7: &centos
+  platform: centos7_java11_devtoolset10
   <<: *common
   <<: *default_tests_with_rpm
 

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,6 +5,8 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
+  centos7_java11_devtoolset10:
+    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,8 +5,6 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7:
-    build_targets: *build_targets
   debian10:
     build_targets: *build_targets
   macos:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,5 +82,3 @@ http_archive(
 load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
 
 rules_cc_dependencies()
-
-rules_cc_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,6 +79,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
 )
 
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 
 rules_cc_dependencies()

--- a/examples/rich_structure/WORKSPACE
+++ b/examples/rich_structure/WORKSPACE
@@ -32,8 +32,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
 )
 
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
 
 rules_cc_dependencies()
-
-rules_cc_toolchains()


### PR DESCRIPTION
The cc toolchain autoconfig in rules_cc is out of sync from Bazel and doesn't work with VS2022.

Related: https://github.com/bazelbuild/continuous-integration/pull/1770