### PR TITLE
fix(test): make `//distro:packaging_test` work with Bazel 9

### DIFF
--- a/distro/BUILD
+++ b/distro/BUILD
@@ -98,6 +98,7 @@ py_test(
         ":small_module",
         "//:standard_package",
     ],
+    env_inherit = ["PATH"],
     imports = [".."],
     local = True,
     python_version = "PY3",


### PR DESCRIPTION
Bazel 9 flipped `--incompatible_strict_action_env` to `true` by default (bazelbuild/bazel#27670), which means tests no longer inherit `PATH` from the host environment. This breaks subprocess calls that rely on `PATH` lookup:
```
==================== Test output for //distro:packaging_test:
E.
======================================================================
ERROR: testBuild (__main__.PackagingTest.testBuild)
----------------------------------------------------------------------
Traceback (most recent call last):
[...]
    build_result = subprocess.check_output(['bazel', 'build', '--enable_workspace', ':dummy_tar'])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
FileNotFoundError: [Errno 2] No such file or directory: 'bazel'
```

This change therefore adds `env_inherit = ["PATH"]` to that very test, which matches the behavior of earlier Bazel versions and is consistent with the presence of a `"noci"` tag.

Additionally, Bazel 9 removed `WORKSPACE` support entirely (bazelbuild/bazel#26131), requiring `bzlmod` with `MODULE.bazel`:
```
==================== Test output for //distro:packaging_test:
[...]
WARNING: --enable_bzlmod is set, but no MODULE.bazel file was found at the workspace root. Bazel will create an empty MODULE.bazel file. Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel. For more details, please refer to https://github.com/bazelbuild/bazel/issues/18958.
[...]
ERROR: error loading package '': Unable to find package for @@[unknown repo 'not_named_rules_pkg' requested from @@]//pkg:tar.bzl: The repository '@@[unknown repo 'not_named_rules_pkg' requested from @@]' could not be resolved: No repository visible as '@not_named_rules_pkg' from main repository.
[...]
ERROR: Build did NOT complete successfully
E.
======================================================================
ERROR: testBuild (__main__.PackagingTest.testBuild)
----------------------------------------------------------------------
[...]
    build_result = subprocess.check_output(['bazel', 'build'] + bazel_flags + [':dummy_tar'])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
subprocess.CalledProcessError: Command '['bazel', 'build', '--enable_workspace', ':dummy_tar']' returned non-zero exit status 1.
```

The test now detects the Bazel version at runtime and generates the appropriate setup:
- Bazel 9+: `MODULE.bazel`, with `bazel_dep` and `archive_override`,
- earlier versions, as before: `WORKSPACE`, with `http_archive` and `--enable_workspace` flag.

For good measure, the change also addresses a leftover TODO by replacing the `tar` subprocess invocation with pure Python code (as otherwise done in the repo).