### PR TITLE
Remove compatibility_level from MODULE files.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,6 @@
 module(
     name = "rules_pkg",
     version = "",  # set by release pipeline from version.bzl.
-    compatibility_level = 1,
     repo_name = "rules_pkg",
 )
 

--- a/providers/MODULE.bazel
+++ b/providers/MODULE.bazel
@@ -1,7 +1,6 @@
 module(
     name = "rules_pkg_providers",
     version = "",  # set by release pipeline from version.bzl.
-    compatibility_level = 1,
     repo_name = "rules_pkg_providers",
 )
 

--- a/tests/mappings/external_repo/MODULE.bazel
+++ b/tests/mappings/external_repo/MODULE.bazel
@@ -15,7 +15,6 @@
 module(
     name = "test_external_project",
     version = "0",
-    compatibility_level = 0,
 )
 
 local_path_override(


### PR DESCRIPTION
- Starting in Bazel 8, this value is unused.
- Starting in Bazel 9, this print a warning that the value is unused.
- In Bazel 10, setting it will become a failure.

Fixes #1061 