### PR TITLE
Fix an unexpected "index out of range"

### DIFF
--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -429,7 +429,7 @@ def add_from_default_info(
 
     if include_runfiles:
         runfiles = src[DefaultInfo].default_runfiles
-        if runfiles:
+        if runfiles and runfiles.files:
             mapping_context.file_deps.append(runfiles.files)
 
             # Computing the runfiles root is subtle. It should be based off of


### PR DESCRIPTION
A bazel target may include "empty" dependencies. For example, a `cc_library` target may be `C/C++ header`-only or `linkopts`-only, so it generates neither `[DefaultInfo].files` nor `di.files_to_run`. Then the below `base_file = ...` in `add_from_default_info` will raise.