### PR TITLE
fix(test): `package_naming_aggregate_test` on Windows

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -47,7 +47,6 @@ win_tests: &win_tests
     - "//pkg/..."
     - "//tests/..."
     - "//toolchains/..."
-    - "-//tests:package_naming_aggregate_test"
     # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"

--- a/tests/package_naming_aggregate_test.sh
+++ b/tests/package_naming_aggregate_test.sh
@@ -14,14 +14,22 @@
 
 # This test simply checks that when we create packages with package_file_name
 # that we get the expected file names.
-set -e
+set -euo pipefail
+
+# Minimalistic `rlocation`: https://github.com/bazelbuild/rules_shell/blob/main/shell/runfiles/runfiles.bash
+locate() {
+  if [ -n "${RUNFILES_MANIFEST_FILE:-}" ]; then
+    grep -m1 "^$1 " "$RUNFILES_MANIFEST_FILE" | cut -d' ' -f2-
+  else
+    echo "$TEST_SRCDIR/$1"
+  fi
+}
 
 # Portably find the absolute path to the test data, even if this code has been
 # vendored in to a source tree and re-rooted.
 TEST_PACKAGE="$(echo ${TEST_TARGET} | sed -e 's/:.*$//' -e 's@//@@')"
-declare -r DATA_DIR="${TEST_SRCDIR}/${TEST_WORKSPACE}/${TEST_PACKAGE}"
 
 for pkg in test_naming_some_value.deb test_naming_some_value.tar test_naming_some_value.zip ; do
-  ls -l "${DATA_DIR}/$pkg"
+  ls -l "$(locate "$TEST_WORKSPACE/$TEST_PACKAGE/$pkg")"
 done
 echo "PASS"


### PR DESCRIPTION
The test was failing on Windows:
```
==================== Test output for //tests:package_naming_aggregate_test:
ls: cannot access 'C:/[...]/bin/tests/package_naming_aggregate_test.exe.runfiles/_main/tests/test_naming_some_value.deb': No such file or directory
================================================================================
```
It tried to directly access files in the `runfiles` directory, but on Windows Bazel uses by default a manifest file instead of creating actual symlinks.

The change consists in adding a minimalistic version of the [rlocation()](https://github.com/bazelbuild/rules_shell/blob/1e8bab64c37cd18837a26eb31ff03a8486eef83f/shell/runfiles/runfiles.bash#L136) helper function that:
- when set, reads from `$RUNFILES_MANIFEST_FILE` to resolve paths,
- otherwise uses `$TEST_SRCDIR` directly, as before.

This allows to enable the test in Windows CI now it passes.

Note on the stricter error handling:
- `set -u` is to fail fast should any of the expected `TEST_*` environment variables be unbound,
- `set -o pipefail` is to fail fast should either side of the `grep | cut` pipe fail.