### PR TITLE
Add variable expansion to string valued attributes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(gh issue *)",
-      "Bash(buildifier)",
+      "Bash(buildifier *)",
       "Bash(echo \"exit: $?\")"
     ]
   }

--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -46,7 +46,7 @@ def _pkg_deb_impl(ctx):
     args.add("--changes", changes_file)
     args.add("--data", ctx.file.data)
     args.add("--package", package)
-    args.add("--maintainer", ctx.attr.maintainer)
+    args.add("--maintainer", substitute_package_variables(ctx, ctx.attr.maintainer))
 
     if ctx.attr.architecture_file:
         if ctx.attr.architecture != "all":
@@ -54,7 +54,7 @@ def _pkg_deb_impl(ctx):
         args.add("--architecture", "@" + ctx.file.architecture_file.path)
         files.append(ctx.file.architecture_file)
     else:
-        args.add("--architecture", ctx.attr.architecture)
+        args.add("--architecture", substitute_package_variables(ctx, ctx.attr.architecture))
 
     if ctx.attr.preinst:
         args.add("--preinst", "@" + ctx.file.preinst.path)
@@ -98,7 +98,7 @@ def _pkg_deb_impl(ctx):
         args.add("--version", "@" + ctx.file.version_file.path)
         files.append(ctx.file.version_file)
     elif ctx.attr.version:
-        args.add("--version", ctx.attr.version)
+        args.add("--version", substitute_package_variables(ctx, ctx.attr.version))
     else:
         fail("Neither version_file nor version attribute was specified")
 
@@ -109,7 +109,7 @@ def _pkg_deb_impl(ctx):
         files.append(ctx.file.description_file)
     elif ctx.attr.description:
         desc_file = ctx.actions.declare_file(out_file_name_base + ".description")
-        ctx.actions.write(desc_file, ctx.attr.description)
+        ctx.actions.write(desc_file, substitute_package_variables(ctx, ctx.attr.description))
         files.append(desc_file)
         args.add("--description", "@" + desc_file.path)
     else:
@@ -126,7 +126,7 @@ def _pkg_deb_impl(ctx):
         args.add("--built_using", "@" + ctx.file.built_using_file.path)
         files.append(ctx.file.built_using_file)
     elif ctx.attr.built_using:
-        args.add("--built_using", ctx.attr.built_using)
+        args.add("--built_using", substitute_package_variables(ctx, ctx.attr.built_using))
 
     if ctx.attr.depends_file:
         if ctx.attr.depends:
@@ -135,31 +135,31 @@ def _pkg_deb_impl(ctx):
         files.append(ctx.file.depends_file)
     elif ctx.attr.depends:
         for d in ctx.attr.depends:
-            args.add("--depends", d)
+            args.add("--depends", substitute_package_variables(ctx, d))
 
     if ctx.attr.priority:
-        args.add("--priority", ctx.attr.priority)
+        args.add("--priority", substitute_package_variables(ctx, ctx.attr.priority))
     if ctx.attr.section:
-        args.add("--section", ctx.attr.section)
+        args.add("--section", substitute_package_variables(ctx, ctx.attr.section))
     if ctx.attr.homepage:
-        args.add("--homepage", ctx.attr.homepage)
+        args.add("--homepage", substitute_package_variables(ctx, ctx.attr.homepage))
     if ctx.attr.license:
-        args.add("--license", ctx.attr.license)
+        args.add("--license", substitute_package_variables(ctx, ctx.attr.license))
 
-    args.add("--distribution", ctx.attr.distribution)
-    args.add("--urgency", ctx.attr.urgency)
+    args.add("--distribution", substitute_package_variables(ctx, ctx.attr.distribution))
+    args.add("--urgency", substitute_package_variables(ctx, ctx.attr.urgency))
     for d in ctx.attr.suggests:
-        args.add("--suggests", d)
+        args.add("--suggests", substitute_package_variables(ctx, d))
     for d in ctx.attr.enhances:
