### PR TITLE
Add extra_control_file attr to pkg_deb

### DIFF
--- a/pkg/private/deb/deb.bzl
+++ b/pkg/private/deb/deb.bzl
@@ -180,6 +180,10 @@ def _pkg_deb_impl(ctx):
         for d in ctx.attr.provides:
             args.add("--provides", substitute_package_variables(ctx, d))
 
+    if ctx.attr.extra_control_file:
+        args.add("--extra_control_file", ctx.file.extra_control_file.path)
+        files.append(ctx.file.extra_control_file)
+
     args.set_param_file_format("flag_per_line")
     args.use_param_file("@%s", use_always = True)
     ctx.actions.run(
@@ -399,6 +403,10 @@ See https://www.debian.org/doc/debian-policy/ch-files.html#s-config-files.""",
         "suggests": attr.string_list(
             doc = """See http://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps.""",
             default = [],
+        ),
+        "extra_control_file": attr.label(
+            doc = """File with extra control fields appended verbatim to the control file.""",
+            allow_single_file = True,
         ),
 
         # Common attributes

--- a/pkg/private/deb/make_deb.py
+++ b/pkg/private/deb/make_deb.py
@@ -157,7 +157,7 @@ def MakeDebianControlField(name: str, value: str, multiline:Multiline=Multiline.
   return result
 
 
-def CreateDebControl(extrafiles=None, **kwargs):
+def CreateDebControl(extrafiles=None, extra_control_content=None, **kwargs):
   """Create the control.tar.gz file."""
   # create the control file
   controlfile = u''
@@ -168,6 +168,8 @@ def CreateDebControl(extrafiles=None, **kwargs):
     key = fieldname[0].lower() + fieldname[1:].replace('-', '')
     if mandatory or (key in kwargs and kwargs[key]):
       controlfile += MakeDebianControlField(fieldname, kwargs[key], multiline)
+  if extra_control_content:
+    controlfile += extra_control_content
   # Create the control.tar file
   tar = io.BytesIO()
   with gzip.GzipFile('control.tar.gz', mode='w', fileobj=tar, mtime=0) as gz:
@@ -204,6 +206,7 @@ def CreateDeb(output,
               md5sums=None,
               conffiles=None,
               changelog=None,
+              extra_control_content=None,
               **kwargs):
   """Create a full debian package."""
   extrafiles = OrderedDict()
@@ -227,7 +230,7 @@ def CreateDeb(output,
     extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
   if changelog:
     extrafiles['changelog'] = (changelog, 0o644)
-  control = CreateDebControl(extrafiles=extrafiles, **kwargs)
+  control = CreateDebControl(extrafiles=extrafiles, extra_control_content=extra_control_content, **kwargs)
 
   # Write the final AR archive (the deb package)
   with open(output, 'wb') as f:
@@ -384,8 +387,16 @@ def main():
   parser.add_argument(
       '--changelog',
       help='The changelog file (prefix item with @ to provide a path).')
+  parser.add_argument(
+      '--extra_control_file',
+      help='File with extra control fields to append verbatim to the control file.')
   AddControlFlags(parser)
   options = parser.parse_args()
+
+  extra_control_content = None
+  if options.extra_control_file:
+    with open(options.extra_control_file, 'r') as f:
+      extra_control_content = f.read()
 
   CreateDeb(
       options.output,
@@ -400,6 +411,7 @@ def main():
       md5sums=helpers.GetFlagValue(options.md5sums, False),
       conffiles=GetFlagValues(options.conffile),
       changelog=helpers.GetFlagValue(options.changelog, False),
+      extra_control_content=extra_control_content,
       package=options.package,
       version=helpers.GetFlagValue(options.version),
       description=helpers.GetFlagValue(options.description),


### PR DESCRIPTION
Adds an optional extra_control_file attribute to pkg_deb, allowing additional Debian control fields to be appended verbatim to the generated control file.

This supports custom control fields that are not modeled directly by pkg_deb.