### PR TITLE
`tar_writer.py`: address duplicate dir warning regression

### DIFF
--- a/pkg/private/tar/tar_writer.py
+++ b/pkg/private/tar/tar_writer.py
@@ -129,7 +129,7 @@ class TarFileWriter(object):
       # Enforce the ending / for directories so we correctly deduplicate.
       if not info.name.endswith('/'):
         info.name += '/'
-    if not self.allow_dups_from_deps and self._have_added(info.name):
+    elif not self.allow_dups_from_deps and self._have_added(info.name):
         print('Duplicate file in archive: %s, '
               'picking first occurrence' % info.name)
         return


### PR DESCRIPTION
It looks like #850 removed the check below, resulting in warning being printed on duplicate _directories_ in addition to files:
https://github.com/bazelbuild/rules_pkg/pull/850/files#diff-9a83a2a408d04cf1937eb6d1eac00438774072bfe46a19082c7f8729d3ac4a27L133-L135

Fixes #899 