### PR TITLE
pkg_install: Support TreeArtifacts.

### DIFF
--- a/pkg/private/install.py.tpl
+++ b/pkg/private/install.py.tpl
@@ -74,11 +74,11 @@ class NativeInstaller(object):
                 logging.info("CHOWN %s:%s %s", user, group, dest)
                 shutil.chown(dest, user, group)
 
-    def _do_file_copy(self, src, dest, mode, user, group):
+    def _do_file_copy(self, src, dest):
         logging.info("COPY %s <- %s", dest, src)
         shutil.copyfile(src, dest)
 
-    def _do_mkdir(self, dirname, mode, user, group):
+    def _do_mkdir(self, dirname, mode):
         logging.info("MKDIR %s %s", mode, dirname)
         os.makedirs(dirname, int(mode, 8), exist_ok=True)
 
@@ -93,12 +93,12 @@ class NativeInstaller(object):
 
     def _install_file(self, entry):
         self._maybe_make_unowned_dir(os.path.dirname(entry.dest))
-        self._do_file_copy(entry.src, entry.dest, entry.mode, entry.user, entry.group)
+        self._do_file_copy(entry.src, entry.dest)
         self._chown_chmod(entry.dest, entry.mode, entry.user, entry.group)
 
     def _install_directory(self, entry):
         self._maybe_make_unowned_dir(os.path.dirname(entry.dest))
-        self._do_mkdir(entry.dest, entry.mode, entry.user, entry.group)
+        self._do_mkdir(entry.dest, entry.mode)
         self._chown_chmod(entry.dest, entry.mode, entry.user, entry.group)
 
     def _install_treeartifact(self, entry):

--- a/pkg/private/install.py.tpl
+++ b/pkg/private/install.py.tpl
@@ -101,17 +101,48 @@ class NativeInstaller(object):
         self._do_mkdir(entry.dest, entry.mode)
         self._chown_chmod(entry.dest, entry.mode, entry.user, entry.group)
 
+    def _install_treeartifact_file(self, entry, src, dst):
+        self._do_file_copy(src, dst)
+        self._chown_chmod(dst, entry.mode, entry.user, entry.group)
+
     def _install_treeartifact(self, entry):
         logging.info("COPYTREE %s <- %s/**", entry.dest, entry.src)
-        raise NotImplementedError("treeartifact installation not yet supported")
-        for root, dirs, files in os.walk(entry.src):
-            relative_installdir = os.path.join(entry.dest, root)
-            for d in dirs:
-                self._maybe_make_unowned_dir(os.path.join(relative_installdir, d))
+        shutil.copytree(
+            src=entry.src,
+            dst=entry.dest,
+            copy_function=lambda s, d:
+                self._install_treeartifact_file(entry, s, d),
+            dirs_exist_ok=True,
+            # Bazel gives us a directory of symlinks, so we dereference it.
+            # TODO: Handle symlinks within the TreeArtifact. This is not yet
+            # tested for other rules (e.g.
+            # https://github.com/bazelbuild/rules_pkg/issues/750)
+            symlinks=False,
+            ignore_dangling_symlinks=True,
+        )
 
-            logging.info("COPY_FROM_TREE %s <- %s", entry.dest, entry.src)
-            logging.info("CHMOD %s %s", entry.mode, entry.dest)
-            logging.info("CHOWN %s:%s %s", entry.user, entry.group, entry.dest)
+        # Set mode/user/group for intermediate directories.
+        # Bazel has no API to specify modes for this, so the least surprising
+        # thing we can do is make it the canonical rwxr-xr-x
+        intermediate_dir_mode = "755"
+        for root, dirs, _ in os.walk(entry.src, topdown=False):
+            relative_installdir = os.path.join(entry.dest,
+                                               os.path.relpath(root, entry.src))
+            for d in dirs:
+                self._chown_chmod(os.path.join(relative_installdir, d),
+                                  intermediate_dir_mode,
+                                  entry.user, entry.group)
+
+        # For top-level directory, use entry.mode +r +x if specified, otherwise
+        # use least-surprising canonical rwxr-xr-x
+        top_dir_mode = entry.mode
+        if top_dir_mode:
+            top_dir_mode = int(top_dir_mode, 8)
+            top_dir_mode |= 0o555
+            top_dir_mode = oct(top_dir_mode).removeprefix("0o")
+        else:
+            top_dir_mode = "755"
+        self._chown_chmod(entry.dest, top_dir_mode, entry.user, entry.group)
 
     def _install_symlink(self, entry):
         raise NotImplementedError("symlinking not yet supported")

--- a/tests/install/BUILD
+++ b/tests/install/BUILD
@@ -93,4 +93,7 @@ directory(
 pkg_files(
     name = "generate_tree_pkg_files",
     srcs = [":generate_tree"],
+    attributes = pkg_attributes(
+        mode = "640",
+    ),
 )

--- a/tests/install/BUILD
+++ b/tests/install/BUILD
@@ -15,7 +15,7 @@
 load("@rules_python//python:defs.bzl", "py_test")
 load("//pkg:install.bzl", "pkg_install")
 load("//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "pkg_mkdirs")
-load("//tests/util:defs.bzl", "fake_artifact")
+load("//tests/util:defs.bzl", "directory", "fake_artifact")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -47,6 +47,7 @@ pkg_install(
         ":artifact-in-owned-dir",
         ":artifact-in-unowned-dir",
         ":dirs",
+        ":generate_tree_pkg_files",
     ],
 )
 
@@ -74,4 +75,22 @@ pkg_mkdirs(
         "empty-owned-dir",
         "owned-dir",
     ],
+)
+
+directory(
+    name = "generate_tree",
+    contents = "hello there",
+    filenames = [
+        # buildifier: don't sort
+        "b/e",
+        "a/a",
+        "b/c/d",
+        "b/d",
+        "a/b/c",
+    ],
+)
+
+pkg_files(
+    name = "generate_tree_pkg_files",
+    srcs = [":generate_tree"],
 )


### PR DESCRIPTION
Implementation notes:
For tree artifacts, when creating directories, we mostly follow the modes set for the whole TreeArtifact, but also +x to allow searching the directory. This is similar to how pkg_tar etc. handles things.

Link: https://github.com/bazelbuild/rules_pkg/issues/308