### PR TITLE
Make compresslevel configurable for .tar.gz

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -114,6 +114,8 @@ def _pkg_tar_impl(ctx):
                 "--owner_names",
                 "%s=%s" % (_quote(key), ctx.attr.ownernames[key]),
             )
+    if ctx.attr.compression_level:
+        args.add("--compression_level", ctx.attr.compression_level)
 
     # Now we begin processing the files.
     path_mapper = None
@@ -272,6 +274,10 @@ pkg_tar_impl = rule(
         ),
         "create_parents": attr.bool(default = True),
         "allow_duplicates_from_deps": attr.bool(default = False),
+        "compression_level": attr.int(
+            doc = """Specify the numeric compression level in gzip mode; may be 0-9 or -1 (default to 6).""",
+            default = -1,
+        ),
 
         # Common attributes
         "out": attr.output(mandatory = True),

--- a/pkg/private/tar/tar_writer.py
+++ b/pkg/private/tar/tar_writer.py
@@ -49,7 +49,8 @@ class TarFileWriter(object):
                create_parents=False,
                allow_dups_from_deps=True,
                default_mtime=None,
-               preserve_tar_mtimes=True):
+               preserve_tar_mtimes=True,
+               compression_level=-1):
     """TarFileWriter wraps tarfile.open().
 
     Args:
@@ -86,10 +87,11 @@ class TarFileWriter(object):
     else:
       mode = 'w:'
       if compression in ['tgz', 'gz']:
+        compression_level = min(compression_level, 9) if compression_level >= 0 else 6
         # The Tarfile class doesn't allow us to specify gzip's mtime attribute.
         # Instead, we manually reimplement gzopen from tarfile.py and set mtime.
         self.fileobj = gzip.GzipFile(
-            filename=name, mode='w', compresslevel=6, mtime=self.default_mtime)
+            filename=name, mode='w', compresslevel=compression_level, mtime=self.default_mtime)
     self.compressor_proc = None
     if self.compressor_cmd:
       mode = 'w|'

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -477,6 +477,10 @@ py_test(
         ":test-tar-strip_prefix-substring.tar",
         ":test-tar-tree-artifact",
         ":test-tar-tree-artifact-noroot",
+        ":test-tar-compression_level--1",
+        ":test-tar-compression_level-3",
+        ":test-tar-compression_level-6",
+        ":test-tar-compression_level-9",
         ":test-tree-input-with-strip-prefix",
         ":test_tar_leading_dotslash",
         ":test_tar_package_dir_substitution.tar",
@@ -756,3 +760,12 @@ verify_archive_test(
     ],
     target = ":program_with_dir_runfiles_tar",
 )
+
+[pkg_tar(
+    name = "test-tar-compression_level-%s" % compression_level,
+    compression_level = compression_level,
+    deps = [
+        "//tests:testdata/tar_test.tar",
+    ],
+    extension = "tgz",
+) for compression_level in [-1, 3, 6, 9]]

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Testing for pkg_tar."""
 
+import os
 import tarfile
 import unittest
 
@@ -293,6 +294,17 @@ class PkgTarTest(unittest.TestCase):
     ]
     self.assertTarFileContent('test-respect-externally-defined-duplicates.tar', content)
 
+  def test_compression_level(self):
+    sizes = [
+      ('test-tar-compression_level--1.tgz', 179),
+      ('test-tar-compression_level-3.tgz', 230),
+      ('test-tar-compression_level-6.tgz', 178),
+      ('test-tar-compression_level-9.tgz', 167),
+    ]
+    for file_name, expected_size in sizes:
+      file_path = runfiles.Create().Rlocation('rules_pkg/tests/tar/' + file_name)
+      file_size = os.stat(file_path).st_size
+      self.assertEqual(file_size, expected_size, 'size error for ' + file_name)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
## What's the problem

The current tar packaging process is not efficient enough, as evidenced by:
- The default gzip compression level "6" can take 200% more time than compression level "1", but the size is only reduced by 10%-20%.
 - For tar packages that reach gigabyte levels and are only transmitted and used within an organization’s intranet, packing speed might be more critical than size.

## How to solve

Add `compresslevel: str` which can be `"" (auto, 6) | "0" | "1" | ... | "9"` (this is extracted from #887).
