### PR TITLE
Apply tar remap_paths to runfiles full paths

### DIFF
--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -427,12 +427,11 @@ def add_from_default_info(
             # the executable, but that is not always obvious. When in doubt,
             # the first file of DefaultInfo.files should be the right target.
             base_file = the_executable or all_files[0]
-            base_file_path = mapping_context.path_mapper(
-                dest_path(base_file, data_path, data_path_without_prefix))
+            base_file_path = dest_path(base_file, data_path, data_path_without_prefix)
             base_path = base_file_path + ".runfiles"
 
             for rf in runfiles.files.to_list():
-                d_path = base_path + "/" + rf.short_path
+                d_path = mapping_context.path_mapper(base_path + "/" + rf.short_path)
                 fmode = "0755" if rf == the_executable else mapping_context.default_mode
                 _check_dest(mapping_context.content_map, d_path, rf, src.label, mapping_context.allow_duplicates_with_different_content)
                 mapping_context.content_map[d_path] = _DestFile(

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -361,6 +361,84 @@ verify_archive_test(
 )
 
 pkg_tar(
+    name = "test-tar-remap-runfiles-base-path",
+    srcs = [
+        ":a_program",
+        "//tests:an_executable",
+    ],
+    include_runfiles = True,
+    remap_paths = {
+        "/a_program": "/new_name",
+        "/an_executable": "/other/different_name",
+    },
+)
+
+verify_archive_test(
+    name = "runfiles_remap_base_path_test",
+    must_contain = [
+        "new_name",
+        "new_name.runfiles/tests/tar/BUILD",
+        "executable.sh",
+    ] + select({
+        "@platforms//os:windows": [
+            "other/different_name.exe",
+            "other/different_name.exe.runfiles/tests/foo.cc",
+            "other/different_name.exe.runfiles/tests/an_executable.exe",
+            "other/different_name.exe.runfiles/tests/testdata/hello.txt",
+        ],
+        "//conditions:default": [
+            "other/different_name",
+            "other/different_name.runfiles/tests/foo.cc",
+            "other/different_name.runfiles/tests/an_executable",
+            "other/different_name.runfiles/tests/testdata/hello.txt",
+        ],
+    }),
+    target = ":test-tar-remap-runfiles-base-path",
+)
+
+pkg_tar(
+    name = "test-tar-remap-runfiles-full-paths",
+    srcs = [
+        ":a_program",
+        "//tests:an_executable",
+    ],
+    include_runfiles = True,
+    remap_paths = {
+        # rename the entire runfiles directory
+        "/a_program.runfiles/": "/a/program/runfiles/",
+        # rename a specific file
+        "/an_executable.runfiles/tests/testdata/hello.txt": "/myfiles/hello.txt",
+        "/an_executable.exe.runfiles/tests/testdata/hello.txt": "/myfiles/hello.txt",
+        # rename a specific subdirectory
+        "/an_executable.runfiles/tests/": "/mytests/",
+        "/an_executable.exe.runfiles/tests/": "/mytests/",
+    },
+)
+
+verify_archive_test(
+    name = "runfiles_remap_full_paths_test",
+    must_contain = [
+        "a_program",
+        "a/program/runfiles/tests/tar/BUILD",
+        "executable.sh",
+    ] + select({
+        "@platforms//os:windows": [
+            "an_executable.exe",
+            "mytests/foo.cc",
+            "mytests/an_executable.exe",
+            "myfiles/hello.txt",
+        ],
+        "//conditions:default": [
+            "an_executable",
+            "mytests/foo.cc",
+            "mytests/an_executable",
+            "myfiles/hello.txt",
+        ],
+    }),
+    target = ":test-tar-remap-runfiles-full-paths",
+)
+
+pkg_tar(
     name = "test_tar_leading_dotslash",
     srcs = [
         "//tests:loremipsum_txt",


### PR DESCRIPTION
This modifies the way `remap_paths` works on `pkg_tar` when using `include_runfiles` so that remapping is performed on the full path of each runfile, instead of just in the base folder (`foo.runfiles`)

This should be backwards compatible with the current behavior, and only affect those that specify runfiles paths in their mappings. For example, for the following path `foo.runfiles/some/folder/file.txt`:
```starlark
remap_paths: {
    "/foo": "/bar", # Still yields the same result as before (bar.runfiles/some/folder/file.txt)
    "/foo.runfiles/some/folder": "/bar", # Now works and yields bar/file.txt
}
```

I have implemented some tests that demonstrate this behaviors.



Resolves #790 