### PR TITLE
fix(test): make `//tests/mappings/filter_directory` work on Windows

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -50,7 +50,6 @@ win_tests: &win_tests
     # Bazel might be broken w.r.t. Unicode processing for windows. Multiple issues:
     # https://github.com/bazelbuild/bazel/issues?q=is%3Aissue+is%3Aopen+%2Bunicode+%2Bwindows+
     - "-//tests/mappings:utf8_manifest_test"
-    - "-//tests/mappings/filter_directory/..."
     - "-//tests/zip:unicode_test"
     # rpmbuild(8) is not supported on Windows
     - "-//tests/rpm/..."


### PR DESCRIPTION
The `filter_directory` tests were failing on Windows:
```
ERROR: test_directory_structure_matches_global (__main__.DirectoryStructureTest.test_directory_structure_matches_global)
[...]
    os.path.isdir(real_directory_root),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[...]
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

This was because `Rlocation()` expects POSIX-style paths (forward slashes), but `os.path.join()` produces backslashes on Windows.

After fixing it, a second error appeared:
```
FAIL: test_directory_structure_matches_global (__main__.DirectoryStructureTest.test_directory_structure_matches_global)
AssertionError: Items in the first set but not the second:
'extra/a'
'extra/subdir/c'
'extra/b'
'extra/subdir/d'
Items in the second set but not the first:
'extra\\subdir\\c'
'extra\\a'
'extra\\b'
'extra\\subdir\\d' : Directory structure mismatch
```

This was because paths collected via `os.walk()` also produce backslashes on Windows against expected paths returned by `Rlocation` that always use forward slashes.

The change consists in leveraging `pathlib` for that purpose: `Path().as_posix()`, `Path.rglob()` and `Path.relative_to()`.

This enables the 9 `filter_directory` tests in Windows CI.