### PR TITLE
Allow some common rule args in verify_archive_test

### DIFF
--- a/pkg/verify_archive.bzl
+++ b/pkg/verify_archive.bzl
@@ -23,6 +23,21 @@ The execution time is O(# expected patterns * size of archive).
 
 load("@rules_python//python:defs.bzl", "py_test")
 
+# Attribute names common to all build rules. See https://bazel.build/reference/be/common-definitions
+COMMON_BUILD_ATTR_NAMES = [
+    "tags",
+    "target_compatible_with",
+    "testonly",
+    "visibility",
+]
+
+# Attribute names common to all test rules. See https://bazel.build/reference/be/common-definitions#common-attributes-tests
+COMMON_TEST_ATTR_NAMES = COMMON_BUILD_ATTR_NAMES + [
+    "size",
+    "timeout",
+    "flaky",
+]
+
 def _gen_verify_archive_test_main_impl(ctx):
     ctx.actions.expand_template(
         template = ctx.file._template,
@@ -95,7 +110,6 @@ def verify_archive_test(
         must_not_contain_regex = None,
         min_size = 1,
         max_size = -1,
-        tags = None,
         verify_links = None,
         **kwargs):
     """Tests that an archive contains specific file patterns.
@@ -110,9 +124,8 @@ def verify_archive_test(
       must_not_contain_regex: A list of path regexes which must not appear in the archive.
       min_size: The minimum number of entries which must be in the archive.
       max_size: The maximum number of entries which must be in the archive.
-      tags: standard meaning
       verify_links: Dict keyed by paths which must appear, and be symlinks to their values.
-      **kwargs: The args to be passed to the underlying py_test rule.
+      **kwargs: The args to be passed to the underlying rules, if supported.
     """
     test_src = name + "__internal_main.py"
     _gen_verify_archive_test_main(
@@ -126,8 +139,8 @@ def verify_archive_test(
         must_not_contain_regex = must_not_contain_regex,
         min_size = min_size,
         max_size = max_size,
-        tags = tags,
         verify_links = verify_links,
+        **{key: kwargs[key] for key in COMMON_BUILD_ATTR_NAMES if key in kwargs}
     )
     py_test(
         name = name,
@@ -135,5 +148,5 @@ def verify_archive_test(
         main = test_src,
         data = [target],
         python_version = "PY3",
-        **kwargs
+        **{key: kwargs[key] for key in COMMON_TEST_ATTR_NAMES if key in kwargs}
     )

--- a/pkg/verify_archive.bzl
+++ b/pkg/verify_archive.bzl
@@ -126,6 +126,7 @@ def verify_archive_test(
       max_size: The maximum number of entries which must be in the archive.
       verify_links: Dict keyed by paths which must appear, and be symlinks to their values.
       **kwargs: The args to be passed to the underlying rules, if supported.
+                See https://github.com/bazelbuild/rules_pkg/blob/main/pkg/verify_archive.bzl for the full list.
     """
     test_src = name + "__internal_main.py"
     _gen_verify_archive_test_main(

--- a/pkg/verify_archive.bzl
+++ b/pkg/verify_archive.bzl
@@ -96,7 +96,8 @@ def verify_archive_test(
         min_size = 1,
         max_size = -1,
         tags = None,
-        verify_links = None):
+        verify_links = None,
+        **kwargs):
     """Tests that an archive contains specific file patterns.
 
     This test is used to verify that an archive contains the expected content.
@@ -111,6 +112,7 @@ def verify_archive_test(
       max_size: The maximum number of entries which must be in the archive.
       tags: standard meaning
       verify_links: Dict keyed by paths which must appear, and be symlinks to their values.
+      **kwargs: The args to be passed to the underlying py_test rule.
     """
     test_src = name + "__internal_main.py"
     _gen_verify_archive_test_main(
@@ -133,4 +135,5 @@ def verify_archive_test(
         main = test_src,
         data = [target],
         python_version = "PY3",
+        **kwargs
     )

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -285,8 +285,6 @@ pkg_tar(
 
 verify_archive_test(
     name = "repackaging_long_filename_test",
-    size = "small",
-    testonly = True,
     max_size = 2,
     must_contain = [
         "can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt",

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -285,6 +285,8 @@ pkg_tar(
 
 verify_archive_test(
     name = "repackaging_long_filename_test",
+    size = "small",
+    testonly = True,
     max_size = 2,
     must_contain = [
         "can_i_repackage_a_file_with_a_long_name/file_with_a_ridiculously_long_name_consectetur_adipiscing_elit_fusce_laoreet_lorem_neque_sed_pharetra_erat.txt",

--- a/tests/verify_archive/BUILD
+++ b/tests/verify_archive/BUILD
@@ -26,22 +26,44 @@ pkg_tar(
     ],
 )
 
+pkg_tar(
+    name = "loremipsum_tar_test_only",
+    testonly = True,
+    srcs = [
+        "//tests:loremipsum_txt",
+    ],
+)
+
 # Test cases
 
 verify_archive_test(
-    name = "test_size_is_allowed",
+    name = "test_py_test_attrs_is_allowed",
     size = "small",
+    timeout = "moderate",
+    flaky = True,
     target = ":loremipsum_tar",
 )
 
 verify_archive_test(
     name = "test_testonly_is_allowed",
     testonly = True,
-    target = ":loremipsum_tar",
+    target = ":loremipsum_tar_test_only",
 )
 
 verify_archive_test(
     name = "test_visibility_is_allowed",
     target = ":loremipsum_tar",
     visibility = ["//visibility:private"],
+)
+
+verify_archive_test(
+    name = "test_tags_are_allowed",
+    tags = ["test_tag"],
+    target = ":loremipsum_tar",
+)
+
+verify_archive_test(
+    name = "test_target_compatible_with_is_allowed",
+    target = ":loremipsum_tar",
+    target_compatible_with = ["@platforms//cpu:x86_64"],
 )

--- a/tests/verify_archive/BUILD
+++ b/tests/verify_archive/BUILD
@@ -43,5 +43,5 @@ verify_archive_test(
 verify_archive_test(
     name = "test_visibility_is_allowed",
     target = ":loremipsum_tar",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )

--- a/tests/verify_archive/BUILD
+++ b/tests/verify_archive/BUILD
@@ -57,13 +57,13 @@ verify_archive_test(
 )
 
 verify_archive_test(
-    name = "test_tags_are_allowed",
-    tags = ["test_tag"],
-    target = ":loremipsum_tar",
-)
-
-verify_archive_test(
     name = "test_target_compatible_with_is_allowed",
     target = ":loremipsum_tar",
     target_compatible_with = ["@platforms//cpu:x86_64"],
+)
+
+verify_archive_test(
+    name = "test_tags_are_allowed",
+    tags = ["test_tag"],
+    target = ":loremipsum_tar",
 )

--- a/tests/verify_archive/BUILD
+++ b/tests/verify_archive/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -*- coding: utf-8 -*-
+"""Tests for verify_archive."""
+
+load("//pkg:tar.bzl", "pkg_tar")
+load("//pkg:verify_archive.bzl", "verify_archive_test")
+
+# Test data
+
+pkg_tar(
+    name = "loremipsum_tar",
+    srcs = [
+        "//tests:loremipsum_txt",
+    ],
+)
+
+# Test cases
+
+verify_archive_test(
+    name = "test_size_is_allowed",
+    size = "small",
+    target = ":loremipsum_tar",
+)
+
+verify_archive_test(
+    name = "test_testonly_is_allowed",
+    testonly = True,
+    target = ":loremipsum_tar",
+)
+
+verify_archive_test(
+    name = "test_visibility_is_allowed",
+    target = ":loremipsum_tar",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Closes #916

This is my proposal for allowing common test arguments for `verify_archive_test`.