### PR TITLE
Fix installing code-signed binaries on macOS

### DIFF
--- a/pkg/private/install.py.tpl
+++ b/pkg/private/install.py.tpl
@@ -23,6 +23,7 @@ import os
 import pathlib
 import shutil
 import sys
+import tempfile
 
 from pkg.private import manifest
 
@@ -79,7 +80,19 @@ class NativeInstaller(object):
 
     def _do_file_copy(self, src, dest):
         logging.debug("COPY %s <- %s", dest, src)
-        shutil.copyfile(src, dest)
+        # Copy to a temporary file and then move it to the destination.
+        # This ensures code-signed executables on certain platforms
+        # behave correctly.
+        # See: https://developer.apple.com/documentation/security/updating-mac-software
+        # Use `dir` to ensure the temporary file is created on the same file system as the destination,
+        # to avoid cross-filesystem replace which is an error on some platforms.
+        with tempfile.NamedTemporaryFile(delete=False, dir=os.path.dirname(dest)) as tmp_file:
+            try:
+                shutil.copyfile(src, tmp_file.name)
+                os.replace(tmp_file.name, dest)
+            except:
+                pathlib.Path(tmp_file.name).unlink(missing_ok=True)
+                raise
 
     def _do_mkdir(self, dirname, mode):
         logging.debug("MKDIR %s %s", mode, dirname)


### PR DESCRIPTION
When running a `pkg_install` on a code-signed binary on macOS, that is already executing from a previous install... I was getting `Killed: 9` when attempting to run the newly installed executable.

This can be reproduced semi-consistently with something like:

```sh
# Run an install & execute the installed binary, background immediately, then do it again.
bazel run //:install --destdir bin && ./bin/foo &; \
bazel run //:install --destdir bin && ./bin/foo
```

This is apparently a long-standing "quirk" on macOS when executing code-signed binaries. 

>This code is incorrect because it modifies the command-line tool’s executable file in place. macOS caches information about the code’s signature in the kernel. It doesn’t flush that cache when you modify the file’s contents. Modifying the file in place yields a mismatch between the file’s contents and the in-kernel cache, which can cause a hard-to-reproduce code-signing crash the next time you run the tool.

> To update a file that contains signed code without risking this crash, write the updated code to a temporary file and replace the existing file with that temporary one

> Using a temporary file eliminates the risk of a code-signing crash because the in-kernel cache is associated with the old file, which remains unmodified. The new file gets its own in-kernel cache, built from the contents of that new file.

Source: https://developer.apple.com/documentation/security/updating-mac-software

Maybe we could do this for just macOS but this should be supported on all platforms.