### PR TITLE
Enable pkg_rpm and pkg_subrpm to create empty RPMs

### DIFF
--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -53,16 +53,16 @@ def pkg_rpm(name, srcs = None, spec_file = None, subrpms = None, **kwargs):
                 depending on mode
 
     """
-    if srcs and spec_file:
+    if srcs != None and spec_file:
         fail("Cannot determine which pkg_rpm rule to use.  `srcs` and `spec_file` are mutually exclusive")
 
     if subrpms and spec_file:
         fail("Cannot build sub RPMs with a specfile.  `subrpms` and `spec_file` are mutually exclusive")
 
-    if not srcs and not spec_file:
+    if srcs == None and not spec_file:
         fail("Either `srcs` or `spec_file` must be provided.")
 
-    if srcs:
+    if srcs != None:
         pkg_rpm_pfg(
             name = name,
             srcs = srcs,

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -352,10 +352,14 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx):
             "%%files %s" % rpm_info.package_name,
         ]
 
-        for dep in rpm_info.srcs:
-            _process_dep(dep, sub_rpm_ctx)
+        if rpm_info.srcs:
+            for dep in rpm_info.srcs:
+                _process_dep(dep, sub_rpm_ctx)
 
-        rpm_lines += sub_rpm_ctx.rpm_files_list
+            rpm_lines += sub_rpm_ctx.rpm_files_list
+        else:
+            rpm_lines += "%defattr(-,root,root)"
+
         rpm_lines += [""]
 
     rpm_ctx.install_script_pieces.extend(sub_rpm_ctx.install_script_pieces)
@@ -702,10 +706,13 @@ def _pkg_rpm_impl(ctx):
     rpm_files_file = ctx.actions.declare_file(
         "{}.spec.files".format(rpm_name),
     )
-    ctx.actions.write(
-        rpm_files_file,
-        "\n".join(rpm_ctx.rpm_files_list),
-    )
+    if rpm_ctx.rpm_files_list:
+        ctx.actions.write(
+            rpm_files_file,
+            "\n".join(rpm_ctx.rpm_files_list),
+        )
+    else:
+        ctx.actions.write(rpm_files_file, "%defattr(-,root,root)")
 
     # TreeArtifact processing work
     if rpm_ctx.packaged_directories:

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -360,7 +360,7 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx):
 
         # rpmbuild will be unhappy if we have no files so we stick
         # default file mode in for that scenario
-        rpm_lines += DEFAULT_FILE_MODE
+        rpm_lines += [DEFAULT_FILE_MODE]
         rpm_lines += sub_rpm_ctx.rpm_files_list
 
         rpm_lines += [""]

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -57,6 +57,9 @@ PackageSubRPMInfo = provider(
     },
 )
 
+# default mode for %files
+DEFAULT_FILE_MODE = "%defattr(-,root,root)"
+
 # TODO(nacl): __install, __cp
 # {0} is the source, {1} is the dest
 #
@@ -352,13 +355,13 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx):
             "%%files %s" % rpm_info.package_name,
         ]
 
-        if rpm_info.srcs:
-            for dep in rpm_info.srcs:
-                _process_dep(dep, sub_rpm_ctx)
+        for dep in rpm_info.srcs:
+            _process_dep(dep, sub_rpm_ctx)
 
-            rpm_lines += sub_rpm_ctx.rpm_files_list
-        else:
-            rpm_lines += "%defattr(-,root,root)"
+        # rpmbuild will be unhappy if we have no files so we stick
+        # default file mode in for that scenario
+        rpm_lines += DEFAULT_FILE_MODE
+        rpm_lines += sub_rpm_ctx.rpm_files_list
 
         rpm_lines += [""]
 
@@ -706,13 +709,11 @@ def _pkg_rpm_impl(ctx):
     rpm_files_file = ctx.actions.declare_file(
         "{}.spec.files".format(rpm_name),
     )
-    if rpm_ctx.rpm_files_list:
-        ctx.actions.write(
-            rpm_files_file,
-            "\n".join(rpm_ctx.rpm_files_list),
-        )
-    else:
-        ctx.actions.write(rpm_files_file, "%defattr(-,root,root)")
+
+    # rpmbuild will be unhappy if we have no files so we stick
+    # default file mode in for that scenario
+    rpm_files_contents = [DEFAULT_FILE_MODE] + rpm_ctx.rpm_files_list
+    ctx.actions.write(rpm_files_file, "\n".join(rpm_files_contents))
 
     # TreeArtifact processing work
     if rpm_ctx.packaged_directories:


### PR DESCRIPTION
At present we fail in two ways if we try to create empty RPMs:

- we expect srcs to be both non-empty and will fail if it is empty and we have no spec file

- we don't emit anything for the `%files` block in the RPM if there are no actual files and rpmbuild doesn't like this

This change tweaks the former condition so that srcs has to be non-None or we have to have a specfile, but will allow us to have an empty (`[]`) value for srcs.  Additionally, it injects `%defattr(-,root,root)` as a reasonable default for the `%files` blocks so as to allow rpmbuild to be happy with what we're providing.

Fixes #711 