### PR TITLE
Add pkg_rpm() "data" attribute to provide files for rpmbuild

### DIFF
--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -878,7 +878,7 @@ def _pkg_rpm_impl(ctx):
         executable = ctx.executable._make_rpm,
         use_default_shell_env = True,
         arguments = rpm_ctx.make_rpm_args,
-        inputs = files,
+        inputs = files + (ctx.files.data or []),
         outputs = rpm_ctx.output_rpm_files,
         env = {
             "LANG": "en_US.UTF-8",
@@ -1278,6 +1278,10 @@ pkg_rpm = rule(
         ),
         "rpmbuild_path": attr.string(
             doc = """Path to a `rpmbuild` binary.  Deprecated in favor of the rpmbuild toolchain""",
+        ),
+        "data": attr.label_list(
+            doc = """Extra files that are needed by rpmbuild or find-debuginfo""",
+            allow_files = True,
         ),
         # Implicit dependencies.
         "_make_rpm": attr.label(


### PR DESCRIPTION
When building debuginfo packages, find-debuginfo is called by rpmbuild. To include the relevant source files, they will need to be accessible to find-debuginfo via rpmbuild.

There are a number of other pieces required for an end-to-end solution with debuginfo, but they're outside the scope of rules_pkg, e.g.

  - customized find-debuginfo that can run inside bazel
  - special _find_debuginfo_opts used to locate source files
  - figuring out which source files to pass to pkg_rpm() in the first place.

The key, though, is that pkg_rpm() accepts extra data in the first place.

Fixes: #965 