### PR TITLE
fix(tar): drop truthy-string default on store_true argparse flags

### DIFF
--- a/pkg/private/tar/build_tar.py
+++ b/pkg/private/tar/build_tar.py
@@ -414,11 +414,11 @@ def main():
                       action='store_true',
                       help='')
   parser.add_argument(
-      '--preserve_mode', default='False',
+      '--preserve_mode',
       action='store_true',
       help='Preserve original file permissions in the archive. Mode argument is ignored.')
   parser.add_argument(
-      '--preserve_mtime', default='False',
+      '--preserve_mtime',
       action='store_true',
       help='Preserve original file mtime in the archive. mtime argument is ignored.')
   parser.add_argument(


### PR DESCRIPTION
The `--preserve_mode` and `--preserve_mtime` flags in `pkg/private/tar/build_tar.py` were declared with `default='False'` (a string, which is truthy) combined with `action='store_true'`. When the flags are not passed, `options.preserve_mode` / `options.preserve_mtime` end up as the string `'False'` rather than the boolean `False` — truthy under any natural truthy check.

Dropping `default='False'` is sufficient: `action='store_true'` already defaults to boolean `False` on its own.

Fixes #1064