### PR TITLE
Fix mappings/external repo tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,3 +23,10 @@ register_toolchains(
     "@rules_pkg_rpmbuild//:all",
     dev_dependency = True,
 )
+
+local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
+local_repository(
+    name = "mappings_test_external_repo",
+    path = "tests/mappings/external_repo",
+)

--- a/doc_build/BUILD
+++ b/doc_build/BUILD
@@ -69,7 +69,10 @@ genrule(
         symbol_names = [
             rule,
         ],
-        deps = [":rules_pkg_lib"],
+        deps = [
+            ":rules_pkg_lib",
+            "//toolchains/rpm:standard_package",
+        ],
     )
     for rule, src in ORDER
     if src

--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -56,6 +56,7 @@ starlark_library(
     srcs = [
         ":standard_package",
         "//pkg:pkg.bzl",
+        "//pkg:rpm_pfg.bzl",
         "//pkg/private:standard_package",
         "//pkg/private/deb:standard_package",
         "//pkg/private/tar:standard_package",

--- a/tests/mappings/external_repo/MODULE.bazel
+++ b/tests/mappings/external_repo/MODULE.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module(
-    name = "test_external_project"
+    name = "test_external_project",
     version = "0",
     compatibility_level = 0,
 )

--- a/tests/mappings/external_repo/MODULE.bazel
+++ b/tests/mappings/external_repo/MODULE.bazel
@@ -14,8 +14,8 @@
 
 module(
     name = "test_external_project"
-    #version = "0,
-    #compatibility_level = 0,
+    version = "0",
+    compatibility_level = 0,
 )
 
 local_path_override(

--- a/tests/mappings/external_repo/MODULE.bazel
+++ b/tests/mappings/external_repo/MODULE.bazel
@@ -1,0 +1,45 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "test_external_project"
+    #version = "0,
+    #compatibility_level = 0,
+)
+
+local_path_override(
+    module_name = "rules_pkg",
+    path = "../../../",
+)
+
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+
+#########################################
+# Do not update to newer versions until you need a specific new feature.
+
+# Only for development
+#bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
+#bazel_dep(name = "rules_cc", version = "0.0.17", dev_dependency = True)
+#bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True)
+#
+## Find the system rpmbuild if one is available.
+#find_rpm = use_extension("//toolchains/rpm:rpmbuild_configure.bzl", "find_system_rpmbuild_bzlmod", dev_dependency = True)
+#use_repo(find_rpm, "rules_pkg_rpmbuild")
+#
+#register_toolchains(
+#    "@rules_pkg_rpmbuild//:all",
+#    dev_dependency = True,
+#)

--- a/toolchains/rpm/BUILD
+++ b/toolchains/rpm/BUILD
@@ -33,7 +33,10 @@ filegroup(
     srcs = glob([
         "*",
     ]),
-    visibility = ["//distro:__pkg__"],
+    visibility = [
+        "//distro:__pkg__",
+        "//doc_build:__pkg__",
+    ],
 )
 
 exports_files(


### PR DESCRIPTION
Adds `tests/mappings/external_repo`  to `MODULE.bazel` in a way that works with current Bazels.

- also fix stardoc generation.