### PR TITLE
Migrate CentOS jobs to Rocky Linux

### DIFF
--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -4,8 +4,8 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
+  rockylinux8:
+    platform: rockylinux8_java11_devtoolset10
     <<: *common
   ubuntu2204:
     platform: ubuntu2204

--- a/.bazelci/examples_rich_structure.yml
+++ b/.bazelci/examples_rich_structure.yml
@@ -4,8 +4,8 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
+  rockylinux8:
+    platform: rockylinux8_java11_devtoolset10
     <<: *common
   ubuntu2204:
     platform: ubuntu2204

--- a/.bazelci/examples_stamping.yml
+++ b/.bazelci/examples_stamping.yml
@@ -4,8 +4,8 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
+  rockylinux8:
+    platform: rockylinux8_java11_devtoolset10
     <<: *common
   ubuntu2204:
     platform: ubuntu2204

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,7 +1,7 @@
 # These tests check the run-time behavior under various combinations
 #
 # - Tests: behavior only. release tools are in the integration tests
-# - Platforms: ubuntu, centos, macos, windows
+# - Platforms: ubuntu, rockylinux, macos, windows
 # - bzlmod enabled or not
 # - bazel: LTS-1, LTS, rolling
 #
@@ -68,8 +68,8 @@ ubuntu2204: &ubuntu
   <<: *common
   <<: *default_tests
 
-centos7: &centos
-  platform: centos7_java11_devtoolset10
+rockylinux8: &rockylinux
+  platform: rockylinux8_java11_devtoolset10
   <<: *common
   <<: *default_tests_with_rpm
 
@@ -117,10 +117,10 @@ tasks:
     <<: *ubuntu
     <<: *nobzlmod
 
-  cent_lts:
-    name: cent_lts
+  rockylinux_lts:
+    name: rockylinux_lts
     bazel: latest
-    <<: *centos
+    <<: *rockylinux
 
   mac_head_bzlmod:
     name: mac_head_bzlmod

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,7 +5,7 @@ build_targets: &build_targets
 - '-@rules_pkg//pkg:make_rpm'
 
 platforms:
-  centos7_java11_devtoolset10:
+  rockylinux_java11_devtoolset10:
     build_targets: *build_targets
   debian10:
     build_targets: *build_targets


### PR DESCRIPTION
Bazel CI is migrating all CentOS 7 jobs to Rocky Linux 8 since the former has been EOL for almost a year now and will be removed from CI soon.

Part of bazelbuild/continuous-integration#2272