### PR TITLE
Generic `debuginfo` RPM platform support

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -26,6 +26,11 @@ find_system_rpmbuild(name="rules_pkg_rpmbuild")
 """
 
 load(
+    "@rules_pkg//toolchains/rpm:rpmbuild_configure.bzl",
+    "DEBUGINFO_TYPE_FEDORA",
+    "DEBUGINFO_TYPE_NONE",
+)
+load(
     "//pkg:providers.bzl",
     "PackageDirsInfo",
     "PackageFilegroupInfo",
@@ -223,7 +228,7 @@ def _process_files(pfi, origin_label, grouping_label, file_base, rpm_ctx, debugi
             rpm_ctx.rpm_files_list.append(_FILE_MODE_STANZA_FMT.format(file_base, abs_dest))
 
             install_stanza_fmt = _INSTALL_FILE_STANZA_FMT
-            if debuginfo_type == "fedora40":
+            if debuginfo_type == DEBUGINFO_TYPE_FEDORA:
                 install_stanza_fmt = _INSTALL_FILE_STANZA_FMT_FEDORA40_DEBUGINFO
 
             rpm_ctx.install_script_pieces.append(install_stanza_fmt.format(
@@ -470,7 +475,7 @@ def _pkg_rpm_impl(ctx):
 
     files = []
     tools = []
-    debuginfo_type = "none"
+    debuginfo_type = DEBUGINFO_TYPE_NONE
     name = ctx.attr.package_name if ctx.attr.package_name else ctx.label.name
     rpm_ctx.make_rpm_args.append("--name=" + name)
 
@@ -755,7 +760,7 @@ def _pkg_rpm_impl(ctx):
         files.append(subrpm_file)
         rpm_ctx.make_rpm_args.append("--subrpms=" + subrpm_file.path)
 
-    if debuginfo_type != "none":
+    if debuginfo_type != DEBUGINFO_TYPE_NONE:
         debuginfo_default_file = ctx.actions.declare_file(
             "{}-debuginfo.rpm".format(rpm_name),
         )

--- a/toolchains/rpm/rpmbuild.bzl
+++ b/toolchains/rpm/rpmbuild.bzl
@@ -60,7 +60,7 @@ rpmbuild_toolchain = rule(
             doc = """
             The underlying debuginfo configuration for the system rpmbuild.
 
-            One of centos7, fedora40, or none
+            One of `centos`, `fedora`, and `none`
             """,
             default = "none",
         ),

--- a/toolchains/rpm/rpmbuild_configure.bzl
+++ b/toolchains/rpm/rpmbuild_configure.bzl
@@ -57,19 +57,21 @@ def _parse_release_info(release_info):
 
     return os_name, os_version
 
-KNOWN_DEBUGINFO_VERSIONS = {
-    "almalinux": ["9.3"],
-    "centos": ["7", "9"],
-    "fedora": ["40"],
+DEBUGINFO_TYPE_NONE = "none"
+DEBUGINFO_TYPE_CENTOS = "centos"
+DEBUGINFO_TYPE_FEDORA = "fedora"
+
+DEBUGINFO_TYPE_BY_OS_RELEASE = {
+    "almalinux": DEBUGINFO_TYPE_CENTOS,
+    "centos": DEBUGINFO_TYPE_CENTOS,
+    "fedora": DEBUGINFO_TYPE_FEDORA,
 }
 
 def _build_repo_for_rpmbuild_toolchain_impl(rctx):
-    debuginfo_type = "none"
+    debuginfo_type = DEBUGINFO_TYPE_NONE
     if rctx.path(RELEASE_PATH).exists:
-        os_name, os_version = _parse_release_info(rctx.read(RELEASE_PATH))
-        if (os_name in KNOWN_DEBUGINFO_VERSIONS and
-            os_version in KNOWN_DEBUGINFO_VERSIONS[os_name]):
-            debuginfo_type = os_name + os_version
+        os_name, _ = _parse_release_info(rctx.read(RELEASE_PATH))
+        debuginfo_type = DEBUGINFO_TYPE_BY_OS_RELEASE.get(os_name, debuginfo_type)
 
     rpmbuild_path = rctx.which("rpmbuild")
     if rctx.attr.verbose:
@@ -110,7 +112,7 @@ build_repo_for_rpmbuild_toolchain = repository_rule(
             doc = """
             The underlying debuginfo configuration for the system rpmbuild.
 
-            One of centos7, fedora40, or none
+            One of `centos`, `fedora`, and `none`
             """,
             default = "none",
         ),


### PR DESCRIPTION
This change splits the `debuginfo` RPM support into `fedora` and `centos` and bundles `almalinux` into the `centos` category.

This facilitates future support as more versions are being added as opposed to hardcoding every individual OS name and version combination.

The fedora and centos specific logic remains unchanged.