### PR TITLE
Add support for repo mapping

### DIFF
--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -29,6 +29,7 @@ here.
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//pkg:providers.bzl", "PackageDirsInfo", "PackageFilegroupInfo", "PackageFilesInfo", "PackageSymlinkInfo")
+load("//pkg/private:util.bzl", "get_repo_mapping_manifest")
 
 # TODO(#333): strip_prefix module functions should produce unique outputs.  In
 # particular, this one and `_sp_from_pkg` can overlap.
@@ -311,12 +312,10 @@ def _pkg_files_impl(ctx):
                     else:
                         src_dest_paths_map[rf] = dest_path
 
-                if (
-                    getattr(target[DefaultInfo], "files_to_run") and
-                    hasattr(target[DefaultInfo].files_to_run, "repo_mapping_manifest") and
-                    target[DefaultInfo].files_to_run.repo_mapping_manifest != None
-                ):
-                    repo_mapping_manifest = target[DefaultInfo].files_to_run.repo_mapping_manifest
+                # if repo_mapping manifest exists (for e.g. with --enable_bzlmod),
+                # create _repo_mapping under runfiles directory
+                repo_mapping_manifest = get_repo_mapping_manifest(target)
+                if repo_mapping_manifest:
                     dest_path = paths.join(src_dest_paths_map[src] + ".runfiles", "_repo_mapping")
                     src_dest_paths_map[repo_mapping_manifest] = dest_path
 

--- a/pkg/mappings.bzl
+++ b/pkg/mappings.bzl
@@ -311,6 +311,15 @@ def _pkg_files_impl(ctx):
                     else:
                         src_dest_paths_map[rf] = dest_path
 
+                if (
+                    getattr(target[DefaultInfo], "files_to_run") and
+                    hasattr(target[DefaultInfo].files_to_run, "repo_mapping_manifest") and
+                    target[DefaultInfo].files_to_run.repo_mapping_manifest != None
+                ):
+                    repo_mapping_manifest = target[DefaultInfo].files_to_run.repo_mapping_manifest
+                    dest_path = paths.join(src_dest_paths_map[src] + ".runfiles", "_repo_mapping")
+                    src_dest_paths_map[repo_mapping_manifest] = dest_path
+
     # At this point, we have a fully valid src -> dest mapping in src_dest_paths_map.
     #
     # Construct the inverse of this mapping to pass to the output providers, and

