### PR TITLE
fix: remove unused glob patterns

### DIFF
--- a/pkg/rpm/BUILD
+++ b/pkg/rpm/BUILD
@@ -18,7 +18,6 @@ package(default_applicable_licenses = ["//:license"])
 
 exports_files(
     glob([
-        "*.bzl",
         "*.tpl",
     ]),
     visibility = ["//visibility:public"],
@@ -27,7 +26,6 @@ exports_files(
 filegroup(
     name = "standard_package",
     srcs = glob([
-        "*.bzl",
         "*.py",
         "*.tpl",
     ]) + [


### PR DESCRIPTION
Some glob patterns do not match any file, which makes building with --incompatible_disallow_empty_glob produce an error. We should be able to just remove them.