### PR TITLE
fix: use appropriate entry type for runfiles that are directories

### DIFF
--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -436,7 +436,7 @@ def add_from_default_info(
                 _check_dest(mapping_context.content_map, d_path, rf, src.label, mapping_context.allow_duplicates_with_different_content)
                 mapping_context.content_map[d_path] = _DestFile(
                     src = rf,
-                    entry_type = ENTRY_IS_FILE,
+                    entry_type = ENTRY_IS_TREE if rf.is_directory else ENTRY_IS_FILE,
                     origin = src.label,
                     mode = fmode,
                     user = mapping_context.default_user,


### PR DESCRIPTION
This fixes a regression at some point from 0.9.1 to 0.10.1, which caused `pkg_tar` to fail when `include_runfiles` was true and some of the sources had data dependencies that were directories.

The code that handles the `include_runfiles` attribute was always assigning ENTRY_IS_FILE as entry type of runfiles. This caused an error in the python code when packaging, as it encountered a directory in an unexpected place.

The fix is just considering ENTRY_IS_TREE types, in the same way as it is done in `_process_pkg_files`.