-        args.add("--enhances", d)
+        args.add("--enhances", substitute_package_variables(ctx, d))
     for d in ctx.attr.conflicts:
-        args.add("--conflicts", d)
+        args.add("--conflicts", substitute_package_variables(ctx, d))
     for d in ctx.attr.breaks:
-        args.add("--breaks", d)
+        args.add("--breaks", substitute_package_variables(ctx, d))
     for d in ctx.attr.predepends:
-        args.add("--pre_depends", d)
+        args.add("--pre_depends", substitute_package_variables(ctx, d))
     for d in ctx.attr.recommends:
-        args.add("--recommends", d)
+        args.add("--recommends", substitute_package_variables(ctx, d))
     if ctx.attr.replaces_file:
         if ctx.attr.replaces:
             fail("Both replaces and replaces_file attributes were specified")
@@ -167,7 +167,7 @@ def _pkg_deb_impl(ctx):
         files.append(ctx.file.replaces_file)
     elif ctx.attr.replaces:
         for d in ctx.attr.replaces:
-            args.add("--replaces", d)
+            args.add("--replaces", substitute_package_variables(ctx, d))
 
     if ctx.attr.provides_file:
         if ctx.attr.provides:
@@ -176,7 +176,7 @@ def _pkg_deb_impl(ctx):
         files.append(ctx.file.provides_file)
     elif ctx.attr.provides:
         for d in ctx.attr.provides:
-            args.add("--provides", d)
+            args.add("--provides", substitute_package_variables(ctx, d))
 
     args.set_param_file_format("flag_per_line")
     args.use_param_file("@%s", use_always = True)

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -511,7 +511,7 @@ def _pkg_rpm_impl(ctx):
     #### Calculate output file name
     # rpm_name takes precedence over name if provided
     if ctx.attr.package_name:
-        rpm_name = ctx.attr.package_name
+        rpm_name = substitute_package_variables(ctx, ctx.attr.package_name)
     else:
         rpm_name = ctx.attr.name
 
@@ -650,7 +650,7 @@ def _pkg_rpm_impl(ctx):
         )
         ctx.actions.write(
             output = description_file,
-            content = ctx.attr.description,
+            content = substitute_package_variables(ctx, ctx.attr.description),
         )
     else:
         fail("None of the description or description_file attributes were specified")

--- a/pkg/rpm_pfg.bzl
+++ b/pkg/rpm_pfg.bzl
@@ -515,6 +515,9 @@ def _pkg_rpm_impl(ctx):
     else:
         rpm_name = ctx.attr.name
 
+    version = substitute_package_variables(ctx, ctx.attr.version)
+    architecture = substitute_package_variables(ctx, ctx.attr.architecture)
+
     default_file = ctx.actions.declare_file("{}.rpm".format(rpm_name))
 
     # When stamp is active, don't embed template placeholders in the filename.
@@ -523,8 +526,8 @@ def _pkg_rpm_impl(ctx):
     if not package_file_name:
         package_file_name = _make_rpm_filename(
             rpm_name,
-            ctx.attr.version,
-            ctx.attr.architecture,
+            version,
+            architecture,
             release = effective_release,
         )
 
@@ -542,7 +545,7 @@ def _pkg_rpm_impl(ctx):
         rpm_ctx.make_rpm_args.append("--version=@" + ctx.file.version_file.path)
         files.append(ctx.file.version_file)
     elif ctx.attr.version:
-        preamble_pieces.append("Version: " + ctx.attr.version)
+        preamble_pieces.append("Version: " + version)
     else:
         fail("None of the version or version_file attributes were specified")
 
@@ -585,7 +588,7 @@ def _pkg_rpm_impl(ctx):
         rpm_ctx.make_rpm_args.append("--source_date_epoch=" + str(ctx.attr.source_date_epoch))
 
     if ctx.attr.epoch:
