### PR TITLE
Pre commit autoupdate and format files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 repos:
     # Check formatting and lint for starlark code
     - repo: https://github.com/keith/pre-commit-buildifier
-      rev: 6.3.3
+      rev: 8.0.0
       hooks:
           - id: buildifier
           - id: buildifier-lint

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -21,6 +21,7 @@ experimental_find_system_git_bzlmod(
     name = "rules_pkg_git",
     verbose = False,
 )
+
 register_toolchains(
     "@rules_pkg_git//:git_auto_toolchain",
     "//toolchains/git:git_missing_toolchain",

--- a/examples/rpm/debuginfo/BUILD
+++ b/examples/rpm/debuginfo/BUILD
@@ -13,16 +13,15 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 
-
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm")
 
 cc_binary(
     name = "test",
-    copts = ["-g"],
     srcs = [
         "test.c",
     ],
+    copts = ["-g"],
 )
 
 pkg_files(
@@ -37,12 +36,12 @@ pkg_rpm(
     srcs = [
         ":rpm_files",
     ],
-    release = "0",
-    version = "1",
-    license = "Some license",
-    summary = "Summary",
-    description = "Description",
     debuginfo = True,
+    description = "Description",
+    license = "Some license",
+    release = "0",
+    summary = "Summary",
+    version = "1",
 )
 
 # If you have rpmbuild, you probably have rpm2cpio too.

--- a/examples/rpm/debuginfo/MODULE.bazel
+++ b/examples/rpm/debuginfo/MODULE.bazel
@@ -15,7 +15,6 @@
 module(name = "rules_pkg_example_rpm_system_rpmbuild_bzlmod")
 
 bazel_dep(name = "rules_pkg")
-
 local_path_override(
     module_name = "rules_pkg",
     path = "../../..",

--- a/examples/rpm/nospecfile/BUILD
+++ b/examples/rpm/nospecfile/BUILD
@@ -30,18 +30,18 @@ pkg_rpm(
     srcs = [
         ":rpm_files",
     ],
-    release = "0",
-    version = "1",
-    summary = "rules_pkg example RPM",
+    architecture = "x86_64",
     description = "This is a package description.",
     license = "Apache License, v2.0",
-    architecture = "x86_64",
-    requires = [
-        "somerpm",
-    ],
     provides = [
         "somefile",
     ],
+    release = "0",
+    requires = [
+        "somerpm",
+    ],
+    summary = "rules_pkg example RPM",
+    version = "1",
 )
 
 # If you have rpmbuild, you probably have rpm2cpio too.

--- a/examples/rpm/nospecfile/MODULE.bazel
+++ b/examples/rpm/nospecfile/MODULE.bazel
@@ -15,7 +15,6 @@
 module(name = "rules_pkg_example_rpm_system_rpmbuild_bzlmod")
 
 bazel_dep(name = "rules_pkg")
-
 local_path_override(
     module_name = "rules_pkg",
     path = "../../..",

--- a/examples/rpm/prebuilt_rpmbuild/BUILD
+++ b/examples/rpm/prebuilt_rpmbuild/BUILD
@@ -19,8 +19,8 @@ pkg_rpm(
     name = "test-rpm",
     data = [
         "BUILD",
-        "WORKSPACE",
         "README.md",
+        "WORKSPACE",
         "test_rpm.spec",
     ],
     release = "0",

--- a/examples/rpm/subrpm/BUILD
+++ b/examples/rpm/subrpm/BUILD
@@ -14,7 +14,7 @@
 # -*- coding: utf-8 -*-
 
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
-load("@rules_pkg//pkg:rpm.bzl", "pkg_sub_rpm", "pkg_rpm")
+load("@rules_pkg//pkg:rpm.bzl", "pkg_rpm", "pkg_sub_rpm")
 
 pkg_files(
     name = "subrpm_files",
@@ -26,17 +26,17 @@ pkg_files(
 pkg_sub_rpm(
     name = "subrpm",
     package_name = "subrpm",
-    summary = "Test subrpm",
-    description = "Test subrpm description",
-    requires = [
-        "somerpm",
-    ],
-    provides = [
-        "someprovision",
-    ],
     srcs = [
         ":subrpm_files",
     ],
+    description = "Test subrpm description",
+    provides = [
+        "someprovision",
+    ],
+    requires = [
+        "somerpm",
+    ],
+    summary = "Test subrpm",
 )
 
 pkg_files(
@@ -52,21 +52,21 @@ pkg_rpm(
     srcs = [
         ":rpm_files",
     ],
-    release = "0",
-    version = "1",
-    summary = "rules_pkg example RPM",
+    architecture = "x86_64",
     description = "This is a package description.",
     license = "Apache License, v2.0",
-    architecture = "x86_64",
-    requires = [
-        "somerpm",
-    ],
     provides = [
         "somefile",
+    ],
+    release = "0",
+    requires = [
+        "somerpm",
     ],
     subrpms = [
         ":subrpm",
     ],
+    summary = "rules_pkg example RPM",
+    version = "1",
 )
 
 # If you have rpmbuild, you probably have rpm2cpio too.

--- a/examples/rpm/subrpm/MODULE.bazel
+++ b/examples/rpm/subrpm/MODULE.bazel
@@ -15,7 +15,6 @@
 module(name = "rules_pkg_example_rpm_system_rpmbuild_bzlmod")
 
 bazel_dep(name = "rules_pkg")
-
 local_path_override(
     module_name = "rules_pkg",
     path = "../../..",

--- a/examples/rpm/system_rpmbuild/BUILD
+++ b/examples/rpm/system_rpmbuild/BUILD
@@ -19,8 +19,8 @@ pkg_rpm(
     name = "test-rpm",
     data = [
         "BUILD",
-        "WORKSPACE",
         "README.md",
+        "WORKSPACE",
         "test_rpm.spec",
     ],
     release = "0",

--- a/examples/rpm/system_rpmbuild/WORKSPACE
+++ b/examples/rpm/system_rpmbuild/WORKSPACE
@@ -28,4 +28,4 @@ load(
     "find_system_rpmbuild",
 )
 
-find_system_rpmbuild(name="my_rpmbuild")
+find_system_rpmbuild(name = "my_rpmbuild")

--- a/examples/rpm/system_rpmbuild_bzlmod/MODULE.bazel
+++ b/examples/rpm/system_rpmbuild_bzlmod/MODULE.bazel
@@ -15,7 +15,6 @@
 module(name = "rules_pkg_example_rpm_system_rpmbuild_bzlmod")
 
 bazel_dep(name = "rules_pkg")
-
 local_path_override(
     module_name = "rules_pkg",
     path = "../../..",

--- a/mappings.bzl
+++ b/mappings.bzl
@@ -14,6 +14,7 @@
 
 load(
     "//pkg:mappings.bzl",
+    _REMOVE_BASE_DIRECTORY = "REMOVE_BASE_DIRECTORY",
     _filter_directory = "filter_directory",
     _pkg_attributes = "pkg_attributes",
     _pkg_filegroup = "pkg_filegroup",
@@ -21,7 +22,6 @@ load(
     _pkg_mkdirs = "pkg_mkdirs",
     _pkg_mklink = "pkg_mklink",
     _strip_prefix = "strip_prefix",
-    _REMOVE_BASE_DIRECTORY = "REMOVE_BASE_DIRECTORY",
 )
 
 REMOVE_BASE_DIRECTORY = _REMOVE_BASE_DIRECTORY

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -259,8 +259,8 @@ pkg_tar_impl = rule(
         "symlinks": attr.string_dict(),
         "empty_files": attr.string_list(),
         "include_runfiles": attr.bool(
-            doc = ("""Include runfiles for executables. These appear as they would in bazel-bin."""
-                   + """For example: 'path/to/myprog.runfiles/path/to/my_data.txt'."""),
+            doc = ("""Include runfiles for executables. These appear as they would in bazel-bin.""" +
+                   """For example: 'path/to/myprog.runfiles/path/to/my_data.txt'."""),
         ),
         "empty_dirs": attr.string_list(),
         "remap_paths": attr.string_dict(),

--- a/pkg/rpm.bzl
+++ b/pkg/rpm.bzl
@@ -66,7 +66,7 @@ def pkg_rpm(name, srcs = None, spec_file = None, subrpms = None, **kwargs):
         pkg_rpm_pfg(
             name = name,
             srcs = srcs,
-	    subrpms = subrpms,
+            subrpms = subrpms,
             **kwargs
         )
     elif spec_file:

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -175,7 +175,7 @@ def _make_absolute_if_not_already_or_is_macro(path):
     # this can be inlined easily.
     return path if path.startswith(("/", "%")) else "/" + path
 
-def _make_rpm_filename(rpm_name, version, architecture, package_name=None, release=None):
+def _make_rpm_filename(rpm_name, version, architecture, package_name = None, release = None):
     prefix = "%s-%s"
     items = [rpm_name, version]
 
@@ -185,7 +185,7 @@ def _make_rpm_filename(rpm_name, version, architecture, package_name=None, relea
 
     if release:
         prefix += "-%s"
-        items += [release]
+        items.append(release)
 
     fmt = prefix + ".%s.rpm"
 
@@ -315,7 +315,7 @@ def _process_dep(dep, rpm_ctx, debuginfo_type):
                 dep.label,
                 file_base,
                 rpm_ctx,
-                debuginfo_type
+                debuginfo_type,
             )
         for entry, origin in pfg_info.pkg_dirs:
             file_base = _make_filetags(entry.attributes, "%dir")
@@ -351,25 +351,25 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx, debuginfo_type):
     ]
 
     if rpm_info.architecture:
-        rpm_lines += ["BuildArch: %s" % rpm_info.architecture]
+        rpm_lines.append("BuildArch: %s" % rpm_info.architecture)
 
     if rpm_info.epoch:
-        rpm_lines += ["Epoch: %s" % rpm_info.epoch]
+        rpm_lines.append("Epoch: %s" % rpm_info.epoch)
 
     if rpm_info.version:
-        rpm_lines += ["Version: %s" % rpm_info.version]
+        rpm_lines.append("Version: %s" % rpm_info.version)
 
     for r in rpm_info.requires:
-        rpm_lines += ["Requires: %s" % r]
+        rpm_lines.append("Requires: %s" % r)
 
     for p in rpm_info.provides:
-        rpm_lines += ["Provides: %s" % p]
+        rpm_lines.append("Provides: %s" % p)
 
     for c in rpm_info.conflicts:
-        rpm_lines += ["Conflicts: %s" % c]
+        rpm_lines.append("Conflicts: %s" % c)
 
     for o in rpm_info.obsoletes:
-        rpm_lines += ["Obsoletes: %s" % o]
+        rpm_lines.append("Obsoletes: %s" % o)
 
     rpm_lines += [
         "",
@@ -394,10 +394,10 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx, debuginfo_type):
 
         # rpmbuild will be unhappy if we have no files so we stick
         # default file mode in for that scenario
-        rpm_lines += [DEFAULT_FILE_MODE]
+        rpm_lines.append(DEFAULT_FILE_MODE)
         rpm_lines += sub_rpm_ctx.rpm_files_list
 
-        rpm_lines += [""]
+        rpm_lines.append("")
 
     rpm_ctx.install_script_pieces.extend(sub_rpm_ctx.install_script_pieces)
     rpm_ctx.packaged_directories.extend(sub_rpm_ctx.packaged_directories)
@@ -726,7 +726,12 @@ def _pkg_rpm_impl(ctx):
         subrpm_lines = []
         for s in ctx.attr.subrpms:
             subrpm_lines.extend(_process_subrpm(
-                ctx, rpm_name, s[PackageSubRPMInfo], rpm_ctx, debuginfo_type))
+                ctx,
+                rpm_name,
+                s[PackageSubRPMInfo],
+                rpm_ctx,
+                debuginfo_type,
+            ))
 
         subrpm_file = ctx.actions.declare_file(
             "{}.spec.subrpms".format(rpm_name),
@@ -740,7 +745,8 @@ def _pkg_rpm_impl(ctx):
 
     if debuginfo_type != "none":
         debuginfo_default_file = ctx.actions.declare_file(
-            "{}-debuginfo.rpm".format(rpm_name))
+            "{}-debuginfo.rpm".format(rpm_name),
+        )
         debuginfo_package_file_name = _make_rpm_filename(
             rpm_name,
             ctx.attr.version,
@@ -757,7 +763,8 @@ def _pkg_rpm_impl(ctx):
 
         rpm_ctx.output_rpm_files.append(debuginfo_output_file)
         rpm_ctx.make_rpm_args.append(
-            "--subrpm_out_file=debuginfo:%s" % debuginfo_output_file.path )
+            "--subrpm_out_file=debuginfo:%s" % debuginfo_output_file.path,
+        )
 
     #### Procedurally-generated scripts/lists (%install, %files)
 

--- a/tests/mappings/BUILD
+++ b/tests/mappings/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_python//python:defs.bzl", "py_library")
 load(
     "//pkg:mappings.bzl",
     "pkg_attributes",
@@ -27,8 +28,6 @@ load(
     "mappings_analysis_tests",
     "mappings_unit_tests",
 )
-load("@rules_python//python:defs.bzl", "py_library")
-
 
 package(default_applicable_licenses = ["//:license"])
 

--- a/tests/rpm/BUILD
+++ b/tests/rpm/BUILD
@@ -128,9 +128,13 @@ pkg_filegroup(
 ############################################################################
 
 _POST_SCRIPTLET = "echo post"
+
 _POSTUN_SCRIPTLET = "echo postun"
+
 _PRE_SCRIPTLET = "echo pre"
+
 _PREUN_SCRIPTLET = "echo preun"
+
 _POSTTRANS_SCRIPTLET = "echo posttrans"
 
 [
@@ -153,6 +157,7 @@ _POSTTRANS_SCRIPTLET = "echo posttrans"
 ############################################################################
 
 _VERSION = "1.1.1"
+
 _RELEASE = "2222"
 
 genrule(
@@ -181,10 +186,10 @@ pkg_rpm(
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
     post_scriptlet = _POST_SCRIPTLET,
+    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     postun_scriptlet = _POSTUN_SCRIPTLET,
     pre_scriptlet = _PRE_SCRIPTLET,
     preun_scriptlet = _PREUN_SCRIPTLET,
-    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     provides = ["test"],
     release = _RELEASE,
     requires = ["test-lib > 1.0"],
@@ -206,10 +211,10 @@ pkg_rpm(
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
     post_scriptlet = _POST_SCRIPTLET,
+    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     postun_scriptlet = _POSTUN_SCRIPTLET,
     pre_scriptlet = _PRE_SCRIPTLET,
     preun_scriptlet = _PREUN_SCRIPTLET,
-    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     provides = ["test"],
     release = _RELEASE,
     requires = ["test-lib > 1.0"],
@@ -234,10 +239,10 @@ pkg_rpm(
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
     post_scriptlet = _POST_SCRIPTLET,
+    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     postun_scriptlet = _POSTUN_SCRIPTLET,
     pre_scriptlet = _PRE_SCRIPTLET,
     preun_scriptlet = _PREUN_SCRIPTLET,
-    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     provides = ["test"],
     release = _RELEASE,
     requires = ["test-lib > 1.0"],
@@ -258,10 +263,10 @@ pkg_rpm(
     description = """pkg_rpm test rpm description""",
     license = "Apache 2.0",
     post_scriptlet_file = ":post",
+    posttrans_scriptlet_file = ":posttrans",
     postun_scriptlet_file = ":postun",
     pre_scriptlet_file = ":pre",
     preun_scriptlet_file = ":preun",
-    posttrans_scriptlet_file = ":posttrans",
     provides = ["test"],
     release = "2222",
     requires = ["test-lib > 1.0"],
@@ -283,10 +288,10 @@ pkg_rpm(
     epoch = "1",
     license = "Apache 2.0",
     post_scriptlet_file = ":post",
+    posttrans_scriptlet_file = ":posttrans",
     postun_scriptlet_file = ":postun",
     pre_scriptlet_file = ":pre",
     preun_scriptlet_file = ":preun",
-    posttrans_scriptlet_file = ":posttrans",
     provides = ["test"],
     release_file = ":release_file",
     requires = ["test-lib > 1.0"],
@@ -308,10 +313,10 @@ pkg_rpm(
     epoch = "1",
     license = "Apache 2.0",
     post_scriptlet = _POST_SCRIPTLET,
+    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     postun_scriptlet = _POSTUN_SCRIPTLET,
     pre_scriptlet = _PRE_SCRIPTLET,
     preun_scriptlet = _PREUN_SCRIPTLET,
-    posttrans_scriptlet = _POSTTRANS_SCRIPTLET,
     provides = ["test"],
     release = _RELEASE,
     requires = ["test-lib > 1.0"],
@@ -429,11 +434,11 @@ sh_library(
         ":test_rpm",
         ":test_rpm_bzip2",
         ":test_rpm_direct",
+        ":test_rpm_epoch",
         ":test_rpm_manifest",
         ":test_rpm_metadata",
-        ":test_rpm_scriptlets_files",
         ":test_rpm_release_version_files",
-        ":test_rpm_epoch",
+        ":test_rpm_scriptlets_files",
     ],
 )
 
@@ -510,21 +515,21 @@ pkg_files(
 pkg_sub_rpm(
     name = "sub_rpm",
     package_name = "test_sub_rpm",
-    description = "Test subrpm description",
-    summary = "Test subrpm",
     srcs = [
         ":test_sub_rpm_files",
     ],
+    description = "Test subrpm description",
+    summary = "Test subrpm",
 )
 
 pkg_sub_rpm(
     name = "sub_rpm2",
     package_name = "test_sub_rpm2",
-    description = "Test subrpm2 description",
-    summary = "Test subrpm2",
     srcs = [
         ":test_sub_rpm_files",
     ],
+    description = "Test subrpm2 description",
+    summary = "Test subrpm2",
 )
 
 genrule(
@@ -542,19 +547,19 @@ pkg_files(
 
 pkg_rpm(
     name = "test_sub_rpm_main",
-    description = "This is a package description.",
-    summary = "rules_pkg example RPM",
-    architecture = "noarch",
-    version = "1",
-    license = "Apache License, v2.0",
-    release = "0",
     srcs = [
         ":test_sub_rpm_main_files",
     ],
+    architecture = "noarch",
+    description = "This is a package description.",
+    license = "Apache License, v2.0",
+    release = "0",
     subrpms = [
         ":sub_rpm",
         ":sub_rpm2",
     ],
+    summary = "rules_pkg example RPM",
+    version = "1",
 )
 
 genrule(
@@ -587,10 +592,10 @@ diff_test(
 ############################################################################
 cc_binary(
     name = "test_debuginfo",
-    copts = ["-g"],
     srcs = [
         "test.c",
     ],
+    copts = ["-g"],
 )
 
 pkg_files(
@@ -602,15 +607,15 @@ pkg_files(
 
 pkg_rpm(
     name = "test_debuginfo_rpm",
-        srcs = [
+    srcs = [
         ":test_debuginfo_rpm_files",
     ],
-    release = "0",
-    version = "1",
-    license = "Some license",
-    summary = "Summary",
-    description = "Description",
     debuginfo = True,
+    description = "Description",
+    license = "Some license",
+    release = "0",
+    summary = "Summary",
+    version = "1",
 )
 
 genrule(

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -93,9 +93,9 @@ pkg_tar(
 
 pkg_tar(
     name = "test-respect-externally-defined-duplicates",
-    deps = ["//tests:testdata/duplicate_entries.tar"],
-    create_parents = False,
     allow_duplicates_from_deps = True,
+    create_parents = False,
+    deps = ["//tests:testdata/duplicate_entries.tar"],
 )
 
 #
@@ -330,9 +330,9 @@ pkg_tar(
 
 fake_artifact(
     name = "a_program",
+    executable = True,
     files = ["//tests:testdata/executable.sh"],
     runfiles = ["BUILD"],
-    executable = True,
 )
 
 pkg_tar(
@@ -346,7 +346,6 @@ pkg_tar(
 
 verify_archive_test(
     name = "runfiles_test",
-    target = ":test-tar-with-runfiles",
     must_contain = [
         "a_program",
         "a_program.runfiles/_main/tests/tar/BUILD",
@@ -363,8 +362,9 @@ verify_archive_test(
             "an_executable.runfiles/_main/tests/foo.cc",
             "an_executable.runfiles/_main/tests/an_executable",
             "an_executable.runfiles/_main/tests/testdata/hello.txt",
-        ]
+        ],
     }),
+    target = ":test-tar-with-runfiles",
 )
 
 pkg_tar(
@@ -464,6 +464,10 @@ py_test(
         ":test-pkg-tar-with-attributes",
         ":test-remap-paths-tree-artifact",
         ":test-respect-externally-defined-duplicates.tar",
+        ":test-tar-compression_level--1",
+        ":test-tar-compression_level-3",
+        ":test-tar-compression_level-6",
+        ":test-tar-compression_level-9",
         ":test-tar-empty_dirs.tar",
         ":test-tar-empty_files.tar",
         ":test-tar-files_dict.tar",
@@ -477,10 +481,6 @@ py_test(
         ":test-tar-strip_prefix-substring.tar",
         ":test-tar-tree-artifact",
         ":test-tar-tree-artifact-noroot",
-        ":test-tar-compression_level--1",
-        ":test-tar-compression_level-3",
-        ":test-tar-compression_level-6",
-        ":test-tar-compression_level-9",
         ":test-tree-input-with-strip-prefix",
         ":test_tar_leading_dotslash",
         ":test_tar_package_dir_substitution.tar",
@@ -722,6 +722,7 @@ verify_archive_test(
         "new/base/something/this": "that",
     },
 )
+
 fake_artifact(
     name = "program_with_dir_runfiles",
     files = ["//tests:testdata/executable.sh"],
@@ -764,8 +765,13 @@ verify_archive_test(
 [pkg_tar(
     name = "test-tar-compression_level-%s" % compression_level,
     compression_level = compression_level,
+    extension = "tgz",
     deps = [
         "//tests:testdata/tar_test.tar",
     ],
-    extension = "tgz",
-) for compression_level in [-1, 3, 6, 9]]
+) for compression_level in [
+    -1,
+    3,
+    6,
+    9,
+]]


### PR DESCRIPTION
Autoupdate pre-commit hooks and run the formatter to bring all files to a consistent autoformatted state. In a follow up PR, I would add the pre-commit check as a GH action, similar to https://github.com/bazel-contrib/rules-template/pull/130.