### PR TITLE
fix(rpm): debuginfo support on some distributions

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -37,8 +37,6 @@ default_tests_with_rpm: &default_tests_with_rpm
     - "//pkg/..."
     - "//tests/..."
     - "//toolchains/..."
-    # This has started to fail, even on CentOS.
-    - "-//tests/rpm:test_golden_debuginfo_rpm_contents"
 
 win_tests: &win_tests
   test_flags:
@@ -66,7 +64,10 @@ win_tests: &win_tests
 ubuntu2204: &ubuntu
   platform: ubuntu2204
   <<: *common
-  <<: *default_tests
+  <<: *default_tests_with_rpm
+  shell_commands:
+    - sudo apt-get update
+    - sudo apt-get install -y rpm elfutils  # for rpmbuild & eu-strip
 
 centos7: &centos
   platform: centos7_java11_devtoolset10

--- a/examples/rpm/debuginfo/README.md
+++ b/examples/rpm/debuginfo/README.md
@@ -6,7 +6,7 @@ This example uses the `find_system_rpmbuild_bzlmod` module extension to help
 us register the system rpmbuild as a toolchain in a bzlmod environment.
 
 It configures the system toolchain to be aware of which debuginfo configuration
-to use (defaults to "none", the example uses "centos7").
+to use (defaults to "none", the example uses "centos" for RPM < 4.18).
 
 ## To use
 

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -604,6 +604,13 @@ def _pkg_rpm_impl(ctx):
     if ctx.attr.architecture:
         preamble_pieces.append("BuildArch: " + ctx.attr.architecture)
 
+    if ctx.attr.debuginfo:
+        # RedHat distros have redhat-rpm-config with %_enable_debug_packages macro; others need explicit declaration
+        preamble_pieces.append("%{{!?_enable_debug_packages:%debug_package}}")  # set %debug_package unless macro exists
+
+        # https://rpm.org/wiki/Releases/4.14.0: "Add support for unique debug file names"
+        preamble_pieces.append("%undefine _unique_debug_names")  # no-op if not defined
+
     preamble_file = ctx.actions.declare_file(
         "{}.spec.preamble".format(rpm_name),
     )

--- a/toolchains/rpm/rpmbuild.bzl
+++ b/toolchains/rpm/rpmbuild.bzl
@@ -60,7 +60,7 @@ rpmbuild_toolchain = rule(
             doc = """
             The underlying debuginfo configuration for the system rpmbuild.
 
-            One of `centos`, `fedora`, and `none`
+            One of `centos` (RPM < 4.18), `fedora` (RPM >= 4.18), and `none`
             """,
             default = "none",
         ),


### PR DESCRIPTION
This enables RPM debuginfo package generation across different Linux distributions (**tested on Rocky and Ubuntu in CI**) by implementing RPM version-based detection if possible, and falling back to the existing OS release-based detection otherwise.

RPM 4.18.0 introduced changes to make `%{buildsubdir}` independent of the `%setup` macro:
- commit: `Make %{buildsubdir} more independent of %setup` (rpm-software-management/rpm@6caca84c904423)
- since: `rpm-4.18.0-alpha1`
- release: https://rpm.org/wiki/Releases/4.18.0

While this change enabled setting `buildsubdir` as a regular macro rather than a `spec` object property, it had the side effect of altering the relative path handling in install scripts.

This requires different file path formats in the `%install` section:
- RPM < 4.18, corresponding to the project's "centos" type:
  ```
  cp 'bazel-out/k8-fastbuild/bin/tests/rpm/test_debuginfo' '%{buildroot}/test_debuginfo'
  ```
- RPM >= 4.18, corresponding to the project's "fedora" type:
  ```
  cp '../bazel-out/k8-fastbuild/bin/tests/rpm/test_debuginfo' '%{buildroot}/test_debuginfo'
  ```

Using the wrong "type" causes build failures:
- "fedora" with RPM < 4.18:
  ```
  cp: cannot stat '../bazel-out/k8-fastbuild/bin/tests/rpm/test_debuginfo': No such file or directory
  ```
- "centos" with RPM >= 4.18:
  ```
  rm: refusing to remove '.' or '..' directory: skipping '.'
  ```

The present change therefore implements version detection to automatically select the appropriate "type".

**Additional fixes for cross-distribution compatibility**

RedHat distros have redhat-rpm-config with `%_enable_debug_packages` that auto-invokes `%debug_package` (rpm-software-management/rpm#2204).
Debian/Ubuntu ship vanilla upstream RPM without this configuration:
```
output 'tests/rpm/test_debuginfo_rpm-debuginfo-1-0..rpm' was not created
```

That's why the change adds `%debug_package` only when applicable:
- `%{!?_enable_debug_packages:%debug_package}`.

Also, since RPM [4.14](https://rpm.org/wiki/Releases/4.14.0), unique debug package filenames are enabled by default, leading to variadic filenames being generated:
```
Executing tests from //tests/rpm:test_golden_debuginfo_rpm_contents
-----------------------------------------------------------------------------
29c29
< /usr/lib/debug/test_debuginfo-1-0.x86_64.debug
---
> /usr/lib/debug/test_debuginfo.debug
FAIL: files "tests/rpm/test_debuginfo_rpm_contents.txt" and "tests/rpm/test_debuginfo_rpm_contents.txt.golden" differ
```

That's why the change makes debug package filenames consistent across distributions by means of:
- `%undefine _unique_debug_names` (safe no-op on older RPM versions).

Note: I also verified the change locally with:
- RPM 4.17.1 on Fedora 35 ("centos" type)
- RPM 4.18.2 on Ubuntu 24.04.3 ("fedora" type)
- RPM 4.19.1.1 on Fedora 40 ("fedora" type)