### PR TITLE
Explicitly set `%{_builddir}` macro

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -357,6 +357,7 @@ class RpmBuilder(object):
     args += [
         '--define', '_topdir %s' % dirname,
         '--define', '_tmppath %s/TMP' % dirname,
+        '--define', '_builddir %s/BUILD' % dirname,
         '--bb',
         '--buildroot=%s' % buildroot,
     ]  # yapf: disable


### PR DESCRIPTION
rules_pkg has baked in the assumption that the value of `%{_builddir}` is going to be `%{_topdir}/BUILD` which is where rpmbuild will `cd` to when being run.  When using the built in system rpmbuild in a situation where the value of `%{_builddir}` has been overriden with a custom local macro, this assumption may be broken which will result in internal rpmbuild failures.

Because we make this assumption about the value of the macro, we can instead be explicit about what we want the value of `%{_builddir}` to be so as to avoid this problem altogether.