### PR TITLE
rpm: fix sub-RPM post_scriptlet and add %postun support

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -47,6 +47,7 @@ PackageSubRPMInfo = provider(
         "group": "RPM subpackage `Group` tag",
         "description": "Multi-line description of this subpackage",
         "post_scriptlet": "RPM `$post` scriplet for this subpackage",
+        "postun_scriptlet": "RPM `$postun` scriplet for this subpackage",
         "architecture": "Subpackage architecture",
         "epoch": "RPM `Epoch` tag for this subpackage",
         "version": "RPM `Version` tag for this subpackage",
@@ -384,6 +385,14 @@ def _process_subrpm(ctx, rpm_name, rpm_info, rpm_ctx, debuginfo_type):
         rpm_lines += [
             "",
             "%%post %s" % rpm_info.package_name,
+            rpm_info.post_scriptlet,
+        ]
+
+    if rpm_info.postun_scriptlet:
+        rpm_lines += [
+            "",
+            "%%postun %s" % rpm_info.package_name,
+            rpm_info.postun_scriptlet,
         ]
 
     if rpm_info.srcs:
@@ -1302,6 +1311,7 @@ def _pkg_sub_rpm_impl(ctx):
             group = ctx.attr.group,
             description = ctx.attr.description,
             post_scriptlet = ctx.attr.post_scriptlet,
+            postun_scriptlet = ctx.attr.postun_scriptlet,
             architecture = ctx.attr.architecture,
             epoch = ctx.attr.epoch,
             version = ctx.attr.version,
@@ -1339,6 +1349,7 @@ pkg_sub_rpm = rule(
         ),
         "description": attr.string(doc = "Multi-line description of this subrpm"),
         "post_scriptlet": attr.string(doc = "RPM `%post` scriplet for this subrpm"),
+        "postun_scriptlet": attr.string(doc = "RPM `%postun` scriplet for this subrpm"),
         "architecture": attr.string(doc = "Sub RPM architecture"),
         "epoch": attr.string(doc = "RPM `Epoch` tag for this subrpm"),
         "version": attr.string(doc = "RPM `Version` tag for this subrpm"),

--- a/tests/rpm/BUILD
+++ b/tests/rpm/BUILD
@@ -529,6 +529,8 @@ pkg_sub_rpm(
         ":test_sub_rpm_files",
     ],
     description = "Test subrpm2 description",
+    post_scriptlet = "echo post",
+    postun_scriptlet = "echo postun",
     summary = "Test subrpm2",
 )
 
@@ -570,13 +572,13 @@ genrule(
     # pkg_rpm emits two outputs
     RPMS=($(SRCS))
     echo "===== main RPM =====" > $@
-    rpm -qpi --list $${RPMS[0]} | \
+    rpm -qpi --scripts --list $${RPMS[0]} | \
         grep -v 'Build Date' | grep -v 'Build Host' | grep -v 'Relocations' >> $@
     echo "===== sub RPM ======" >> $@
-    rpm -qpi --list $${RPMS[1]} | \
+    rpm -qpi --scripts --list $${RPMS[1]} | \
         grep -v 'Build Date' | grep -v 'Build Host' | grep -v 'Relocations' >> $@
     echo "===== sub RPM ======" >> $@
-    rpm -qpi --list $${RPMS[2]} | \
+    rpm -qpi --scripts --list $${RPMS[2]} | \
         grep -v 'Build Date' | grep -v 'Build Host' | grep -v 'Relocations' >> $@
     """,
 )

--- a/tests/rpm/test_sub_rpm_contents.txt.golden
+++ b/tests/rpm/test_sub_rpm_contents.txt.golden
@@ -42,4 +42,8 @@ Source RPM  : test_sub_rpm_main-1-0.src.rpm
 Summary     : Test subrpm2
 Description :
 Test subrpm2 description
+postinstall scriptlet (using /bin/sh):
+echo post
+postuninstall scriptlet (using /bin/sh):
+echo postun
 /test_sub_rpm_file_input.txt


### PR DESCRIPTION
The existing implementation of `%post` neglected to actually include the contents of the `%post` scriptlet and simply added a `%post` section to the spec file without the body, e.g.

    %post sub

    %files sub
    ...

With this change, I've also added support for `%postun` and included the scriptlet support in the `test_golden_sub_rpm_contents` test case.