### PR TITLE
Fix bcr metadata templates in main so we can test push workflow

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -2,7 +2,7 @@
     "homepage": "https://github.com/bazelbuild/rules_pkg",
     "maintainers": [
 	    {
-		    "email": "aiuto@google.com",
+		    "email": "aiuto@datadoghq.com",
 		    "name": "Tony Aiuto"
 	    }
     ],


### PR DESCRIPTION
Sigh.  JSON.
I'm testing the push to bcr workflow in the bcr branch, but when it reads the workflow template, it picks it up from the main branch.