### PR TITLE
Honor compression level=0 in pkg_tar

### DIFF
--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -139,7 +139,8 @@ def _pkg_tar_impl(ctx):
     for target, f_dest_path in ctx.attr.files.items():
         target_files = target[DefaultInfo].files.to_list()
         if len(target_files) != 1:
-            fail("Each input must describe exactly one file.", attr = "files") mapping_context.file_deps_direct.append(target_files[0])
+            fail("Each input must describe exactly one file.", attr = "files")
+        mapping_context.file_deps_direct.append(target_files[0])
         add_single_file(
             mapping_context,
             f_dest_path,

--- a/pkg/private/tar/tar.bzl
+++ b/pkg/private/tar/tar.bzl
@@ -113,7 +113,7 @@ def _pkg_tar_impl(ctx):
                 "--owner_names",
                 "%s=%s" % (_quote(key), ctx.attr.ownernames[key]),
             )
-    if ctx.attr.compression_level:
+    if ctx.attr.compression_level >= 0:
         args.add("--compression_level", str(ctx.attr.compression_level))
 
     # Now we begin processing the files.
@@ -139,8 +139,7 @@ def _pkg_tar_impl(ctx):
     for target, f_dest_path in ctx.attr.files.items():
         target_files = target[DefaultInfo].files.to_list()
         if len(target_files) != 1:
-            fail("Each input must describe exactly one file.", attr = "files")
-        mapping_context.file_deps_direct.append(target_files[0])
+            fail("Each input must describe exactly one file.", attr = "files") mapping_context.file_deps_direct.append(target_files[0])
         add_single_file(
             mapping_context,
             f_dest_path,


### PR DESCRIPTION
Fix bug where `compression_level=0`, was being ignored, so you get a default (of 6)

Fixes #1048