### PR TITLE
Delete deb_packages directory

### DIFF
--- a/deb_packages/README.md
+++ b/deb_packages/README.md
@@ -1,5 +1,0 @@
-# This module is deprecated
-
-The work here has forked to two other places.  Please look at both to see which is better maintained and meets your needs best.
-- https://github.com/mariusgrigoriu/rules_dpkg
-- https://github.com/aisbaa/deb_packages


### PR DESCRIPTION
The notice in this folder is misleading since `rules_pkg` now has better maintained `.deb` rules than the two suggested alternatives