### PR TITLE
Force stardoc integration test to run with bazel 7.0.0

### DIFF
--- a/.bazelci/integration.yml
+++ b/.bazelci/integration.yml
@@ -11,7 +11,8 @@ tasks:
   integration:
     name: rolling_distro
     platform: ubuntu1804
-    bazel: rolling
+    # See https://github.com/bazelbuild/rules_pkg/issues/808
+    bazel: 7.0.0
     build_flags:
     - "--noenable_bzlmod"
     <<: *common

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "rules_python", version = "0.24.0")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 
 # Only for development
-bazel_dep(name = "platforms", version = "0.0.5", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.5.3", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,10 +36,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "platforms",
-    sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
+    sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Force the integration test (stardoc and packaging) to run with bazel 7.0.0.
Bazel at head seems to have broken --noenable_bzlmod in some cases. See #808.

This also bumps platforms to the latest, but that was a red herring from the error message in the underlying problem