### PR TITLE
fix: symlinks in pkg_tar

### DIFF
--- a/pkg/private/pkg_files.bzl
+++ b/pkg/private/pkg_files.bzl
@@ -141,6 +141,10 @@ def _check_dest(content_map, dest, src, origin, allow_duplicates_with_different_
     if old_entry.src == src or old_entry.origin == origin:
         return
 
+    # 'src' is None when _check_dest is called for symlinks.
+    if not src:
+        return
+
     # TODO(#385): This is insufficient but good enough for now. We should
     # compare over all the attributes too. That will detect problems where
     # people specify the owner in one place, but another overly broad glob


### PR DESCRIPTION
User defined symlinks was not working in pkg_tar as _check_dest() in pkg_files did not account for src=None.