### PR TITLE
Speed up tar packing by lower compresslevel and create symbolic links for same files

### DIFF
--- a/pkg/private/tar/tar_writer.py
+++ b/pkg/private/tar/tar_writer.py
@@ -49,7 +49,8 @@ class TarFileWriter(object):
                create_parents=False,
                allow_dups_from_deps=True,
                default_mtime=None,
-               preserve_tar_mtimes=True):
+               preserve_tar_mtimes=True,
+               compresslevel=None):
     """TarFileWriter wraps tarfile.open().
 
     Args:
@@ -86,10 +87,11 @@ class TarFileWriter(object):
     else:
       mode = 'w:'
       if compression in ['tgz', 'gz']:
+        compresslevel = int(compresslevel) if compresslevel or compresslevel == 0 else 6
         # The Tarfile class doesn't allow us to specify gzip's mtime attribute.
         # Instead, we manually reimplement gzopen from tarfile.py and set mtime.
         self.fileobj = gzip.GzipFile(
-            filename=name, mode='w', compresslevel=6, mtime=self.default_mtime)
+            filename=name, mode='w', compresslevel=compresslevel, mtime=self.default_mtime)
     self.compressor_proc = None
     if self.compressor_cmd:
       mode = 'w|'

--- a/pkg/tar.bzl
+++ b/pkg/tar.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Forwarder for pkg_tar."""
 
-load("//pkg/private/tar:tar.bzl", _pkg_tar = "pkg_tar")
+load("//pkg/private/tar:tar.bzl", _pkg_tar = "pkg_tar", _pkg_tar_group = "pkg_tar_group")
 
 pkg_tar = _pkg_tar
+pkg_tar_group = _pkg_tar_group


### PR DESCRIPTION
## What's the problem

The current tar packaging process is not efficient enough, as evidenced by:
- The default gzip compression level "6" can take 200% more time than compression level "1", but the size is only reduced by 10%-20%.
 - For tar packages that reach gigabyte levels and are only transmitted and used within an organization’s intranet, packing speed might be more critical than size.
- If other tar packages are relied upon, the respective tar package must be created and then decompressed, causing a single file to possibly be compressed multiple times.
- If multiple srcs and deps projects' runfiles directories reference the same file, i.e., in the case of diamond dependencies, `add_file` will create N identical copies, significantly increasing the package size and time.

## How to solve

1. add `compresslevel: str` which can be `"" (auto, 6) | "0" | "1" | ... | "9"`
2. provide `MappingManifestInfo` besides `DefaultInfo` to expose `manifest_file` and `package_dir` info to downstream targets
- add `merge_mappings: bool` to enable this behavior manually
3. add `auto_deduplicate: bool` to identify added files across all manifest files by content paths and realpaths, and then auto-create symbolic links