### PR TITLE
test with latest instead of rolling

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -3,7 +3,7 @@
 # - Tests: behavior only. release tools are in the integration tests
 # - Platforms: ubuntu, centos, macos, windows
 # - bzlmod enabled or not
-# - bazel: LTS-1, LTS, rolling
+# - bazel: LTS-1, LTS, latest
 #
 #
 
@@ -64,7 +64,7 @@ win_tests: &win_tests
 # Common features and tests by platform
 #
 ubuntu2204: &ubuntu
-  platform: ubuntu2204
+  olatform: ubuntu2204
   <<: *common
   <<: *default_tests
 
@@ -89,13 +89,13 @@ windows: &windows
 tasks:
   ub_head_bzlmod:
     name: ub_head_bzlmod
-    bazel: rolling
+    bazel: latest
     <<: *ubuntu
     <<: *bzlmod
 
   ub_head_nobzlmod:
     name: ub_head_nobzlmod
-    bazel: rolling
+    bazel: latest
     <<: *ubuntu
     <<: *nobzlmod
 
@@ -124,7 +124,7 @@ tasks:
 
   mac_head_bzlmod:
     name: mac_head_bzlmod
-    bazel: rolling
+    bazel: latest
     <<: *macos
     <<: *bzlmod
 
@@ -142,7 +142,7 @@ tasks:
 
   win_head_bzlmod:
     name: win_head_bzlmod
-    bazel: rolling
+    bazel: latest
     <<: *windows
     <<: *bzlmod
 

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -64,7 +64,7 @@ win_tests: &win_tests
 # Common features and tests by platform
 #
 ubuntu2204: &ubuntu
-  olatform: ubuntu2204
+  platform: ubuntu2204
   <<: *common
   <<: *default_tests
 


### PR DESCRIPTION
CI failing with
```
Using Bazel version rolling
--
  |  
  |  
  | bazel --version
  | 2025/11/19 00:13:39 could not download Bazel: could not resolve the version 'rolling' to an actual version number: cannot resolve version "rolling": There are not enough matching Bazel releases (0)
  | bazel --version
```
https://buildkite.com/bazel/rules-pkg/builds/4045/steps/canvas?sid=019a9974-f6af-4261-9da8-de2eaa04daa1
