### PR TITLE
Allow substitution of user-defined variables in RPM preamble

### DIFF
--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -82,5 +82,14 @@ def substitute_package_variables(ctx, attribute_value):
 
     # Map $(var) to {x} and then use format for substitution.
     # This is brittle and I hate it. We should have template substitution
-    # in the Starlark runtime.
-    return attribute_value.replace("$(", "{").replace(")", "}").format(**vars)
+    # in the Starlark runtime.  This loop compensates for mismatched counts
+    # of $(foo) so that we don't try replace things like (bar) because we
+    # have no regex matching
+    for _ in range(attribute_value.count("$(")):
+        if attribute_value.find(")") == -1:
+            fail("mismatched variable declaration")
+
+        attribute_value = attribute_value.replace("$(", "{", 1)
+        attribute_value = attribute_value.replace(")", "}", 1)
+
+    return attribute_value.format(**vars)

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -33,7 +33,7 @@ load(
     "PackageSymlinkInfo",
     "PackageVariablesInfo",
 )
-load("//pkg/private:util.bzl", "setup_output_files")
+load("//pkg/private:util.bzl", "setup_output_files", "substitute_package_variables")
 
 rpm_filetype = [".rpm"]
 
@@ -349,7 +349,7 @@ def _pkg_rpm_impl(ctx):
     )
     ctx.actions.write(
         output = preamble_file,
-        content = "\n".join(preamble_pieces),
+        content = substitute_package_variables(ctx, "\n".join(preamble_pieces)),
     )
     files.append(preamble_file)
     args.append("--preamble=" + preamble_file.path)


### PR DESCRIPTION
It's desirable to be able to parameterize some variables in the preamble such as architecture when RPM packages.  This change enables variable substitution in the preamble section so that the values may be injected in this fashion in lieu of only using statically defined values.