### PR TITLE
Add AlmaLinux 9.3 debuginfo support

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -375,10 +375,10 @@ class RpmBuilder(object):
       '--define', '_builddir %s/BUILD' % dirname,
     ]
 
-    if debuginfo_type in ["fedora40", "centos7", "centos9"]:
+    if debuginfo_type in ["fedora40", "centos7", "centos9", "almalinux9.3"]:
       args += ['--undefine', '_debugsource_packages']
 
-    if debuginfo_type in ["centos7", "centos9"]:
+    if debuginfo_type in ["centos7", "centos9", "almalinux9.3"]:
       args += ['--define', 'buildsubdir .']
 
     if debuginfo_type == "fedora40":

--- a/toolchains/rpm/rpmbuild_configure.bzl
+++ b/toolchains/rpm/rpmbuild_configure.bzl
@@ -57,19 +57,19 @@ def _parse_release_info(release_info):
 
     return os_name, os_version
 
+KNOWN_DEBUGINFO_VERSIONS = {
+    "almalinux": ["9.3"],
+    "centos": ["7", "9"],
+    "fedora": ["40"],
+}
+
 def _build_repo_for_rpmbuild_toolchain_impl(rctx):
     debuginfo_type = "none"
     if rctx.path(RELEASE_PATH).exists:
         os_name, os_version = _parse_release_info(rctx.read(RELEASE_PATH))
-
-        if os_name == "centos":
-            if os_version == "7":
-                debuginfo_type = "centos7"
-            elif os_version == "9":
-                debuginfo_type = "centos9"
-
-        if os_name == "fedora" and os_version == "40":
-            debuginfo_type = "fedora40"
+        if (os_name in KNOWN_DEBUGINFO_VERSIONS and
+            os_version in KNOWN_DEBUGINFO_VERSIONS[os_name]):
+            debuginfo_type = os_name + os_version
 
     rpmbuild_path = rctx.which("rpmbuild")
     if rctx.attr.verbose:


### PR DESCRIPTION
AlmaLinux 9.3 appears to behave as a CentOS variant so adding it in the same places.  This change also cleans up the way we declare debuginfo_type to make it a bit less verbose.