### PR TITLE
Append workspace name to the runfiles directory name for `pkg_files`

### DIFF
--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -298,7 +298,7 @@ def _pkg_files_impl(ctx):
             target = file_to_target[src]
             runfiles = target[DefaultInfo].default_runfiles
             if runfiles:
-                base_path = src_dest_paths_map[src] + ".runfiles"
+                base_path = src_dest_paths_map[src] + ".runfiles/" + ctx.workspace_name
                 for rf in runfiles.files.to_list():
                     dest_path = paths.join(base_path, rf.short_path)
 

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -59,14 +59,21 @@ def _pkg_files_contents_test_impl(ctx):
     target_under_test = analysistest.target_under_test(env)
 
     expected_dests = {e: None for e in ctx.attr.expected_dests}
+    actual_dests = target_under_test[PackageFilesInfo].dest_src_map.keys()
     n_found = 0
-    for got in target_under_test[PackageFilesInfo].dest_src_map.keys():
+
+    for actual in actual_dests:
         asserts.true(
-            got in expected_dests,
-            "got <%s> not in expected set: %s" % (got, ctx.attr.expected_dests),
+            env,
+            actual in expected_dests,
+            "actual dest <%s> not in expected expected set: %s" % (actual, ctx.attr.expected_dests),
         )
-        n_found += 1
-    asserts.equals(env, len(expected_dests), n_found)
+    for expected in expected_dests:
+        asserts.true(
+            env,
+            expected in actual_dests,
+            "expected dest <%s> missing from actual set: %s" % (expected, actual_dests),
+        )
 
     # Simple equality checks for the others, if specified
     if ctx.attr.expected_attributes:

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -257,6 +257,33 @@ def _test_pkg_files_contents():
         target_under_test = ":pf_strip_prefix_from_root_invalid_g",
     )
 
+    # Test include_runfiles.
+    pkg_files(
+        name = "pf_include_runfiles_g",
+        include_runfiles = True,
+        srcs = ["//tests:an_executable"],
+        tags = ["manual"],
+    )
+
+    pkg_files_contents_test(
+        name = "pf_include_runfiles",
+        target_under_test = ":pf_include_runfiles_g",
+        expected_dests = select(
+            {
+                "@bazel_tools//src/conditions:windows": [
+                    "an_executable.exe",
+                    "an_executable.exe.runfiles/_main/tests/foo.cc",
+                    "an_executable.exe.runfiles/_main/tests/testdata/hello.txt",
+                ],
+                "//conditions:default": [
+                    "an_executable",
+                    "an_executable.runfiles/_main/tests/foo.cc",
+                    "an_executable.runfiles/_main/tests/testdata/hello.txt",
+                ],
+            },
+        ),
+    )
+
 def _test_pkg_files_exclusions():
     # Normal filegroup, used in all of the below tests
     #


### PR DESCRIPTION
This is a follow-up to #856, which applies to most rules but `pkg_files` uses a different code path. This change applies the fix to `pkg_files` and adds a test to avoid future regressions.

It also fixes a (silent) bug in the test logic.