### PR TITLE
fix(ci): update deprecated GH Actions (scorecard)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -62,7 +62,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Updates `ossf/scorecard-action` from `v2` to `v2.4.0` and `actions/upload-artifact` from `v3` to `v4` to comply with GitHub's deprecation notice (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions).

As of January 22, 2025, workflows using v3 artifact actions fail with:
```
##[error]This request has been automatically failed because it uses a
deprecated version of `actions/upload-artifact: v3`. Learn more:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.
```

Fixes #1012.
Note: CI still fails due to #1010, for which there's a proposed countermeasure: #1007.