### PR TITLE
use sys.exit() instead of exit()

### DIFF
--- a/pkg/filter_directory.py
+++ b/pkg/filter_directory.py
@@ -282,4 +282,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))

--- a/pkg/private/install.py.tpl
+++ b/pkg/private/install.py.tpl
@@ -200,4 +200,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    exit(main(sys.argv))
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Just a cleanup.

Fixes #843

cc @joefradley