### PR TITLE
Make `pkg_install` work without "runfiles" (Windows default)

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -56,8 +56,6 @@ win_tests: &win_tests
     - "-//tests/mappings:utf8_manifest_test"
     - "-//tests/mappings/filter_directory/..."
     - "-//tests/zip:unicode_test"
-    # See #387
-    - "-//tests/install/..."
     # rpmbuild(8) is not supported on Windows
     - "-//tests/rpm/..."
     - "-//pkg/legacy/tests/rpm/..."

--- a/pkg/install.bzl
+++ b/pkg/install.bzl
@@ -185,7 +185,7 @@ def pkg_install(name, srcs, destdir = None, **kwargs):
         name = name,
         srcs = [":" + name + "_install_script"],
         main = name + "_install_script.py",
-        deps = [Label("//pkg/private:manifest")],
+        deps = [Label("//pkg/private:manifest"), Label("@rules_python//python/runfiles")],
         srcs_version = "PY3",
         python_version = "PY3",
         **kwargs

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -25,6 +25,8 @@ from pkg.private import manifest
 
 
 class PkgInstallTestBase(unittest.TestCase):
+    _extension = ".exe" if os.name == "nt" else ""
+
     @classmethod
     def setUpClass(cls):
         cls.runfiles = runfiles.Create()
@@ -47,7 +49,7 @@ class PkgInstallTest(PkgInstallTestBase):
         env = {}
         env.update(cls.runfiles.EnvVars())
         subprocess.check_call([
-            cls.runfiles.Rlocation("rules_pkg/tests/install/test_installer"),
+            cls.runfiles.Rlocation(f"rules_pkg/tests/install/test_installer{cls._extension}"),
             "--destdir", cls.installdir,
             "--verbose",
         ],
@@ -215,7 +217,7 @@ class WipeTest(PkgInstallTestBase):
         (self.installdir / "should_be_deleted.txt").touch()
 
         subprocess.check_call([
-            self.runfiles.Rlocation("rules_pkg/tests/install/test_installer"),
+            self.runfiles.Rlocation(f"rules_pkg/tests/install/test_installer{self._extension}"),
             "--destdir", self.installdir,
             "--wipe_destdir",
         ],


### PR DESCRIPTION
On Windows, `pkg_install` wouldn't work out of the box without passing `--enable_runfiles` to Bazel:
```py
windows> bazel run [redacted]//:install -- --destdir=d:\est
[...]
INFO: Running command line: [redacted]/install.exe <args omitted>
Traceback (most recent call last):
  File "[redacted]\install_install_script.py", line 307, in <module>
    sys.exit(main(sys.argv))
             ^^^^^^^^^^^^^^
  File "[redacted]\install_install_script.py", line 299, in main
    installer.include_manifest_path(f)
  File "[redacted]\install_install_script.py", line 182, in include_manifest_path
    with open(path, 'r') as fh:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '../[redacted]/install_install_script-install-manifest.json'
```

In order to accomodate the various use cases (`build`, `test` and `run` actions; enabled and disabled runfiles), the present change proposes to leverage `rules_python`'s "runfiles" lookup library: https://rules-python.readthedocs.io/en/latest/api/py/runfiles/runfiles.runfiles.html

For good measure, the change also enables `bazel test //tests/install/...` in CI for Windows.

This might close #387.