### PR TITLE
rpm: Consume group info for sub RPMs

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -350,6 +350,9 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx, debuginfo_type):
         "Summary: %s" % rpm_info.summary,
     ]
 
+    if rpm_info.group:
+        rpm_lines.append("Group: %s" % rpm_info.group)
+
     if rpm_info.architecture:
         rpm_lines.append("BuildArch: %s" % rpm_info.architecture)
 


### PR DESCRIPTION
In the original subrpm implementation this field appears to have been overlooked.  This change just injects the correct specfile lines based on the existing group info from the provider.