### PR TITLE
Remove incompatible_use_toolchain_transition again, now that it has been removed from bazel

### DIFF
--- a/examples/naming_package_files/my_package_name.bzl
+++ b/examples/naming_package_files/my_package_name.bzl
@@ -89,7 +89,6 @@ names_from_toolchains = rule(
         ),
     },
     toolchains = ["@rules_cc//cc:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 #


### PR DESCRIPTION
I think this might break compatibility with bazel 4.x, in order to fix compatibility with the tip of bazel's master branch.

Resolves #962
See also: #452, #454

cc @katre 