### PR TITLE
Fix distro packaging test

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -93,6 +93,7 @@ py_test(
     data = [
         "testdata/BUILD.tpl",
         ":distro",
+        ":small_module",
         "//:standard_package",
     ],
     imports = [".."],

--- a/distro/packaging_test.py
+++ b/distro/packaging_test.py
@@ -38,7 +38,7 @@ class PackagingTest(unittest.TestCase):
   def testVersionsMatch(self):
     """version.bzl must match MODULE.bazel"""
     module_bazel_path = self.data_files.Rlocation(
-          'rules_pkg/MODULE.bazel')
+          'rules_pkg/distro/MODULE.bazel')
     with open(module_bazel_path, encoding="utf-8") as inp:
       want = 'version = "%s"' % self.version
       content = inp.read()


### PR DESCRIPTION
Update the packaging tests to reflect a recent change to strip internal dev only code from the MODULE.bazel file.