### PR TITLE
Convert the compression level to a string before calling Args.add()

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -115,7 +115,7 @@ def _pkg_tar_impl(ctx):
                 "%s=%s" % (_quote(key), ctx.attr.ownernames[key]),
             )
     if ctx.attr.compression_level:
-        args.add("--compression_level", ctx.attr.compression_level)
+        args.add("--compression_level", str(ctx.attr.compression_level))
 
     # Now we begin processing the files.
     path_mapper = None

--- a/toolchains/rpm/rpmbuild_configure.bzl
+++ b/toolchains/rpm/rpmbuild_configure.bzl
@@ -82,7 +82,7 @@ def _build_repo_for_rpmbuild_toolchain_impl(rctx):
         fail("debuginfo_type must be one of", DEBUGINFO_VALID_VALUES)
 
     debuginfo_type = rctx.attr.debuginfo_type
-    if debuginfo_type == DEBUGINFO_TYPE_AUTODETECT:   
+    if debuginfo_type == DEBUGINFO_TYPE_AUTODETECT:
         if rctx.path(RELEASE_PATH).exists:
             rctx.watch(RELEASE_PATH)
             os_name, _ = _parse_release_info(rctx.read(RELEASE_PATH))


### PR DESCRIPTION
The documentation for Bazel's Args states that standard conversion rules are only specified for strings, Files, and Labels. For all other types the conversion to a string is done in an unspecified manner, which is why it should be avoided.

Let's stay away from this unspecified behaviour by explicitly converting the compression level to a string before calling Args.add().