### PR TITLE
fix CI for verify_archive_test

### DIFF
--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -93,9 +93,9 @@ pkg_tar(
 
 pkg_tar(
     name = "test-respect-externally-defined-duplicates",
-    deps = ["//tests:testdata/duplicate_entries.tar"],
-    create_parents = False,
     allow_duplicates_from_deps = True,
+    create_parents = False,
+    deps = ["//tests:testdata/duplicate_entries.tar"],
 )
 
 #
@@ -290,7 +290,7 @@ verify_archive_test(
         "can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt",
     ],
     must_contain_regex = [
-        ".*can_i_repackage_a_file_with_a_long_name/$",
+        ".*can_i_repackage_a_file_with_a_long_name/.*$",
     ],
     # there is really no need for these cases. I just want to use all the test capabilities.
     must_not_contain = [
@@ -330,9 +330,9 @@ pkg_tar(
 
 fake_artifact(
     name = "a_program",
+    executable = True,
     files = ["//tests:testdata/executable.sh"],
     runfiles = ["BUILD"],
-    executable = True,
 )
 
 pkg_tar(
@@ -346,7 +346,6 @@ pkg_tar(
 
 verify_archive_test(
     name = "runfiles_test",
-    target = ":test-tar-with-runfiles",
     must_contain = [
         "a_program",
         "a_program.runfiles/_main/tests/tar/BUILD",
@@ -363,8 +362,9 @@ verify_archive_test(
             "an_executable.runfiles/_main/tests/foo.cc",
             "an_executable.runfiles/_main/tests/an_executable",
             "an_executable.runfiles/_main/tests/testdata/hello.txt",
-        ]
+        ],
     }),
+    target = ":test-tar-with-runfiles",
 )
 
 pkg_tar(
@@ -464,6 +464,10 @@ py_test(
         ":test-pkg-tar-with-attributes",
         ":test-remap-paths-tree-artifact",
         ":test-respect-externally-defined-duplicates.tar",
+        ":test-tar-compression_level--1",
+        ":test-tar-compression_level-3",
+        ":test-tar-compression_level-6",
+        ":test-tar-compression_level-9",
         ":test-tar-empty_dirs.tar",
         ":test-tar-empty_files.tar",
         ":test-tar-files_dict.tar",
@@ -477,10 +481,6 @@ py_test(
         ":test-tar-strip_prefix-substring.tar",
         ":test-tar-tree-artifact",
         ":test-tar-tree-artifact-noroot",
-        ":test-tar-compression_level--1",
-        ":test-tar-compression_level-3",
-        ":test-tar-compression_level-6",
-        ":test-tar-compression_level-9",
         ":test-tree-input-with-strip-prefix",
         ":test_tar_leading_dotslash",
         ":test_tar_package_dir_substitution.tar",
@@ -722,6 +722,7 @@ verify_archive_test(
         "new/base/something/this": "that",
     },
 )
+
 fake_artifact(
     name = "program_with_dir_runfiles",
     files = ["//tests:testdata/executable.sh"],
@@ -764,8 +765,13 @@ verify_archive_test(
 [pkg_tar(
     name = "test-tar-compression_level-%s" % compression_level,
     compression_level = compression_level,
+    extension = "tgz",
     deps = [
         "//tests:testdata/tar_test.tar",
     ],
-    extension = "tgz",
-) for compression_level in [-1, 3, 6, 9]]
+) for compression_level in [
+    -1,
+    3,
+    6,
+    9,
+]]


### PR DESCRIPTION
Fix [one unit test](https://buildkite.com/bazel/rules-pkg/builds/3493#01945e37-6afe-48de-a673-5d6b9856addd) after https://github.com/bazelbuild/rules_pkg/pull/910 was merged. I assume that PR must have been merged with red CI.

With this PR, all should be good now. Some of the changes are just my Buildifier kicking in.