### PR TITLE
ci: Bump Ubuntu version in CI from 18 to 22

### DIFF
--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -7,8 +7,8 @@ tasks:
   centos7:
     platform: centos7_java11_devtoolset10
     <<: *common
-  ubuntu1804:
-    platform: ubuntu1804
+  ubuntu2204:
+    platform: ubuntu2204
     <<: *common
   macos:
     platform: macos
@@ -18,7 +18,7 @@ tasks:
     <<: *common
   bzlmod:
     name: bzlmod
-    platform: ubuntu1804
+    platform: ubuntu2204
     build_flags:
       - "--enable_bzlmod"
     <<: *common

--- a/.bazelci/examples_rich_structure.yml
+++ b/.bazelci/examples_rich_structure.yml
@@ -7,8 +7,8 @@ tasks:
   centos7:
     platform: centos7_java11_devtoolset10
     <<: *common
-  ubuntu1804:
-    platform: ubuntu1804
+  ubuntu2204:
+    platform: ubuntu2204
     <<: *common
   macos:
     <<: *common

--- a/.bazelci/examples_stamping.yml
+++ b/.bazelci/examples_stamping.yml
@@ -7,8 +7,8 @@ tasks:
   centos7:
     platform: centos7_java11_devtoolset10
     <<: *common
-  ubuntu1804:
-    platform: ubuntu1804
+  ubuntu2204:
+    platform: ubuntu2204
     <<: *common
   macos:
     <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -62,9 +62,9 @@ win_tests: &win_tests
 
 #
 # Commmon features and tests by platform
-# 
-ubuntu1804: &ubuntu
-  platform: ubuntu1804
+#
+ubuntu2204: &ubuntu
+  platform: ubuntu2204
   <<: *common
   <<: *default_tests
 

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -11,7 +11,7 @@ platforms:
     build_targets: *build_targets
   macos:
     build_targets: *build_targets
-  ubuntu2004:
+  ubuntu2204:
     build_targets: *build_targets
   windows:
     build_targets: *build_targets


### PR DESCRIPTION
Follow up PR of https://github.com/bazelbuild/rules_pkg/pull/911. Ubuntu 18.04 is EOL already, 20.04 will be soon, hence bumping to 22.04.