### PR TITLE
Only inject pre and post scriptlets when provided

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -268,10 +268,10 @@ class RpmBuilder(object):
     # Then prepare for textual substitution.  This is typically only the case for the
     # experimental `pkg_rpm`.
     tpl_replacements = {
-      'PRE_SCRIPTLET': "%pre\n" + self.pre_scriptlet,
-      'POST_SCRIPTLET': "%post\n" + self.post_scriptlet,
-      'PREUN_SCRIPTLET': "%preun\n" + self.preun_scriptlet,
-      'POSTUN_SCRIPTLET': "%postun\n" + self.postun_scriptlet,
+      'PRE_SCRIPTLET': ("%pre\n" + self.pre_scriptlet) if self.pre_scriptlet else "",
+      'POST_SCRIPTLET': ("%post\n" + self.post_scriptlet) if self.post_scriptlet else "",
+      'PREUN_SCRIPTLET': ("%preun\n" + self.preun_scriptlet) if self.preun_scriptlet else "",
+      'POSTUN_SCRIPTLET': ("%postun\n" + self.postun_scriptlet) if self.postun_scriptlet else "",
       'CHANGELOG': ""
     }
 


### PR DESCRIPTION
Currently if the consumer doesn't provide a value for the pre or post scriplets we inject an empty scriptlet which has the effect of constructing an RPM that appears to have these scriplets (although they're empty).  Instead, we likely want to not provide them at all in these cases.