### PR TITLE
Update scorecard.yml to new checkout and analysis actions.

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/setup-node@v4.0.2
 
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
+        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Update scorecard workflow as per https://github.com/ossf/scorecard-action

My earlier suggested fix had no effect.  This one seems more likely, based on the error message on the security tab
```
[Scorecard analysis](https://github.com/bazelbuild/rules_pkg/actions/runs/8391092847/job/22980629120)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

That suggests that actions/checkout is out of date.

\<rant>I think it is inexcusable for a security scanner to not do numbered releases. You can not expect humans to audit and reason about github hashes.\</rant>