### PR TITLE
Implement pkg_install(symlink) also for pkg_zip

### DIFF
--- a/pkg/private/zip/build_zip.py
+++ b/pkg/private/zip/build_zip.py
@@ -182,6 +182,11 @@ class ZipWriter(object):
       # Set directory bits
       entry_info.external_attr |= (UNIX_SYMLINK_BIT << 16)
       self.zip_file.writestr(entry_info, src.encode('utf-8'))
+    elif entry_type == manifest.ENTRY_IS_RAW_LINK:
+      entry_info.compress_type = zipfile.ZIP_STORED
+      # Set directory bits
+      entry_info.external_attr |= (UNIX_SYMLINK_BIT << 16)
+      self.zip_file.writestr(entry_info, os.readlink(src).encode('utf-8'))
     elif entry_type == manifest.ENTRY_IS_TREE:
       self.add_tree(src, dst_path, mode)
     elif entry_type == manifest.ENTRY_IS_EMPTY_FILE:

--- a/tests/zip/BUILD
+++ b/tests/zip/BUILD
@@ -19,6 +19,7 @@ load("//pkg:mappings.bzl", "pkg_attributes", "pkg_mkdirs", "pkg_mklink")
 load("//pkg:zip.bzl", "pkg_zip")
 load("//tests:my_package_name.bzl", "my_package_naming")
 load("//tests/util:defs.bzl", "directory")
+load("//tests/zip:symlink_util.bzl", "create_fake_symlink")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -268,6 +269,20 @@ pkg_zip(
     compression_type = "stored",
 )
 
+create_fake_symlink(
+    name = "fake_symlink",
+    link = "fake_symlink",
+    target = "../does_not_exist",
+)
+
+pkg_zip(
+    name = "test_zip_symlink",
+    srcs = [
+        ":fake_symlink",
+        "//tests:file_and_link",
+    ],
+)
+
 py_test(
     name = "zip_test",
     srcs = [
@@ -287,6 +302,7 @@ py_test(
         ":test_zip_package_dir_substitution.zip",
         ":test_zip_permissions.zip",
         ":test_zip_stored",
+        ":test_zip_symlink",
         ":test_zip_timestamp.zip",
         ":test_zip_tree.zip",
     ],

--- a/tests/zip/symlink_util.bzl
+++ b/tests/zip/symlink_util.bzl
@@ -1,0 +1,14 @@
+"""Helpers for testing zip packaging."""
+
+def _create_fake_symlink_impl(ctx):
+    symlink = ctx.actions.declare_symlink(ctx.attr.link)
+    ctx.actions.symlink(output = symlink, target_path = ctx.attr.target)
+    return [DefaultInfo(files = depset([symlink]))]
+
+create_fake_symlink = rule(
+    implementation = _create_fake_symlink_impl,
+    attrs = {
+        "link": attr.string(mandatory = True),
+        "target": attr.string(mandatory = True),
+    },
+)

--- a/tests/zip/zip_test.py
+++ b/tests/zip/zip_test.py
@@ -150,6 +150,13 @@ class ZipContentsTests(zip_test_lib.ZipContentsTestBase):
           {"filename": "loremipsum.txt", "crc": LOREM_CRC, "size": 543},
     ])
 
+  def test_symlink(self):
+    self.assertZipFileContent("test_zip_symlink.zip", [
+          {"filename": "BUILD", "islink": False},
+          {"filename": "fake_symlink", "islink": True}, # raw symlink -> keep symlink
+          {"filename": "outer_BUILD", "islink": False},# nonraw symlink -> copy
+    ])
+
 
 
 if __name__ == "__main__":

--- a/tests/zip/zip_test_lib.py
+++ b/tests/zip/zip_test_lib.py
@@ -25,6 +25,7 @@ UNIX_DIR_BIT = 0o40000
 MSDOS_DIR_BIT = 0x10
 UNIX_RWX_BITS = 0o777
 UNIX_RX_BITS = 0o555
+UNIX_SYMLINK_BIT = 0o120000
 
 # The ZIP epoch date: (1980, 1, 1, 0, 0, 0)
 _ZIP_EPOCH_DT = datetime.datetime(1980, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
@@ -77,7 +78,17 @@ class ZipContentsTestBase(ZipTest):
                            oct(expected.get("attr", 0o755)))
         elif "isexe" in expected:
           got_mode = (info.external_attr >> 16) & UNIX_RX_BITS
-          self.assertEqual(oct(got_mode), oct(UNIX_RX_BITS))
+          if expected['isexe']:
+            self.assertEqual(oct(got_mode), oct(UNIX_RX_BITS))
+          else:
+            self.assertNotEqual(oct(got_mode), oct(UNIX_RX_BITS))
+        elif "islink" in expected:
+          got_mode = (info.external_attr >> 16) & UNIX_SYMLINK_BIT
+          if expected['islink']:
+            self.assertEqual(oct(got_mode), oct(UNIX_SYMLINK_BIT))
+          else:
+            self.assertNotEqual(oct(got_mode), oct(UNIX_SYMLINK_BIT))
+
         elif "size" in expected:
           self.assertEqual(info.compress_size, expected["size"])
 


### PR DESCRIPTION
I start to use hermetic python environment and saw https://github.com/bazelbuild/rules_pkg/issues/929.

It mostly works, but in my case I use pkg_zip instead of pkg_tar.

https://github.com/bazelbuild/rules_pkg/commit/4eed5466fb7062e196c4fa01495e1dfe0cf5c850 implements `raw_symlink`/ support for `pkg_tar`.
This MR adds the same functionality for `pkg_zip`.

The exception when the feature is not implemented yet:
```
Exception: ('Unknown type for manifest entry:', ManifestEntry<{'type': 'raw_symlink', 'dest': 'system_impl.runfiles/_main/example/_impl_py_client_install.venv/bin/python3', 'src': 'bazel-out/k8-fastbuild/bin/example/_impl_py_client_install.venv/bin/python3', 'mode': '0555', 'user': None, 'group': None, 'uid': None, 'gid': None, 'origin': '@@//example:system_impl'}>)
```