### PR TITLE
Drop centos7 from CI

### DIFF
--- a/.bazelci/examples_naming.yml
+++ b/.bazelci/examples_naming.yml
@@ -4,9 +4,6 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
-    <<: *common
   ubuntu2204:
     platform: ubuntu2204
     <<: *common

--- a/.bazelci/examples_rich_structure.yml
+++ b/.bazelci/examples_rich_structure.yml
@@ -4,9 +4,6 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
-    <<: *common
   ubuntu2204:
     platform: ubuntu2204
     <<: *common

--- a/.bazelci/examples_stamping.yml
+++ b/.bazelci/examples_stamping.yml
@@ -4,9 +4,6 @@ common: &common
   - "..."
 
 tasks:
-  centos7:
-    platform: centos7_java11_devtoolset10
-    <<: *common
   ubuntu2204:
     platform: ubuntu2204
     <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -58,11 +58,6 @@ ubuntu2204: &ubuntu
     - sudo apt-get update
     - sudo apt-get install -y rpm elfutils  # for rpmbuild & eu-strip
 
-centos7: &centos
-  platform: centos7_java11_devtoolset10
-  <<: *common
-  <<: *default_tests_with_rpm
-
 macos: &macos
   platform: macos
   <<: *common

--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -1,7 +1,7 @@
 # These tests check the run-time behavior under various combinations
 #
 # - Tests: behavior only. release tools are in the integration tests
-# - Platforms: ubuntu, centos, macos, windows
+# - Platforms: ubuntu, macos, windows
 # - bzlmod enabled or not
 # - bazel: LTS-1, LTS, latest
 #
@@ -93,11 +93,6 @@ tasks:
     bazel: latest-1
     <<: *ubuntu
     <<: *nobzlmod
-
-  cent_lts:
-    name: cent_lts
-    bazel: latest
-    <<: *centos
 
   mac_head:
     name: mac_head


### PR DESCRIPTION
It is no longer supported on buildkite.
```
File "/workdir/bazelci.py", line 3479, in runner_step
--
  | py = PLATFORMS[platform]["python"]
  | ~~~~~~~~~^^^^^^^^^^
  | KeyError: 'centos7_java11_devtoolset10'
```