-        preamble_pieces.append("Epoch: " + ctx.attr.epoch)
+        preamble_pieces.append("Epoch: " + substitute_package_variables(ctx, ctx.attr.epoch))
     if ctx.attr.summary:
         preamble_pieces.append("Summary: " + ctx.attr.summary)
     if ctx.attr.url:
@@ -619,7 +622,7 @@ def _pkg_rpm_impl(ctx):
     # In the meantime, this will allow the "architecture" attribute to take
     # effect.
     if ctx.attr.architecture:
-        preamble_pieces.append("BuildArch: " + ctx.attr.architecture)
+        preamble_pieces.append("BuildArch: " + architecture)
 
     if ctx.attr.debuginfo:
         # RedHat distros have redhat-rpm-config with %_enable_debug_packages macro; others need explicit declaration

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -158,3 +158,40 @@ package_naming_test(
     expected_name = "fizzbuzz_7_fastbuild.deb",
     target_under_test = ":deb_using_ctxvar",
 )
+
+# Test case for expanding $(var) constructions from package_variables
+pkg_deb(
+    name = "deb_with_package_variables",
+    architecture = "$(label)",
+    config = "config",
+    data = ":tar_input",
+    depends = ["dep-$(label)"],
+    description = "Description for $(label)",
+    maintainer = "test@example.com",
+    package = "pkg-$(label)",
+    package_variables = ":my_package_variables",
+    version = "1.0",
+)
+
+package_naming_test(
+    name = "expand_from_package_variables",
+    expected_name = "pkg-some_value_1.0_some_value.deb",
+    target_under_test = ":deb_with_package_variables",
+)
+
+py_test(
+    name = "pkg_deb_variables_test",
+    size = "medium",
+    srcs = [
+        "pkg_deb_variables_test.py",
+    ],
+    data = [
+        ":deb_with_package_variables",
+    ],
+    imports = ["../.."],
+    python_version = "PY3",
+    deps = [
+        "//pkg/private:archive",
+        "@rules_python//python/runfiles",
+    ],
+)

