### PR TITLE
fix(test): make `//tests:path_test` work on Windows

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -48,7 +48,6 @@ win_tests: &win_tests
     - "//tests/..."
     - "//toolchains/..."
     - "-//tests:package_naming_aggregate_test"
-    - "-//tests:path_test"
     # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"

--- a/tests/path_test.py
+++ b/tests/path_test.py
@@ -15,7 +15,7 @@
 
 import collections
 import imp
-import os
+import posixpath
 import unittest
 
 
@@ -37,7 +37,7 @@ class File(object):
     else:
       self.owner = Owner('', '')
       self.short_path = short_path
-    self.path = os.path.join(
+    self.path = posixpath.join(
         self.root.path, self.owner.workspace_root, short_path)
 
 


### PR DESCRIPTION
The test was failing on Windows:
```
FAIL: testDestPathExt (__main__.DestPathTest.testDestPathExt)
AssertionError: '/bar/baz' != 'external/repo\\foo/bar/baz'

FAIL: testDestPathExtWrong (__main__.DestPathTest.testDestPathExtWrong)
AssertionError: 'external/repo/foo/bar/baz' != 'external/repo\\foo/bar/baz'

FAIL: testSafeShortPathExt (__main__.SafeShortPathTest.testSafeShortPathExt)
AssertionError: 'external/repo/foo/bar/baz' != 'external/repo\\foo/bar/baz'

FAIL: testSafeShortPathGenExt (__main__.SafeShortPathTest.testSafeShortPathGenExt)
AssertionError: 'external/repo/foo/bar/baz' != 'external/repo\\foo/bar/baz'

FAIL: testShortPathDirnameExt (__main__.ShortPathDirnameTest.testShortPathDirnameExt)
AssertionError: 'external/repo/foo/bar' != 'external/repo\\foo/bar'

FAIL: testShortPathDirnameGenExt (__main__.ShortPathDirnameTest.testShortPathDirnameGenExt)
AssertionError: 'external/repo/foo/bar' != 'external/repo\\foo/bar'

FAIL: testTopLevelExt (__main__.ShortPathDirnameTest.testTopLevelExt)
AssertionError: 'external/repo' != 'external'
```

The mock `File` class used `os.path.join()` which produces platform-specific path separators (backslashes on Windows), which doesn't match Bazel's behavior which always uses forward slashes regardless of platform:
- use `posixpath.join()` instead,
- enable the test in Windows CI since it now passes.