### PR TITLE
bump version.bzl to 1.3

### DIFF
--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of rules_pkg."""
 
-version = "1.2.0"
+version = "1.3.0"


### PR DESCRIPTION
Time for a rollup release of fixes, before we switch to depending on the other repo for providers.