### PR TITLE
Bring testing for bzlmod vs. non-bzlmod up to date with bazel features

### DIFF
--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -16,9 +16,3 @@ tasks:
   windows:
     platform: windows
     <<: *common
-  bzlmod:
-    name: bzlmod
-    platform: ubuntu2204
-    build_flags:
-      - "--enable_bzlmod"
-    <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -11,10 +11,6 @@
 common: &common
   working_directory: ..
 
-bzlmod: &bzlmod
-  build_flags:
-    - "--enable_bzlmod"
-
 nobzlmod: &nobzlmod
   build_flags:
     - "--noenable_bzlmod"
@@ -85,23 +81,15 @@ windows: &windows
 # Finally, the cross product of bazel releases X platforms
 #
 tasks:
-  ub_head_bzlmod:
-    name: ub_head_bzlmod
+  ub_head:
+    name: ub_head
     bazel: latest
     <<: *ubuntu
-    <<: *bzlmod
 
-  ub_head_nobzlmod:
-    name: ub_head_nobzlmod
+  ub_lts:
+    name: ub_lts
     bazel: latest
     <<: *ubuntu
-    <<: *nobzlmod
-
-  ub_lts_bzlmod:
-    name: ub_lts_bzlmod
-    bazel: latest
-    <<: *ubuntu
-    <<: *bzlmod
 
   ub_lts_nobzlmod:
     name: ub_lts_nobzlmod
@@ -120,17 +108,15 @@ tasks:
     bazel: latest
     <<: *centos
 
-  mac_head_bzlmod:
-    name: mac_head_bzlmod
+  mac_head:
+    name: mac_head
     bazel: latest
     <<: *macos
-    <<: *bzlmod
 
-  mac_lts_bzlmod:
-    name: mac_lts_bzlmod
+  mac_lts:
+    name: mac_lts
     bazel: latest
     <<: *macos
-    <<: *bzlmod
 
   mac_lts_nobzlmod:
     name: mac_lts_nobzlmod
@@ -138,17 +124,15 @@ tasks:
     <<: *macos
     <<: *nobzlmod
 
-  win_head_bzlmod:
-    name: win_head_bzlmod
+  win_head:
+    name: win_head
     bazel: latest
     <<: *windows
-    <<: *bzlmod
 
-  win_lts_bzlmod:
-    name: win_lts_bzlmod
+  win_lts:
+    name: win_lts
     bazel: latest
     <<: *windows
-    <<: *bzlmod
 
   win_lts_nobzlmod:
     name: win_lts_nobzlmod

--- a/distro/packaging_test.py
+++ b/distro/packaging_test.py
@@ -97,9 +97,10 @@ class PackagingTest(unittest.TestCase):
   def _select_bazel_supported_setup(self):
     output = subprocess.check_output(['bazel', 'version'], text=True)
     major_version = re.search(r'Build label:\s+(\d+)', output)
-    if major_version and int(major_version.group(1)) >= 9:
-      return 'MODULE.bazel', self._module_bazel_lines, []
-    return 'WORKSPACE', self._workspace_lines, ['--enable_workspace']
+    # Module support was not the default at 7
+    if major_version and int(major_version.group(1)) <= 7:
+      return 'WORKSPACE', self._workspace_lines, ['--enable_workspace']
+    return 'MODULE.bazel', self._module_bazel_lines, []
 
   def _module_bazel_lines(self, local_path, sha256):
     return (


### PR DESCRIPTION
Bring testing for bzlmod vs. non-bzlmod up to date with bazel features.

Head and LTS have bzlmod enabled by default, so:
- stop enabling the flag explicitly
- stop calling out "bzlmod" in the test name, that is now assumed, only nobzlmod needs naming

- Do the packaging test against workspace only for bazel 7 and earlier.
  - we probably could drop the workspace test entirely. It is essentially meaningless now

This is a spin out from a followup PR to #1027.  //distro:packaging_test was failing on workspace tests while using bazel 8.x. Since that seemed strange, I decided to clean this up now, to get a little better prepared for the day that `--enable_bzlmod` is no longer a valid flag.