### PR TITLE
fix: avoid creating "/" zip entry when using REMOVE_BASE_DIRECTORY

### DIFF
--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -219,7 +219,15 @@ class ZipWriter(object):
         dest_dir = dest + rel_path_from_top + '/'
       else:
         dest_dir = dest
-      to_write[dest_dir] = None
+      if dest_dir:
+        to_write[dest_dir] = None
+      else:
+        # This branch represents the case where we are evaluating the
+        # root of a tree which is mapped to the root of the zip archive,
+        # such as via `REMOVE_BASE_DIRECTORY`.  When that happens, we
+        # do nothing.  (We do not record an entry for the root of the
+        # zip file.)
+        pass
       for file in files:
         content_path = os.path.abspath(os.path.join(root, file))
         if os.name == "nt":

--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -15,7 +15,7 @@
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs", "pkg_mklink")
+load("//pkg:mappings.bzl", "REMOVE_BASE_DIRECTORY", "pkg_attributes", "pkg_files", "pkg_mkdirs", "pkg_mklink")
 load("//pkg:zip.bzl", "pkg_zip")
 load("//tests:my_package_name.bzl", "my_package_naming")
 load("//tests/util:defs.bzl", "directory")
@@ -132,6 +132,17 @@ pkg_zip(
 pkg_zip(
     name = "test_zip_tree",
     srcs = [":generate_tree"],
+)
+
+pkg_zip(
+    name = "test_zip_tree_remove_base_directory",
+    srcs = [":generate_tree_remove_base_directory"],
+)
+
+pkg_files(
+    name = "generate_tree_remove_base_directory",
+    srcs = [":generate_tree"],
+    renames = {":generate_tree": REMOVE_BASE_DIRECTORY},
 )
 
 pkg_zip(
@@ -289,6 +300,7 @@ py_test(
         ":test_zip_stored",
         ":test_zip_timestamp.zip",
         ":test_zip_tree.zip",
+        ":test_zip_tree_remove_base_directory.zip",
     ],
     python_version = "PY3",
     deps = [

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -124,6 +124,20 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
         {"filename": "generate_tree/b/e"},
     ])
 
+  def test_zip_tree_remove_base_directory(self):
+    # Files' mode of `0o644` comes from `pkg_files`'s default.
+    self.assertZipFileContent("test_zip_tree_remove_base_directory.zip", [
+        {"filename": "a/", "isdir": True, "attr": 0o755},
+        {"filename": "a/a", "attr": 0o644},
+        {"filename": "a/b/", "isdir": True, "attr": 0o755},
+        {"filename": "a/b/c", "attr": 0o644},
+        {"filename": "b/", "isdir": True, "attr": 0o755},
+        {"filename": "b/c/", "isdir": True, "attr": 0o755},
+        {"filename": "b/c/d", "attr": 0o644},
+        {"filename": "b/d", "attr": 0o644},
+        {"filename": "b/e", "attr": 0o644},
+    ])
+
   def test_compression_deflated(self):
     if sys.version_info >= (3, 7):
       self.assertZipFileContent("test_zip_deflated_level_3.zip", [


### PR DESCRIPTION
This is just a quick fix to handle the special case of mapping a tree artifact to the root of a zip archive.

Resolves #927.