### PR TITLE
CI fixes

### DIFF
--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -2,15 +2,13 @@
 common: &common
   working_directory: ..
   build_targets:
-  - "distro:*"
+  - "distro:all"
 
 tasks:
   rolling_ubuntu:
     name: rolling_distro
     platform: ubuntu1804
     bazel: rolling
-    build_flags:
-    - "--noenable_bzlmod"
     <<: *common
   lts_ubuntu:
     name: lts_distro

--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -1,12 +1,5 @@
-lts: &lts
-  bazel: latest
-
-rolling: &rolling
-  bazel: rolling
-
 
 common: &common
-  platform: ubuntu1804
   working_directory: ..
   build_targets:
   - "distro:*"
@@ -14,10 +7,13 @@ common: &common
 tasks:
   rolling_ubuntu:
     name: rolling_distro
-    <<: *rolling
+    platform: ubuntu1804
+    bazel: rolling
+    build_flags:
+    - "--noenable_bzlmod"
     <<: *common
   lts_ubuntu:
     name: lts_distro
     platform: ubuntu1804
-    <<: *lts
+    bazel: latest
     <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -61,10 +61,6 @@ ubuntu1804: &ubuntu
   platform: ubuntu1804
   <<: *common
   <<: *default_tests
-  build_targets:
-    - "//distro:distro"
-    - "//distro:relnotes"
-    - "//doc_build:*"
 
 centos7: &centos
   platform: centos7_java11_devtoolset10
@@ -94,6 +90,9 @@ tasks:
     platform: ubuntu1804
     build_flags:
       - "--enable_bzlmod"
+    build_targets:
+      - "//distro:distro"
+      - "//distro:relnotes"
     <<: *common
     <<: *rolling
     <<: *default_tests
@@ -118,6 +117,10 @@ tasks:
     name: lts_ubuntu
     <<: *ubuntu
     <<: *lts
+    build_targets:
+      - "//distro:distro"
+      - "//distro:relnotes"
+      - "//doc_build:*"
   lts_windows:
     name: lts_windows
     <<: *windows

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -14,7 +14,7 @@ local_repository(
 #    verbose = False,
 #)
 
- Needed for making our release notes
+# Needed for making our release notes
 load("//toolchains/git:git_configure.bzl", "experimental_find_system_git")
 
 experimental_find_system_git(

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -14,10 +14,10 @@ local_repository(
 #    verbose = False,
 #)
 
-# Needed for making our release notes
-#load("//toolchains/git:git_configure.bzl", "experimental_find_system_git")
-#
-#experimental_find_system_git(
-#    name = "rules_pkg_git",
-#    verbose = False,
-#)
+ Needed for making our release notes
+load("//toolchains/git:git_configure.bzl", "experimental_find_system_git")
+
+experimental_find_system_git(
+    name = "rules_pkg_git",
+    verbose = False,
+)

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -15,9 +15,13 @@ local_repository(
 #)
 
 # Needed for making our release notes
-load("//toolchains/git:git_configure.bzl", "experimental_find_system_git")
+load("//toolchains/git:git_configure.bzl", "experimental_find_system_git_bzlmod")
 
-experimental_find_system_git(
+experimental_find_system_git_bzlmod(
     name = "rules_pkg_git",
     verbose = False,
+)
+register_toolchains(
+    "@rules_pkg_git//:git_auto_toolchain",
+    "//toolchains/git:git_missing_toolchain",
 )

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -20,7 +20,7 @@ How to:
 """
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 load("//:version.bzl", "version")
 
 package(default_applicable_licenses = ["//:license"])

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -20,7 +20,7 @@ How to:
 """
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("//:version.bzl", "version")
 
 package(default_applicable_licenses = ["//:license"])

--- a/toolchains/git/git_configure.bzl
+++ b/toolchains/git/git_configure.bzl
@@ -58,6 +58,7 @@ _find_system_git = repository_rule(
     },
 )
 
+# buildifier: disable=function-docstring-args
 def experimental_find_system_git(name, workspace_file = None, verbose = False):
     """Create a toolchain that lets you run git.
 
@@ -76,3 +77,19 @@ def experimental_find_system_git(name, workspace_file = None, verbose = False):
         "@%s//:git_auto_toolchain" % name,
         "@rules_pkg//toolchains/git:git_missing_toolchain",
     )
+
+# buildifier: disable=function-docstring-args
+def experimental_find_system_git_bzlmod(name, workspace_file = None, verbose = False):
+    """Create a toolchain that lets you run git.
+
+    WARNING: This is experimental. The API and behavior are subject to change
+    at any time.
+
+    This presumes that your Bazel WORKSPACE file is located under your git
+    client. That is often true, but might not be in a multi-repo where you
+    might weave together a Bazel workspace from several git repos that are
+    all rooted under the WORKSPACE file.
+    """
+    if not workspace_file:
+        workspace_file = Label("//:MODULE.bazel")
+    _find_system_git(name = name, workspace_file = workspace_file, verbose = verbose)


### PR DESCRIPTION
These are just to stop the spurious CI failures at head.
The right solution is to go back and have everything build uniformly with bzlmod or without it.
- Get experimental git toolchain working enough with bzlmod so we can use it. But yeech. It really needs a bzlmod conversion. I would rather someone else build it.
- Do not run the doc_build with bzlmod. It is impossible to have the sources work for both bzlmod and non_bzlmod because the module name changed. Or maybe it is, but I don't want to solve that right now.