--- a/tests/deb/BUILD
+++ b/tests/deb/BUILD
@@ -162,7 +162,7 @@ package_naming_test(
 # Test case for expanding $(var) constructions from package_variables
 pkg_deb(
     name = "deb_with_package_variables",
-    architecture = "$(label)",
+    architecture = "{arch}",  # check both {} and $() styles
     config = "config",
     data = ":tar_input",
     depends = ["dep-$(label)"],
@@ -175,7 +175,7 @@ pkg_deb(
 
 package_naming_test(
     name = "expand_from_package_variables",
-    expected_name = "pkg-some_value_1.0_some_value.deb",
+    expected_name = "pkg-some_value_1.0_target_arch.deb",
     target_under_test = ":deb_with_package_variables",
 )
 

--- a/tests/deb/pkg_deb_variables_test.py
+++ b/tests/deb/pkg_deb_variables_test.py
@@ -1,0 +1,96 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -*- coding: utf-8 -*-
+"""Tests that package_variables substitution works in pkg_deb string attributes."""
+
+import codecs
+from io import BytesIO
+import tarfile
+import unittest
+
+from python.runfiles import runfiles
+from pkg.private import archive
+
+
+class DebInspect(object):
+    """Class to open and unpack a .deb file so we can examine it."""
+
+    def __init__(self, deb_file):
+        self.deb_version = None
+        self.data = None
+        self.control = None
+        with archive.SimpleArReader(deb_file) as f:
+            info = f.next()
+            while info:
+                if info.filename == 'debian-binary':
+                    self.deb_version = info.data
+                elif info.filename == 'control.tar.gz':
+                    self.control = info.data
+                elif info.filename == 'data.tar.gz':
+                    self.data = info.data
+                else:
+                    raise Exception('Unexpected file: %s' % info.filename)
+                info = f.next()
+
+    def get_deb_ctl_file(self, file_name):
+        """Extract a control file."""
+        with tarfile.open(mode='r:gz', fileobj=BytesIO(self.control)) as f:
+            for info in f:
+                if info.name == './' + file_name:
+                    return codecs.decode(f.extractfile(info).read(), 'utf-8')
+        raise Exception('Could not find control file: %s' % file_name)
+
+
+class PkgDebVariablesTest(unittest.TestCase):
+    """Tests that package_variables substitution is applied to pkg_deb string attributes."""
+
+    def setUp(self):
+        super(PkgDebVariablesTest, self).setUp()
+        self.runfiles = runfiles.Create()
+        # my_package_variables provides label="some_value", so:
+        #   package = "pkg-$(label)" -> "pkg-some_value"
+        #   architecture = "$(label)" -> "some_value"
+        deb_path = self.runfiles.Rlocation(
+            'rules_pkg/tests/deb/pkg-some_value_1.0_some_value.deb')
+        self.deb_file = DebInspect(deb_path)
+
+    def test_control_fields_have_substituted_values(self):
+        control = self.deb_file.get_deb_ctl_file('control')
+        # Variables from my_package_variables: label="some_value"
+        fields_expected = [
+            'Package: pkg-some_value',
+            'Architecture: some_value',
+            'Depends: dep-some_value',
+        ]
+        for field in fields_expected:
+            self.assertIn(
+                field, control,
+                'Missing or unsubstituted control field: <%s> in <%s>' % (field, control))
+
+    def test_description_has_substituted_value(self):
+        control = self.deb_file.get_deb_ctl_file('control')
+        self.assertIn(
+            'Description: Description for some_value',
+            control,
+            'Description field does not have substituted value in <%s>' % control)
+        # Confirm the raw variable syntax is NOT present
+        self.assertNotIn(
+            '$(label)',
+            control,
+            'Raw variable syntax still present in control: <%s>' % control)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/deb/pkg_deb_variables_test.py
+++ b/tests/deb/pkg_deb_variables_test.py
@@ -34,23 +34,23 @@ class DebInspect(object):
         with archive.SimpleArReader(deb_file) as f:
             info = f.next()
             while info:
-                if info.filename == 'debian-binary':
+                if info.filename == "debian-binary":
                     self.deb_version = info.data
-                elif info.filename == 'control.tar.gz':
+                elif info.filename == "control.tar.gz":
                     self.control = info.data
-                elif info.filename == 'data.tar.gz':
+                elif info.filename == "data.tar.gz":
                     self.data = info.data
                 else:
-                    raise Exception('Unexpected file: %s' % info.filename)
+                    raise Exception("Unexpected file: %s" % info.filename)
                 info = f.next()
 
     def get_deb_ctl_file(self, file_name):
         """Extract a control file."""
-        with tarfile.open(mode='r:gz', fileobj=BytesIO(self.control)) as f:
+        with tarfile.open(mode="r:gz", fileobj=BytesIO(self.control)) as f:
             for info in f:
-                if info.name == './' + file_name:
-                    return codecs.decode(f.extractfile(info).read(), 'utf-8')
-        raise Exception('Could not find control file: %s' % file_name)
+                if info.name == "./" + file_name:
+                    return codecs.decode(f.extractfile(info).read(), "utf-8")
+        raise Exception("Could not find control file: %s" % file_name)
 
 
 class PkgDebVariablesTest(unittest.TestCase):
@@ -59,38 +59,44 @@ class PkgDebVariablesTest(unittest.TestCase):
     def setUp(self):
         super(PkgDebVariablesTest, self).setUp()
         self.runfiles = runfiles.Create()
-        # my_package_variables provides label="some_value", so:
+        # my_package_variables provides arch=target_arch, label="some_value", so:
         #   package = "pkg-$(label)" -> "pkg-some_value"
-        #   architecture = "$(label)" -> "some_value"
+        #   architecture = "$(arch)" -> "target_arch"
         deb_path = self.runfiles.Rlocation(
-            'rules_pkg/tests/deb/pkg-some_value_1.0_some_value.deb')
+            "rules_pkg/tests/deb/pkg-some_value_1.0_target_arch.deb"
+        )
         self.deb_file = DebInspect(deb_path)
 
     def test_control_fields_have_substituted_values(self):
-        control = self.deb_file.get_deb_ctl_file('control')
+        control = self.deb_file.get_deb_ctl_file("control")
         # Variables from my_package_variables: label="some_value"
         fields_expected = [
-            'Package: pkg-some_value',
-            'Architecture: some_value',
-            'Depends: dep-some_value',
+            "Package: pkg-some_value",
+            "Architecture: target_arch",
+            "Depends: dep-some_value",
         ]
         for field in fields_expected:
             self.assertIn(
-                field, control,
-                'Missing or unsubstituted control field: <%s> in <%s>' % (field, control))
+                field,
+                control,
+                "Missing or unsubstituted control field: <%s> in <%s>"
+                % (field, control),
+            )
 
     def test_description_has_substituted_value(self):
-        control = self.deb_file.get_deb_ctl_file('control')
+        control = self.deb_file.get_deb_ctl_file("control")
         self.assertIn(
-            'Description: Description for some_value',
+            "Description: Description for some_value",
             control,
-            'Description field does not have substituted value in <%s>' % control)
+            "Description field does not have substituted value in <%s>" % control,
+        )
         # Confirm the raw variable syntax is NOT present
         self.assertNotIn(
-            '$(label)',
+            "$(label)",
             control,
-            'Raw variable syntax still present in control: <%s>' % control)
+            "Raw variable syntax still present in control: <%s>" % control,
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/my_package_name.bzl
+++ b/tests/my_package_name.bzl
@@ -20,12 +20,14 @@ def _my_package_naming_impl(ctx):
     values = {}
 
     # then add in my own custom values
