### PR TITLE
fix(ci): use own `md5` tool for Bazel 9 compatibility

### DIFF
--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -30,14 +30,15 @@ genrule(
         "etc/nsswitch.conf",
         "usr/fizzbuzz",
     ],
-    cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+    cmd = "for i in $(OUTS); do echo $$i >$$i; done",
 )
 
 genrule(
     name = "generate_md5sums",
     srcs = [":generate_files"],
     outs = ["md5sums"],
-    cmd = "md5sum $(SRCS) | sed 's|$(RULEDIR)/||' > $@",
+    cmd = 'for i in $(SRCS); do echo "$$($(execpath //tests/util:md5) $$i)  $${i#$(RULEDIR)/}"; done >$@',
+    tools = ["//tests/util:md5"],
 )
 
 my_package_naming(


### PR DESCRIPTION
Bazel 9.0.0 flipped `--incompatible_strict_action_env` to `true` by default (bazelbuild/bazel#27670), restricting `PATH` to `/bin:/usr/bin:/usr/local/bin`.

On macOS, this broke a few tests relying on the `md5sum` command ([example](https://buildkite.com/bazel/rules-pkg/builds/4228/steps/canvas?sid=019bdd78-3eea-4e37-a367-75c7f9b64d7b#019bdd79-d684-45b7-a14e-5cdacff52b4b/L344)):
```
Executing genrule //tests/deb:generate_md5sums failed: (Exit 127): [...]
[...]
/bin/bash: md5sum: command not found
```

This is because:
1. `md5sum` is not a native macOS command (macOS equivalent is `md5`),
2. Homebrew's `md5sum` is typically in `/opt/homebrew/bin`, which is no longer in the restricted `PATH`.

Since the repo already maintains a cross-platform `//tests/util:md5` tool, the fix simply consists in leveraging it.

Note on:
```diff
-    cmd = "for i in $(OUTS); do echo 1 >$$i; done",
+    cmd = "for i in $(OUTS); do echo $$i >$$i; done",
```
... is only meant to get distinct md5 sums for the 2 input files used in the tests.

Fixes #1010.