--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -122,5 +122,7 @@ def get_repo_mapping_manifest(src):
     """
     files_to_run_provider = get_files_to_run_provider(src)
     if files_to_run_provider:
+        # repo_mapping_manifest may not exist in older Bazel versions (<7.0.0)
+        # https://github.com/bazelbuild/bazel/issues/19937
         return getattr(files_to_run_provider, "repo_mapping_manifest")
     return None

--- a/pkg/private/util.bzl
+++ b/pkg/private/util.bzl
@@ -93,3 +93,34 @@ def substitute_package_variables(ctx, attribute_value):
         attribute_value = attribute_value.replace(")", "}", 1)
 
     return attribute_value.format(**vars)
+
+def get_files_to_run_provider(src):
+    """Safely retrieve FilesToRunProvider from a target.
+
+    Args:
+        src: target to get FilesToRunProvider from
+
+    Returns:
+        FilesToRunProvider or None: FilesToRunProvider if found in target
+            provider, otherwise None
+    """
+    if not DefaultInfo in src:
+        return None
+    di = src[DefaultInfo]
+    if not hasattr(di, "files_to_run"):
+        return None
+    return di.files_to_run
+
+def get_repo_mapping_manifest(src):
+    """Safely retrieve repo_mapping_manifest from a target if it exists.
+
+    Args:
+        src: target to get repo_mapping_manifest from
+
+    Returns:
+        File or None: repo_mapping_manifest
+    """
+    files_to_run_provider = get_files_to_run_provider(src)
+    if files_to_run_provider:
+        return getattr(files_to_run_provider, "repo_mapping_manifest")
+    return None

--- a/tests/mappings/executable.manifest.golden
+++ b/tests/mappings/executable.manifest.golden
@@ -1,7 +1,9 @@
 [
-{"dest":"an_executable.runfiles/_main/tests/foo.cc","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/foo.cc","type":"file","uid":null,"user":null},
 {"dest":"an_executable.runfiles/_main/tests/an_executable","gid":null,"group":null,"mode":"0755","origin":"@//tests:an_executable","src":"tests/an_executable","type":"file","uid":null,"user":null},
+{"dest":"an_executable.runfiles/_main/tests/foo.cc","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/foo.cc","type":"file","uid":null,"user":null},
 {"dest":"an_executable.runfiles/_main/tests/testdata/hello.txt","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/testdata/hello.txt","type":"file","uid":null,"user":null},
 {"dest":"an_executable","gid":null,"group":null,"mode":"0755","origin":"@//tests:an_executable","src":"tests/an_executable","type":"file","uid":null,"user":null},
+{"dest":"an_executable.repo_mapping","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/an_executable.repo_mapping","type":"file","uid":null,"user":null},
+{"dest":"an_executable.runfiles/_repo_mapping","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/an_executable.repo_mapping","type":"file","uid":null,"user":null},
 {"dest":"mappings_test.bzl","gid":null,"group":null,"mode":"","origin":"@//tests/mappings:mappings_test.bzl","src":"tests/mappings/mappings_test.bzl","type":"file","uid":null,"user":null}
 ]

--- a/tests/mappings/executable.manifest.windows.golden
+++ b/tests/mappings/executable.manifest.windows.golden
@@ -3,5 +3,7 @@
 {"dest":"an_executable.exe.runfiles/_main/tests/an_executable.exe","gid":null,"group":null,"mode":"0755","origin":"@//tests:an_executable","src":"tests/an_executable.exe","type":"file","uid":null,"user":null},
 {"dest":"an_executable.exe.runfiles/_main/tests/testdata/hello.txt","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src":"tests/testdata/hello.txt","type":"file","uid":null,"user":null},
 {"dest":"an_executable.exe","gid":null,"group":null,"mode":"0755","origin":"@//tests:an_executable","src":"tests/an_executable.exe","type":"file","uid":null,"user":null},
+{"dest":"an_executable.exe.repo_mapping","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src": "tests/an_executable.exe.repo_mapping","type": "file","uid":null,"user":null},
+{"dest":"an_executable.exe.runfiles/_repo_mapping","gid":null,"group":null,"mode":"","origin":"@//tests:an_executable","src": "tests/an_executable.exe.repo_mapping","type": "file","uid":null,"user":null},
 {"dest":"mappings_test.bzl","gid":null,"group":null,"mode":"","origin":"@//tests/mappings:mappings_test.bzl","src":"tests/mappings/mappings_test.bzl","type":"file","uid":null,"user":null}
 ]

--- a/tests/mappings/mappings_test.bzl
+++ b/tests/mappings/mappings_test.bzl
@@ -272,11 +272,13 @@ def _test_pkg_files_contents():
             {
                 "@bazel_tools//src/conditions:windows": [
                     "an_executable.exe",
+                    "an_executable.exe.runfiles/_repo_mapping",
                     "an_executable.exe.runfiles/_main/tests/foo.cc",
                     "an_executable.exe.runfiles/_main/tests/testdata/hello.txt",
                 ],
                 "//conditions:default": [
                     "an_executable",
+                    "an_executable.runfiles/_repo_mapping",
                     "an_executable.runfiles/_main/tests/foo.cc",
                     "an_executable.runfiles/_main/tests/testdata/hello.txt",
                 ],


### PR DESCRIPTION
## Context

When a binary is packaged with `pkg_*` rules, the repo_mapping manifest file is not included in the archive. For example

```starlark
java_binary(
    name = "example",
    main_class = "...",
)

pkg_tar(
    name = "example_tar",
    srcs = [":example"],
    include_runfiles = True,
)
```

The above generates an archive that does not have `_repo_mapping` under runfiles directory even when bzlmod is enabled, and therefore runfiles libraries are not able to convert apparent repo names into canonical repo names.

## Changes

Patch `rules_pkg` such that when

1. bzlmod is enabled, and
1. `include_runfiles = True`

it copies the repo mapping manifest into the archive at the correct location

i.e.

```
example
example.repo_mapping
example.runfiles/
├─ _repo_mapping
```

Closes #769