+    values["arch"] = ctx.attr.arch
     values["label"] = ctx.attr.label
     return PackageVariablesInfo(values = values)
 
 my_package_naming = rule(
     implementation = _my_package_naming_impl,
     attrs = {
+        "arch": attr.string(doc = "A fake architecture.", default = "target_arch"),
         "label": attr.string(doc = "A label that matters to me."),
     },
 )

--- a/tests/rpm/analysis_tests.bzl
+++ b/tests/rpm/analysis_tests.bzl
@@ -288,6 +288,43 @@ def _test_naming(name):
     )
 
     ##################################################
+    # With pkg_variables expanding version/architecture
+    ##################################################
+
+    pkg_files(
+        name = "{}_varsubst_file_base".format(name),
+        srcs = ["foo"],
+        tags = ["manual"],
+    )
+
+    pkg_filegroup(
+        name = "{}_varsubst_pfg".format(name),
+        srcs = [":{}_varsubst_file_base".format(name)],
+        tags = ["manual"],
+    )
+
+    pkg_rpm(
+        name = name + "_varsubst_rpm",
+        srcs = [":{}_varsubst_pfg".format(name)],
+        architecture = "$(BAR)",
+        description = "Description for $(FOO)",
+        license = "N/A",
+        package_variables = ":{}_pkg_variables".format(name),
+        release = "1",
+        summary = "A test",
+        tags = ["manual"],
+        version = "$(FOO)",
+    )
+
+    # Verify that version="$(FOO)"→"foo" and architecture="$(BAR)"→"bar"
+    # are reflected in the output filename (NVR.A format: name-version-release.arch.rpm).
+    package_naming_test(
+        name = name + "_varsubst",
+        target_under_test = ":" + name + "_varsubst_rpm",
+        expected_name = name + "_varsubst_rpm-foo-1.bar.rpm",
+    )
+
+    ##################################################
     # Test suite declaration
     ##################################################
 
@@ -297,6 +334,7 @@ def _test_naming(name):
             ":{}_{}".format(name, test_name)
             for test_name in [
                 "no_extra",
+                "varsubst",
                 "with_different_name",
             ]
         ],


### PR DESCRIPTION
Uses `substitute_package_variables()` around all the string valued attributes for `pkg_deb` and `pkg_rpm`.

Closes #521