### PR TITLE
📦 Conditionally preserve file permissions when archiving through pkg_tar

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -184,6 +184,9 @@ def _pkg_tar_impl(ctx):
     if ctx.attr.preserve_mode:
         args.add("--preserve_mode")
 
+    if ctx.attr.preserve_mtime:
+        args.add("--preserve_mtime")
+
     inputs = depset(
         direct = ctx.files.deps + files,
         transitive = mapping_context.file_deps,
@@ -300,6 +303,10 @@ builds were accidentally doing it. Never explicitly set this to true for new cod
         "preserve_mode": attr.bool(
             default = False,
             doc = """If true, will add file to archive with preserved file permissions.""",
+        ),
+        "preserve_mtime": attr.bool(
+            default = False,
+            doc = """If true, will add file to archive with preserved file mtime.""",
         ),
         "stamp": attr.int(
             doc = """Enable file time stamping.  Possible values:

--- a/tests/tar/BUILD
+++ b/tests/tar/BUILD
@@ -476,6 +476,8 @@ py_test(
         ":test-tar-mtime.tar",
         ":test-tar-preserve_mode-False.tar",
         ":test-tar-preserve_mode-True.tar",
+        ":test-tar-preserve_mtime-False.tar",
+        ":test-tar-preserve_mtime-True.tar",
         ":test-tar-repackaging-long-filename.tar",
         ":test-tar-strip_prefix-dot.tar",
         ":test-tar-strip_prefix-empty.tar",
@@ -810,6 +812,18 @@ verify_archive_test(
         "//tests:testdata/hello.txt",  # rw- r-- r--
     ],
     preserve_mode = state,
+) for state in [
+    True,
+    False,
+]]
+
+[pkg_tar(
+    name = "test-tar-preserve_mtime-%s" % state,
+    srcs = [
+        "//tests:testdata/hello.txt", # ok
+    ],
+    preserve_mtime = state,
+    #portable_mtime = False,
 ) for state in [
     True,
     False,

--- a/tests/tar/pkg_tar_test.py
+++ b/tests/tar/pkg_tar_test.py
@@ -324,5 +324,21 @@ class PkgTarTest(unittest.TestCase):
           self.assertEqual(member.name, "hello.txt", "unexpected file name for " + file_name)
           self.assertEqual(member.mode, int(expected_mode, 0), 'file mode not preserved for ' + file_name)
 
+  def test_preserve_mtime(self):
+    test_cases = [
+      # tar file name, mtime should be equal to PORTABLE_MTIME?
+      ('test-tar-preserve_mtime-False.tar', True), 
+      ('test-tar-preserve_mtime-True.tar', False),
+    ]
+    for file_name, should_be_equal_to_portable_mtime in test_cases:
+      file_path = runfiles.Create().Rlocation('rules_pkg/tests/tar/' + file_name)
+      with tarfile.open(file_path, 'r') as f:
+        for member in f.getmembers():
+          self.assertEqual(member.name, "hello.txt", "unexpected file name for " + file_name)
+          if should_be_equal_to_portable_mtime:
+            self.assertEqual(member.mtime, PORTABLE_MTIME, "unexpected mtime for " + file_name)
+          else:
+            self.assertNotEqual(member.mtime, PORTABLE_MTIME, "file mtime not preserved for " + file_name)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
If the new `preserve_mtime` flag is enabled, set mtime by extracting it from the file's mtime attribute. The `preserve_mtime` flag is disabled by default.

This is related to Issue https://github.com/bazelbuild/bazel/issues/1299