### PR TITLE
update scorecard workflow to newer nodejs setup

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,9 @@ jobs:
       # actions: read
 
     steps:
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.0.2
+
       - name: "Checkout code"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:


### PR DESCRIPTION
All the runs started failing with messages from github about node 16 not being supported and needing node 20. 

TBH... I have no idea if this is the right solution. I'm guessing from comments on the OSSF/scorecard site.