### PR TITLE
pkg_rpm: propagate make_rpm PATH to rpmbuild

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -420,6 +420,7 @@ class RpmBuilder(object):
     env = {
         'LANG': 'C',
         'RPM_BUILD_ROOT': buildroot,
+        'PATH': os.getenv( 'PATH' ),
     }
 
     if self.source_date_epoch is not None:


### PR DESCRIPTION
Depending on the specific rpmbuild macros in use, we might need to have a valid PATH set.

I saw a specific issue where one of the macros calls a "find-debuginfo" script that uses "which" (/usr/bin/which) to locate gdb. Because "which" is not a shell command, it doesn't know about the default PATH provided by bash, and so it doesn't see _any_ path.

If we just propagate PATH we can avoid this confusing class of errors. It seems reasonable that the PATH used by `rpmbuild` is inherited from bazel in this case as it is more generally during rule execution.