### PR TITLE
Use raw string for docstring that contains a backslash

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -26,7 +26,7 @@ from pkg.private.tar import tar_writer
 
 
 def normpath(path):
-  """Normalize a path to the format we need it.
+  r"""Normalize a path to the format we need it.
 
   os.path.normpath changes / to \ on windows, but tarfile needs / style paths.
 


### PR DESCRIPTION
Python 3.12 started to complain about invalid escape sequences. https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes

One supposed to use r""" when dostrings contains backslashes """ https://stackoverflow.com/a/33734332