### PR TITLE
fix(rpm): propagate main() return code as process exit code

### DIFF
--- a/pkg/make_rpm.py
+++ b/pkg/make_rpm.py
@@ -622,6 +622,6 @@ def main(argv):
 
 
 if __name__ == '__main__':
-  main(sys.argv[1:])
+  sys.exit(main(sys.argv[1:]))
 
 # vim: ts=2:sw=2:


### PR DESCRIPTION
Wrap the main() call with sys.exit() so that non-zero return values from main() are properly reflected in the process exit code.

Fixes #1023 