### PR TITLE
Exclude release from filename when using release_file

### DIFF
--- a/tests/rpm/pkg_rpm_basic_test.py
+++ b/tests/rpm/pkg_rpm_basic_test.py
@@ -51,7 +51,7 @@ class PkgRpmBasicTest(unittest.TestCase):
         self.test_rpm_scriptlets_files_path = self.runfiles.Rlocation(
             "rules_pkg/tests/rpm/test_rpm_scriptlets_files-1.1.1-2222.noarch.rpm")
         self.test_rpm_release_version_files = self.runfiles.Rlocation(
-            "rules_pkg/tests/rpm/test_rpm_release_version_files--.noarch.rpm")
+            "rules_pkg/tests/rpm/test_rpm_release_version_files-.noarch.rpm")
         self.test_rpm_epoch = self.runfiles.Rlocation(
             "rules_pkg/tests/rpm/test_rpm_epoch-1.1.1-2222.noarch.rpm")
         self.maxDiff = None


### PR DESCRIPTION
When we're using `release_file` in lieu of `release` we're just pointing rpmbuild at the file containing the `Release` string and we don't have it available to inject into the filename resulting in a strange looking filename of the form `Foo-version-.arch.rpm`.

This change extracts the RPM name generation to a single helper, `_make_rpm_filename` and tweaks it s.t. if we're missing the value for `release` we'll just exclude it from the filename format instead.