### PR TITLE
chore(deps): upgrade `skylib` to remove warnings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 # Do not update to newer versions until you need a specific new feature.
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_python", version = "1.0.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
 # Only for development
 bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)


### PR DESCRIPTION
This upgrade of `bazel_skylib` from version 1.7.1 to 1.9.0 eliminates a few deprecation warnings when executing Bazel commands:
> WARNING: [...]: target '[...]' depends on deprecated target '@@bazel_tools//src/conditions:host_windows_x64_constraint': No longer used by Bazel and will be removed in the future. Migrate to toolchains or define your own version of this setting.

These warnings originated from `bazel_skylib` 1.7.1's use of the deprecated `@bazel_tools//src/conditions:host_windows` constraint in `copy_file` and `diff_test` rules.
Since version 1.8.0, `bazel_skylib` migrated away from this deprecated constraint (see bazelbuild/bazel-skylib#574).