### PR TITLE
Add Alma 9 rpmbuild + bazel environment for examples

### DIFF
--- a/contrib/alma9_rpmbuild_docker/README.md
+++ b/contrib/alma9_rpmbuild_docker/README.md
@@ -1,0 +1,35 @@
+rpmbuild_docker
+===============
+
+This provides an easy way to create an almalinux-based container that can be used
+to run `rpmbuild` via `pkg_rpm()` rules.
+
+For example:
+
+```console
+[rules_pkg]$ cd examples/rpm/system_rpmbuild_bzlmod/
+[system_rpmbuild_bzlmod]$ ../../../contrib/alma9_rpmbuild_docker/run.sh
+[+] Building 0.1s (9/9) FINISHED
+```
+
+```console
+[devuser@fd4cc85e6e5a system_rpmbuild_bzlmod]$ bazel build test-rpm
+Starting local Bazel server (8.3.1) and connecting to it...
+INFO: Analyzed target //:test-rpm (80 packages loaded, 3318 targets configured).
+INFO: Found 1 target...
+Target //:test-rpm up-to-date:
+  bazel-bin/test-rpm.rpm
+  bazel-bin/test-rpm-all.rpm
+  bazel-bin/test-rpm-1-0.all.rpm
+INFO: Elapsed time: 5.007s, Critical Path: 0.06s
+INFO: 1 process: 9 action cache hit, 1 internal.
+INFO: Build completed successfully, 1 total action
+```
+
+```console
+[devuser@fd4cc85e6e5a system_rpmbuild_bzlmod]$ rpm -qlp bazel-bin/test-rpm.rpm
+/BUILD
+/MODULE.bazel
+/README.md
+/test_rpm.spec
+```

--- a/contrib/alma9_rpmbuild_docker/docker/Dockerfile
+++ b/contrib/alma9_rpmbuild_docker/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM almalinux:9.6
+
+ARG USER_ID
+ARG GROUP_ID
+
+ENV BAZELISK_VERSION=v1.26.0
+ENV BAZELISK_URL=https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64
+
+RUN dnf install -y \
+    ca-certificates \
+    gcc-c++ \
+    rpm-build \
+    && dnf clean all \
+    && curl -sSL -o /usr/local/bin/bazel ${BAZELISK_URL} \
+    && chmod +x /usr/local/bin/bazel
+
+RUN groupadd --gid $GROUP_ID devgroup && \
+    useradd --uid $USER_ID --gid $GROUP_ID --create-home --shell /bin/bash -l devuser
+
+VOLUME /home/devuser/.cache
+
+RUN mkdir -p /home/devuser/.cache && \
+    chown -R ${USER_ID}:${GROUP_ID} /home/devuser/.cache
+
+USER devuser
+WORKDIR /home/devuser

--- a/contrib/alma9_rpmbuild_docker/docker/Dockerfile
+++ b/contrib/alma9_rpmbuild_docker/docker/Dockerfile
@@ -1,10 +1,11 @@
 FROM almalinux:9.6
 
-ARG USER_ID
-ARG GROUP_ID
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+ARG TARGETARCH
 
 ENV BAZELISK_VERSION=v1.26.0
-ENV BAZELISK_URL=https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64
+ENV BAZELISK_URL=https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-${TARGETARCH}
 
 RUN dnf install -y \
     ca-certificates \

--- a/contrib/alma9_rpmbuild_docker/run.sh
+++ b/contrib/alma9_rpmbuild_docker/run.sh
@@ -36,7 +36,6 @@ docker_args=(
    -i
    -t
 )
-(
-   set -x
-   exec docker run "${docker_args[@]}" "$tag" "$@"
-)
+
+set -x
+exec docker run "${docker_args[@]}" "$tag" "$@"

--- a/contrib/alma9_rpmbuild_docker/run.sh
+++ b/contrib/alma9_rpmbuild_docker/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ueo pipefail
+
+tag="${TAG:-alma9-bazel}"
+volume="${VOLUME:-bazel-cache}"
+
+dir=$(realpath "$(dirname "$0")")
+repo_root="$dir/../.."
+
+docker build -t "$tag" --build-arg USER_ID="$(id -u)" --build-arg GROUP_ID="$(id -g)" "$dir/docker"
+
+docker_args=(
+   -v "$volume":/home/devuser/.cache
+   -v "$repo_root:$repo_root"
+   -w "$PWD"
+   --rm
+   -i
+   -t
+)
+exec docker run "${docker_args[@]}" "$tag" "$@"

--- a/contrib/alma9_rpmbuild_docker/run.sh
+++ b/contrib/alma9_rpmbuild_docker/run.sh
@@ -21,7 +21,12 @@ volume="${VOLUME:-bazel-cache}"
 dir=$(realpath "$(dirname "$0")")
 repo_root="$dir/../.."
 
-docker build -t "$tag" --build-arg USER_ID="$(id -u)" --build-arg GROUP_ID="$(id -g)" "$dir/docker"
+USER_ID=${USER_ID:-1000}
+GROUP_ID=${GROUP_ID:-1000}
+(
+   set -x
+   docker build -t "$tag" --build-arg USER_ID="$USER_ID" --build-arg GROUP_ID="$GROUP_ID" "$dir/docker"
+)
 
 docker_args=(
    -v "$volume":/home/devuser/.cache
@@ -31,4 +36,7 @@ docker_args=(
    -i
    -t
 )
-exec docker run "${docker_args[@]}" "$tag" "$@"
+(
+   set -x
+   exec docker run "${docker_args[@]}" "$tag" "$@"
+)


### PR DESCRIPTION
This provides a consistent starting point for running rpmbuild examples using a docker container build on Alma 9.

Closes: #968