### PR TITLE
turn off doc building in CI

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -120,7 +120,7 @@ tasks:
     build_targets:
       - "//distro:distro"
       - "//distro:relnotes"
-      - "//doc_build:*"
+      # - "//doc_build:*"  Temporary disable
   lts_windows:
     name: lts_windows
     <<: *windows

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -120,7 +120,7 @@ tasks:
     build_targets:
       - "//distro:distro"
       - "//distro:relnotes"
-      - "//doc_build:*"
+      # - "//doc_build:*"  (Temporary disable)
   lts_windows:
     name: lts_windows
     <<: *windows

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -120,7 +120,7 @@ tasks:
     build_targets:
       - "//distro:distro"
       - "//distro:relnotes"
-      # - "//doc_build:*"  (Temporary disable)
+      - "//doc_build:*"
   lts_windows:
     name: lts_windows
     <<: *windows

--- a/examples/naming_package_files/MODULE.bazel
+++ b/examples/naming_package_files/MODULE.bazel
@@ -3,9 +3,10 @@ module(
     version = "0.0.1",
 )
 
-local_path_override(
-    module_name = "rules_pkg",
-    path = "../..",
-)
+# Temporarilly using WORKSPACE.bzlmod until CI switches to bazel past 7.0.0
+#local_path_override(
+#    module_name = "rules_pkg",
+#    path = "../..",
+#)
 
 bazel_dep(name = "rules_cc", version = "0.0.2")

--- a/examples/naming_package_files/WORKSPACE.bzlmod
+++ b/examples/naming_package_files/WORKSPACE.bzlmod
@@ -1,0 +1,8 @@
+local_repository(
+    name = "rules_pkg",
+    path = "../..",
+)
+
+load("@rules_pkg//pkg:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()


### PR DESCRIPTION
stardoc is borked if you have builds that are both WORKSPACE and bzlmod
And at bazel 7.0.0 if we have a local_repository in MODULE.bazel that seems to break the build with a wonky errorr.
I reverted to WORKSPACE.bzlmod in examples/naming to correct for that.