### PR TITLE
pkg_tar: Fix #948: Don't add duplicate directory members to tar file when a symlink with the same path exists

### DIFF
--- a/tests/tar/tar_writer_test.py
+++ b/tests/tar/tar_writer_test.py
@@ -162,7 +162,7 @@ class TarFileWriterTest(unittest.TestCase):
           "rules_pkg/tests/testdata/tar_test.tar")
       f.add_tar(input_tar_path)
       input_tar = tarfile.open(input_tar_path, "r")
-      for file_name in f.members:
+      for file_name in f.existing_members.keys():
         input_file = input_tar.getmember(file_name)
         output_file = f.tar.getmember(file_name)
         self.assertEqual(input_file.mtime, output_file.mtime)

--- a/tests/tar/tar_writer_test.py
+++ b/tests/tar/tar_writer_test.py
@@ -313,6 +313,19 @@ class TarFileWriterTest(unittest.TestCase):
     ]
     self.assertTarFileContent(self.tempfile, content)
 
+  def testSymlinkDoesNotShadowDirectory(self):
+    with tar_writer.TarFileWriter(self.tempfile, create_parents=True, allow_dups_from_deps=False) as f:
+      f.add_file("target_dir", tarfile.DIRTYPE)
+      f.add_file("not_a_symlink", tarfile.DIRTYPE)
+      f.add_file("not_a_symlink", tarfile.SYMTYPE, link="target_dir")
+      f.add_file('not_a_symlink/a', content="q")
+    content = [
+      {"name": "target_dir", "type": tarfile.DIRTYPE},
+      {"name": "not_a_symlink", "type": tarfile.DIRTYPE},
+      {"name": "not_a_symlink/a", "type": tarfile.REGTYPE},
+    ]
+    self.assertTarFileContent(self.tempfile, content)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/tar/tar_writer_test.py
+++ b/tests/tar/tar_writer_test.py
@@ -300,6 +300,18 @@ class TarFileWriterTest(unittest.TestCase):
 
     self.assertTarFileContent(self.tempfile, expected_content)
 
+  def testDirectoryDoesNotShadowSymlink(self):
+    with tar_writer.TarFileWriter(self.tempfile, create_parents=True, allow_dups_from_deps=False) as f:
+      f.add_file("target_dir", tarfile.DIRTYPE)
+      f.add_file("symlink", tarfile.SYMTYPE, link="target_dir")
+      f.add_file("symlink", tarfile.DIRTYPE)
+      f.add_file('symlink/a', content="q")
+    content = [
+      {"name": "target_dir", "type": tarfile.DIRTYPE},
+      {"name": "symlink", "type": tarfile.SYMTYPE},
+      {"name": "symlink/a", "type": tarfile.REGTYPE},
+    ]
+    self.assertTarFileContent(self.tempfile, content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've modified the deduplication logic to account for the fact that directories must not have the same path as other types of files. Previously, the paths `/lib` and `/lib/` would be treated differently.

Two test cases are included: one for symlinks preceding directories, and one for directories preceding symlinks. In both cases, the first member is preserved and the second member with the same path is discarded as a duplicate.