### PR TITLE
pkg_tar: if symlink starts with ./, keep it absolute

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -184,7 +184,10 @@ class TarFile(object):
       names: (username, groupname) for the file to set ownership.  An empty
         file will be created as `destfile` in the layer.
     """
-    dest = self.normalize_path(symlink)
+    if not symlink.startswith("./"):
+      dest = self.normalize_path(symlink)
+    else:
+      dest = symlink
     self.tarfile.add_file(
         dest,
         tarfile.SYMTYPE,


### PR DESCRIPTION
For the `symlink` attribute of `pkg_tar`, if the path begins with ./, preserve the path rather than prefixing package_dir. This allows graceful migration for some uses who rely on the previous package_dir behavior.

Hyrum's law is a strong one.