### PR TITLE
Modify the rich_structure example to set include_runfiles

### DIFF
--- a/examples/rich_structure/src/client/BUILD
+++ b/examples/rich_structure/src/client/BUILD
@@ -58,8 +58,7 @@ pkg_files(
     ],
     # Where it should be in the final package
     prefix = select(shared_object_path_selector) + "/bin",
-    # Should this work?
-    # runfiles_prefix = select(shared_object_path_selector) + "/bin/runfiles",
+    include_runfiles = True,
 )
 
 pkg_files(

--- a/examples/rich_structure/src/client/BUILD
+++ b/examples/rich_structure/src/client/BUILD
@@ -56,9 +56,9 @@ pkg_files(
         ":foo",
         ":fooctl",
     ],
+    include_runfiles = True,
     # Where it should be in the final package
     prefix = select(shared_object_path_selector) + "/bin",
-    include_runfiles = True,
 )
 
 pkg_files(


### PR DESCRIPTION
Without this, the runfiles will not be packaged which is against the intent of this example which is to show how to package runfiles.